### PR TITLE
fix: Moon v2 migration, build ordering, gen-types path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ apps/web/build/
 # Moon
 .moon/cache/
 
+# Claude Code
+.claude/*
+!.claude/rules/
+!.claude/rules/**
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -1,7 +1,0 @@
-$schema: 'https://moonrepo.dev/schemas/toolchain.json'
-
-node:
-  version: '22.14.0'
-  packageManager: 'pnpm'
-  pnpm:
-    version: '10.6.5'

--- a/.moon/toolchains.yml
+++ b/.moon/toolchains.yml
@@ -1,0 +1,7 @@
+$schema: https://moonrepo.dev/schemas/toolchains.json
+node:
+  version: 22.14.0
+javascript:
+  packageManager: pnpm
+pnpm:
+  version: 10.6.5

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,15 +1,12 @@
-$schema: 'https://moonrepo.dev/schemas/workspace.json'
-
+$schema: https://moonrepo.dev/schemas/workspace.json
 projects:
-  web: 'apps/web'
-  api: 'services/api'
-  core: 'crates/core'
-  types: 'crates/types'
-  db: 'crates/db'
-
+  web: apps/web
+  api: services/api
+  core: crates/core
+  types: crates/types
+  db: crates/db
 vcs:
-  provider: 'github'
-  defaultBranch: 'main'
-
+  provider: github
+  defaultBranch: main
 pipeline:
   logRunningCommand: true

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -1,52 +1,46 @@
-language: 'javascript'
-stack: 'frontend'
-
+language: javascript
+stack: frontend
 fileGroups:
   app:
-    - 'static/**/*'
-    - 'svelte.config.*'
-    - 'vite.config.*'
+  - static/**/*
+  - svelte.config.*
+  - vite.config.*
   sources:
-    - 'src/**/*'
+  - src/**/*
   tests:
-    - 'tests/**/*'
-    - 'src/**/*.test.*'
-
+  - tests/**/*
+  - src/**/*.test.*
 tasks:
   dev:
-    command: 'pnpm dev'
+    command: pnpm dev
     options:
       cache: false
       persistent: true
-      outputStyle: 'stream'
-
+      outputStyle: stream
   build:
-    command: 'pnpm build'
+    command: pnpm build
     inputs:
-      - '@group(app)'
-      - '@group(sources)'
-      - 'package.json'
-      - 'tsconfig.json'
+    - '@group(app)'
+    - '@group(sources)'
+    - package.json
+    - tsconfig.json
     outputs:
-      - 'build'
-
+    - build
   preview:
-    command: 'pnpm preview'
+    command: pnpm preview
     deps:
-      - 'build'
+    - build
     options:
       cache: false
       persistent: true
-      outputStyle: 'stream'
-
+      outputStyle: stream
   test:
-    command: 'pnpm test'
+    command: pnpm test
     inputs:
-      - '@group(sources)'
-      - '@group(tests)'
-
+    - '@group(sources)'
+    - '@group(tests)'
   check:
-    command: 'pnpm check'
+    command: pnpm check
     inputs:
-      - '@group(sources)'
-      - 'tsconfig.json'
+    - '@group(sources)'
+    - tsconfig.json

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,10 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()]
+	plugins: [tailwindcss(), sveltekit()],
+	test: {
+		passWithNoTests: true
+	}
 });

--- a/crates/core/moon.yml
+++ b/crates/core/moon.yml
@@ -1,2 +1,2 @@
-language: 'rust'
-stack: 'backend'
+language: rust
+stack: backend

--- a/crates/db/moon.yml
+++ b/crates/db/moon.yml
@@ -1,2 +1,2 @@
-language: 'rust'
-stack: 'backend'
+language: rust
+stack: backend

--- a/crates/types/moon.yml
+++ b/crates/types/moon.yml
@@ -1,2 +1,2 @@
-language: 'rust'
-stack: 'backend'
+language: rust
+stack: backend

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,79 +263,66 @@ packages:
     resolution: {integrity: sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.1':
     resolution: {integrity: sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.1':
     resolution: {integrity: sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.1':
     resolution: {integrity: sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.1':
     resolution: {integrity: sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.1':
     resolution: {integrity: sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.1':
     resolution: {integrity: sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.1':
     resolution: {integrity: sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.1':
     resolution: {integrity: sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.1':
     resolution: {integrity: sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.1':
     resolution: {integrity: sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.1':
     resolution: {integrity: sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.1':
     resolution: {integrity: sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.1':
     resolution: {integrity: sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==}
@@ -449,28 +436,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -712,28 +695,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -1,88 +1,80 @@
-language: 'rust'
-stack: 'backend'
-
+language: rust
+stack: backend
 env:
-  CARGO_TERM_COLOR: 'always'
-
+  CARGO_TERM_COLOR: always
 fileGroups:
   sources:
-    - 'src/**/*'
-    - 'Cargo.toml'
-    - '/Cargo.toml'
-    - '/Cargo.lock'
+  - src/**/*
+  - Cargo.toml
+  - /Cargo.toml
+  - /Cargo.lock
   migrations:
-    - '/crates/db/migrations/**/*'
+  - /crates/db/migrations/**/*
   allRust:
-    - '/crates/*/src/**/*'
-    - '/crates/*/Cargo.toml'
-    - 'src/**/*'
-    - 'Cargo.toml'
-    - '/Cargo.toml'
-    - '/Cargo.lock'
-
+  - /crates/*/src/**/*
+  - /crates/*/Cargo.toml
+  - src/**/*
+  - Cargo.toml
+  - /Cargo.toml
+  - /Cargo.lock
 tasks:
   build:
-    command: 'cargo build --package mokumo-api'
+    command: cargo build --package mokumo-api
+    deps:
+    - web:build
     inputs:
-      - '@group(allRust)'
+    - '@group(allRust)'
     options:
       runFromWorkspaceRoot: true
-
   dev:
-    command: 'cargo run --package mokumo-api'
+    command: cargo run --package mokumo-api
     deps:
-      - 'web:build'
+    - web:build
     options:
       cache: false
       persistent: true
-      outputStyle: 'stream'
+      outputStyle: stream
       runFromWorkspaceRoot: true
-
   test:
-    command: 'cargo test --workspace'
+    command: cargo test --workspace
     inputs:
-      - '@group(allRust)'
-      - '/crates/*/tests/**/*'
+    - '@group(allRust)'
+    - /crates/*/tests/**/*
     options:
       runFromWorkspaceRoot: true
-
   lint:
-    command: 'cargo clippy --workspace --all-targets -- -D warnings'
+    command: cargo clippy --workspace --all-targets -- -D warnings
     inputs:
-      - '@group(allRust)'
+    - '@group(allRust)'
     options:
       runFromWorkspaceRoot: true
-
   fmt:
-    command: 'cargo fmt --all --check'
+    command: cargo fmt --all --check
     inputs:
-      - '@group(allRust)'
+    - '@group(allRust)'
     options:
       runFromWorkspaceRoot: true
-
   fmt-write:
-    command: 'cargo fmt --all'
+    command: cargo fmt --all
     options:
       cache: false
       runFromWorkspaceRoot: true
-
   gen-types:
-    command: 'cargo test --package mokumo-types -- export_bindings'
+    command: cargo test --package mokumo-types -- export_bindings
     env:
-      TS_RS_EXPORT_DIR: '../../apps/web/src/lib/types'
+      TS_RS_EXPORT_DIR: apps/web/src/lib/types
     inputs:
-      - '/crates/types/src/**/*'
-      - '/crates/types/Cargo.toml'
+    - /crates/types/src/**/*
+    - /crates/types/Cargo.toml
     outputs:
-      - '/apps/web/src/lib/types/'
+    - /apps/web/src/lib/types/
     options:
       runFromWorkspaceRoot: true
-
   db-prepare:
-    command: 'cargo sqlx prepare --workspace'
+    command: cargo sqlx prepare --workspace
     inputs:
-      - '@group(allRust)'
-      - '@group(migrations)'
+    - '@group(allRust)'
+    - '@group(migrations)'
     options:
       cache: false
       runFromWorkspaceRoot: true

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -1,4 +1,4 @@
-use axum::{Router, routing::get, Json, extract::State, response::IntoResponse, http::StatusCode};
+use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
 use clap::Parser;
 use rust_embed::Embed;
 use std::path::PathBuf;
@@ -73,9 +73,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn health(
-    State(state): State<SharedState>,
-) -> Result<Json<HealthResponse>, StatusCode> {
+async fn health(State(state): State<SharedState>) -> Result<Json<HealthResponse>, StatusCode> {
     sqlx::query("SELECT 1")
         .execute(&state.db)
         .await
@@ -98,7 +96,10 @@ async fn serve_spa(uri: axum::http::Uri) -> impl IntoResponse {
         return (
             StatusCode::NOT_FOUND,
             [
-                (axum::http::header::CONTENT_TYPE, "application/json".to_owned()),
+                (
+                    axum::http::header::CONTENT_TYPE,
+                    "application/json".to_owned(),
+                ),
                 (axum::http::header::CACHE_CONTROL, "no-store".to_owned()),
             ],
             r#"{"error":"not_found","message":"No API route matches this path"}"#
@@ -116,7 +117,10 @@ async fn serve_spa(uri: axum::http::Uri) -> impl IntoResponse {
         (
             StatusCode::OK,
             [
-                (axum::http::header::CONTENT_TYPE, file.metadata.mimetype().to_owned()),
+                (
+                    axum::http::header::CONTENT_TYPE,
+                    file.metadata.mimetype().to_owned(),
+                ),
                 (axum::http::header::CACHE_CONTROL, cache.to_owned()),
             ],
             file.data.to_vec(),
@@ -125,7 +129,10 @@ async fn serve_spa(uri: axum::http::Uri) -> impl IntoResponse {
         (
             StatusCode::OK,
             [
-                (axum::http::header::CONTENT_TYPE, index.metadata.mimetype().to_owned()),
+                (
+                    axum::http::header::CONTENT_TYPE,
+                    index.metadata.mimetype().to_owned(),
+                ),
                 (axum::http::header::CACHE_CONTROL, "no-cache".to_owned()),
             ],
             index.data.to_vec(),


### PR DESCRIPTION
## Summary

- Migrate Moon config from v1 to v2 format (`toolchain.yml` → `toolchains.yml`, v2 YAML across all `moon.yml` files)
- Add `web:build` as dependency of `api:build` so rust-embed has SPA output on clean checkout
- Fix `gen-types` `TS_RS_EXPORT_DIR` to resolve correctly from workspace root (`apps/web/src/lib/types`)
- Configure vitest `passWithNoTests` for empty test suite
- Apply `cargo fmt` formatting, add `.claude/*` gitignore pattern

## Test plan

- [x] `moon check --all` passes (10 tasks, 0 failures)
- [x] `api:build` triggers `web:build` first, compiles successfully
- [x] `gen-types` writes `HealthResponse.ts` to `apps/web/src/lib/types/`
- [x] `web:test` exits 0 with no test files
- [x] `web:check` (svelte-check) passes with vitest/config import

## Review

- CAO (Archer): Approved — clean migration, sound dependency graph, correct gen-types path
- CEng (Kit): Approved — 0 critical issues, 2 low-priority suggestions (api:build outputs declaration, api:dev split for DX)

Closes #2, closes #3, closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain configuration and formatting across project files.
  * Refined test framework configuration to gracefully handle projects with no tests.
  * Normalized configuration syntax and removed unnecessary quote wrapping.
  * Updated version control ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->