### PR TITLE
feat: database enhancements — settings table, backup, setup detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +804,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +842,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hashlink"
@@ -1067,6 +1107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1228,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1281,7 +1339,11 @@ version = "0.1.0"
 name = "mokumo-db"
 version = "0.1.0"
 dependencies = [
+ "rusqlite",
  "sqlx",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1535,6 +1597,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1635,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,7 +1667,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1648,6 +1726,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +1781,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1825,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "seq-macro"
@@ -1948,7 +2059,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "log",
  "memchr",
@@ -2340,6 +2451,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +2788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2853,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2919,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2998,6 +3180,94 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 # SQLite direct access (backup version queries)
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.32", features = ["bundled", "backup"] }
 
 # Testing
 serial_test = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,12 @@ clap = { version = "4", features = ["derive"] }
 # Date/time
 chrono = { version = "0.4", features = ["serde"] }
 
+# SQLite direct access (backup version queries)
+rusqlite = { version = "0.32", features = ["bundled"] }
+
+# Testing
+serial_test = "3"
+
 # Internal crates
 mokumo-core = { path = "crates/core" }
 mokumo-types = { path = "crates/types" }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -6,3 +6,9 @@ license.workspace = true
 
 [dependencies]
 sqlx = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+rusqlite = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/db/migrations/20260322000000_settings.sql
+++ b/crates/db/migrations/20260322000000_settings.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT
+);

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -43,30 +43,41 @@ pub async fn initialize_database(database_url: &str) -> Result<SqlitePool, sqlx:
 /// Skips silently when:
 /// - The database file does not exist (first run)
 /// - The `_sqlx_migrations` table does not exist
+///
+/// # Important
+/// Call this BEFORE opening any SQLx pool to the same database.
 pub async fn pre_migration_backup(
     db_path: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if !db_path.exists() {
-        tracing::info!("No existing database at {:?}, skipping backup", db_path);
-        return Ok(());
+    match tokio::fs::metadata(db_path).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::info!("No existing database at {:?}, skipping backup", db_path);
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
     }
 
-    // Open a raw rusqlite connection to query the current schema version
+    // Open a raw rusqlite connection to query the current schema version.
+    // Check table existence explicitly to avoid swallowing real errors.
     let version = {
         let conn = rusqlite::Connection::open(db_path)?;
-        let result: Result<i64, rusqlite::Error> = conn.query_row(
+        let table_exists: bool = conn.query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='_sqlx_migrations'",
+            [],
+            |row| row.get(0),
+        )?;
+        if !table_exists {
+            tracing::info!("No _sqlx_migrations table found, skipping backup");
+            return Ok(());
+        }
+        let v: i64 = conn.query_row(
             "SELECT MAX(version) FROM _sqlx_migrations",
             [],
             |row| row.get(0),
-        );
-        // Connection is dropped (closed) at end of this block
-        match result {
-            Ok(v) => v,
-            Err(_) => {
-                tracing::info!("No _sqlx_migrations table found, skipping backup");
-                return Ok(());
-            }
-        }
+        )?;
+        v
+        // conn dropped here
     };
 
     // Build the backup filename as {original_name}.backup-v{version}
@@ -78,7 +89,17 @@ pub async fn pre_migration_backup(
     let backup_name = format!("{}.backup-v{}", file_name, version);
     let backup_path = db_path.with_file_name(&backup_name);
 
-    tokio::fs::copy(db_path, &backup_path).await?;
+    // Use SQLite's backup API for WAL-safe copies
+    let backup_path_clone = backup_path.clone();
+    let db_path_owned = db_path.to_path_buf();
+    tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
+        let src = rusqlite::Connection::open(&db_path_owned)?;
+        let mut dst = rusqlite::Connection::open(&backup_path_clone)?;
+        let backup = rusqlite::backup::Backup::new(&src, &mut dst)?;
+        backup.run_to_completion(5, std::time::Duration::from_millis(250), None)?;
+        Ok(())
+    })
+    .await.map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })??;
     tracing::info!("Created database backup at {:?}", backup_path);
 
     // Rotate: keep only the last 3 backups
@@ -95,12 +116,24 @@ pub async fn pre_migration_backup(
         }
     }
 
-    backups.sort();
+    // Sort by parsed version number to handle multi-digit versions correctly
+    backups.sort_by_key(|path| {
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .and_then(|n| n.rsplit("backup-v").next())
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(0)
+    });
     if backups.len() > 3 {
         let to_delete = backups.len() - 3;
         for path in backups.into_iter().take(to_delete) {
-            tracing::info!("Removing old backup {:?}", path);
-            tokio::fs::remove_file(&path).await?;
+            match tokio::fs::remove_file(&path).await {
+                Ok(()) => tracing::info!("Removed old backup {:?}", path),
+                Err(e) => tracing::warn!(
+                    "Failed to remove old backup {:?}: {}. Manual cleanup may be needed.",
+                    path, e
+                ),
+            }
         }
     }
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -20,6 +20,9 @@ pub async fn initialize_database(database_url: &str) -> Result<SqlitePool, sqlx:
                 sqlx::query("PRAGMA foreign_keys=ON")
                     .execute(&mut *conn)
                     .await?;
+                sqlx::query("PRAGMA cache_size=-64000")
+                    .execute(&mut *conn)
+                    .await?;
                 Ok(())
             })
         })
@@ -29,4 +32,90 @@ pub async fn initialize_database(database_url: &str) -> Result<SqlitePool, sqlx:
     sqlx::migrate!().run(&pool).await?;
 
     Ok(pool)
+}
+
+/// Create a backup of the database file before running migrations.
+///
+/// The backup is named `{db_path}.backup-v{version}` where `version` is the
+/// current schema version from the `_sqlx_migrations` table. Only the last 3
+/// backups are kept; older ones are deleted.
+///
+/// Skips silently when:
+/// - The database file does not exist (first run)
+/// - The `_sqlx_migrations` table does not exist
+pub async fn pre_migration_backup(
+    db_path: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !db_path.exists() {
+        tracing::info!("No existing database at {:?}, skipping backup", db_path);
+        return Ok(());
+    }
+
+    // Open a raw rusqlite connection to query the current schema version
+    let version = {
+        let conn = rusqlite::Connection::open(db_path)?;
+        let result: Result<i64, rusqlite::Error> = conn.query_row(
+            "SELECT MAX(version) FROM _sqlx_migrations",
+            [],
+            |row| row.get(0),
+        );
+        // Connection is dropped (closed) at end of this block
+        match result {
+            Ok(v) => v,
+            Err(_) => {
+                tracing::info!("No _sqlx_migrations table found, skipping backup");
+                return Ok(());
+            }
+        }
+    };
+
+    // Build the backup filename as {original_name}.backup-v{version}
+    let file_name = db_path
+        .file_name()
+        .ok_or("Invalid database path")?
+        .to_str()
+        .ok_or("Non-UTF8 database path")?;
+    let backup_name = format!("{}.backup-v{}", file_name, version);
+    let backup_path = db_path.with_file_name(&backup_name);
+
+    tokio::fs::copy(db_path, &backup_path).await?;
+    tracing::info!("Created database backup at {:?}", backup_path);
+
+    // Rotate: keep only the last 3 backups
+    let parent = db_path.parent().ok_or("Invalid database path")?;
+    let prefix = format!("{}.", file_name);
+
+    let mut backups: Vec<std::path::PathBuf> = Vec::new();
+    let mut entries = tokio::fs::read_dir(parent).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let entry_name = entry.file_name();
+        let name = entry_name.to_str().unwrap_or("");
+        if name.starts_with(&prefix) && name.contains("backup-v") {
+            backups.push(entry.path());
+        }
+    }
+
+    backups.sort();
+    if backups.len() > 3 {
+        let to_delete = backups.len() - 3;
+        for path in backups.into_iter().take(to_delete) {
+            tracing::info!("Removing old backup {:?}", path);
+            tokio::fs::remove_file(&path).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Check whether first-run setup has been completed.
+///
+/// Queries the `settings` table for a row with `key = 'setup_complete'` and
+/// returns `true` only when `value = "true"`.
+pub async fn is_setup_complete(pool: &SqlitePool) -> Result<bool, sqlx::Error> {
+    let row: Option<(Option<String>,)> =
+        sqlx::query_as("SELECT value FROM settings WHERE key = 'setup_complete'")
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(matches!(row, Some((Some(ref v),)) if v == "true"))
 }

--- a/crates/db/tests/database_init.rs
+++ b/crates/db/tests/database_init.rs
@@ -1,0 +1,63 @@
+use mokumo_db::initialize_database;
+use sqlx::Row;
+
+#[tokio::test]
+async fn pragmas_are_set_correctly() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let pool = initialize_database(&url).await.unwrap();
+
+    let journal: String = sqlx::query("PRAGMA journal_mode")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(journal.to_lowercase(), "wal");
+
+    let synchronous: i32 = sqlx::query("PRAGMA synchronous")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(synchronous, 1); // NORMAL
+
+    let busy_timeout: i32 = sqlx::query("PRAGMA busy_timeout")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(busy_timeout, 5000);
+
+    let foreign_keys: i32 = sqlx::query("PRAGMA foreign_keys")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(foreign_keys, 1); // ON
+
+    let cache_size: i32 = sqlx::query("PRAGMA cache_size")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(cache_size, -64000);
+
+    pool.close().await;
+}
+
+#[tokio::test]
+async fn database_creation_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    // First initialization
+    let pool1 = initialize_database(&url).await.unwrap();
+    pool1.close().await;
+
+    // Second initialization on same file
+    let pool2 = initialize_database(&url).await.unwrap();
+    pool2.close().await;
+}

--- a/crates/db/tests/first_run.rs
+++ b/crates/db/tests/first_run.rs
@@ -33,3 +33,41 @@ async fn completed_setup_is_remembered() {
 
     pool.close().await;
 }
+
+#[tokio::test]
+async fn setup_with_null_value_reports_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let pool = initialize_database(&url).await.unwrap();
+
+    sqlx::query("INSERT INTO settings (key, value) VALUES ('setup_complete', NULL)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let complete = is_setup_complete(&pool).await.unwrap();
+    assert!(!complete, "NULL value should report setup incomplete");
+
+    pool.close().await;
+}
+
+#[tokio::test]
+async fn setup_with_non_true_value_reports_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let pool = initialize_database(&url).await.unwrap();
+
+    sqlx::query("INSERT INTO settings (key, value) VALUES ('setup_complete', 'false')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let complete = is_setup_complete(&pool).await.unwrap();
+    assert!(!complete, "Non-'true' value should report setup incomplete");
+
+    pool.close().await;
+}

--- a/crates/db/tests/first_run.rs
+++ b/crates/db/tests/first_run.rs
@@ -1,0 +1,35 @@
+use mokumo_db::{initialize_database, is_setup_complete};
+
+#[tokio::test]
+async fn fresh_database_reports_setup_incomplete() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let pool = initialize_database(&url).await.unwrap();
+
+    let complete = is_setup_complete(&pool).await.unwrap();
+    assert!(!complete, "Fresh database should report setup incomplete");
+
+    pool.close().await;
+}
+
+#[tokio::test]
+async fn completed_setup_is_remembered() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let pool = initialize_database(&url).await.unwrap();
+
+    // Insert setup_complete = true
+    sqlx::query("INSERT INTO settings (key, value) VALUES ('setup_complete', 'true')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let complete = is_setup_complete(&pool).await.unwrap();
+    assert!(complete, "Should report setup complete after insert");
+
+    pool.close().await;
+}

--- a/crates/db/tests/migration_safety.rs
+++ b/crates/db/tests/migration_safety.rs
@@ -88,3 +88,35 @@ async fn backup_rotation_keeps_only_last_three() {
         backups
     );
 }
+
+#[tokio::test]
+async fn backup_skipped_when_db_exists_but_no_migrations_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Create a plain SQLite file with no _sqlx_migrations table
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute("CREATE TABLE dummy (id INTEGER PRIMARY KEY)", [])
+        .unwrap();
+    drop(conn);
+
+    let result = pre_migration_backup(&db_path).await;
+    assert!(
+        result.is_ok(),
+        "Should succeed (skip) when no migrations table exists"
+    );
+
+    // Verify no backup files were created
+    let mut entries = tokio::fs::read_dir(dir.path()).await.unwrap();
+    let mut backup_count = 0;
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        let name = entry.file_name().to_str().unwrap().to_string();
+        if name.contains("backup-v") {
+            backup_count += 1;
+        }
+    }
+    assert_eq!(
+        backup_count, 0,
+        "No backup files should exist when migrations table is missing"
+    );
+}

--- a/crates/db/tests/migration_safety.rs
+++ b/crates/db/tests/migration_safety.rs
@@ -1,0 +1,90 @@
+use mokumo_db::{initialize_database, pre_migration_backup};
+
+#[tokio::test]
+async fn no_backup_on_first_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Database file does not exist yet — should skip silently
+    let result = pre_migration_backup(&db_path).await;
+    assert!(result.is_ok(), "Should succeed (skip) when no DB file exists");
+
+    // Verify no backup files were created
+    let mut entries = tokio::fs::read_dir(dir.path()).await.unwrap();
+    let mut count = 0;
+    while let Some(_) = entries.next_entry().await.unwrap() {
+        count += 1;
+    }
+    assert_eq!(count, 0, "No files should exist on first run");
+}
+
+#[tokio::test]
+async fn backup_created_with_correct_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    // Create and initialize the database so _sqlx_migrations exists
+    let pool = initialize_database(&url).await.unwrap();
+    pool.close().await;
+
+    // Query the max version from _sqlx_migrations
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let version: i64 = conn
+        .query_row("SELECT MAX(version) FROM _sqlx_migrations", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    drop(conn);
+
+    // Run the backup
+    pre_migration_backup(&db_path).await.unwrap();
+
+    // Verify backup file exists with correct name
+    let expected_backup = dir
+        .path()
+        .join(format!("test.db.backup-v{}", version));
+    assert!(
+        expected_backup.exists(),
+        "Backup file should exist at {:?}",
+        expected_backup
+    );
+}
+
+#[tokio::test]
+async fn backup_rotation_keeps_only_last_three() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    // Create and initialize the database
+    let pool = initialize_database(&url).await.unwrap();
+    pool.close().await;
+
+    // Create 4 fake old backup files (simulating previous versions)
+    for v in 1..=4 {
+        let backup_name = format!("test.db.backup-v{}", v);
+        let backup_path = dir.path().join(&backup_name);
+        tokio::fs::write(&backup_path, b"fake backup").await.unwrap();
+    }
+
+    // Now run a real backup (this will create a 5th backup file)
+    pre_migration_backup(&db_path).await.unwrap();
+
+    // Count remaining backup files
+    let mut entries = tokio::fs::read_dir(dir.path()).await.unwrap();
+    let mut backups: Vec<String> = Vec::new();
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        let name = entry.file_name().to_str().unwrap().to_string();
+        if name.starts_with("test.db.") && name.contains("backup-v") {
+            backups.push(name);
+        }
+    }
+
+    assert_eq!(
+        backups.len(),
+        3,
+        "Should keep only 3 backups, found: {:?}",
+        backups
+    );
+}


### PR DESCRIPTION
## Summary

Wave 0 of M0 Layer 1 Stack Foundation (`mokumo/20260322-layer1-stack`).

- Add 5th PRAGMA `cache_size=-64000` to SQLite connection pool
- Create `settings` table migration for first-run detection
- Add `pre_migration_backup()` — backs up DB file before migrations, self-determines schema version via rusqlite, rotates keeping last 3
- Add `is_setup_complete()` — queries settings table for setup wizard state
- Add `rusqlite` and `serial_test` as workspace dependencies
- 7 integration tests covering all 7 BDD scenarios across 3 feature files

## BDD Coverage

- `database_initialization.feature` (2 scenarios) — PRAGMA verification, idempotent init
- `first_run_detection.feature` (2 scenarios) — fresh DB incomplete, remembers completion
- `migration_safety.feature` (3 scenarios) — backup naming, rotation, first-run skip

## Test plan

- [x] All 5 PRAGMAs verified (WAL, synchronous=NORMAL, busy_timeout=5000, foreign_keys=ON, cache_size=-64000)
- [x] `is_setup_complete` returns false on fresh DB, true after insert
- [x] Backup created with `{name}.backup-v{version}` naming
- [x] Backup rotation keeps only last 3
- [x] No backup on first run (no DB file)
- [x] All 7 tests pass

Closes #5 (partial — data directory and CLI flags in W1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic database backups before migrations with retention of recent backups (keeps latest 3)
  * Setup-complete status tracking to manage first-run initialization
  * Persistent settings table for storing configuration key/value pairs
  * Optimized SQLite cache configuration for improved performance

* **Chores / Tests**
  * Added comprehensive integration tests covering initialization, first-run behavior, migration backups and rotation
  * Test infrastructure updated for reliable async/serial test runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->