### PR TITLE
feat: number sequence system — atomic generator for display identifiers (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,13 +3215,17 @@ dependencies = [
 name = "mokumo-core"
 version = "0.1.0"
 dependencies = [
+ "cucumber",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
 name = "mokumo-db"
 version = "0.1.0"
 dependencies = [
+ "cucumber",
+ "mokumo-core",
  "rusqlite",
  "sqlx",
  "tempfile",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,3 +6,15 @@ license.workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
+
+[dev-dependencies]
+cucumber = { workspace = true }
+tokio = { workspace = true }
+
+[features]
+bdd = []
+
+[[test]]
+name = "bdd"
+harness = false
+required-features = ["bdd"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod customer;
 pub mod error;
 pub mod filter;
 pub mod pagination;
+pub mod sequence;

--- a/crates/core/src/sequence/mod.rs
+++ b/crates/core/src/sequence/mod.rs
@@ -1,0 +1,16 @@
+pub mod traits;
+
+/// A formatted sequence value combining the raw integer with its display string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormattedSequence {
+    pub raw_value: i64,
+    pub formatted: String,
+}
+
+/// Format a sequence number as `{prefix}-{value}` with zero-padding.
+///
+/// The value is left-padded with zeros to at least `padding` digits.
+/// If the value exceeds the padding width, it naturally overflows (no error).
+pub fn format_sequence_number(prefix: &str, value: i64, padding: u32) -> String {
+    format!("{}-{:0>width$}", prefix, value, width = padding as usize)
+}

--- a/crates/core/src/sequence/traits.rs
+++ b/crates/core/src/sequence/traits.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use super::FormattedSequence;
 use crate::error::DomainError;
 
@@ -5,11 +7,9 @@ use crate::error::DomainError;
 ///
 /// Implementors must guarantee that concurrent calls never produce
 /// duplicate values for the same sequence name.
-///
-/// Uses `async fn` in trait (RPITIT). Dyn-incompatible by design —
-/// impls are wired via concrete types or generics (static dispatch).
-/// If dynamic dispatch is needed, migrate to `Pin<Box<dyn Future>>`.
-#[allow(async_fn_in_trait)]
 pub trait SequenceGenerator: Send + Sync {
-    async fn next_value(&self, sequence_name: &str) -> Result<FormattedSequence, DomainError>;
+    fn next_value(
+        &self,
+        sequence_name: &str,
+    ) -> impl Future<Output = Result<FormattedSequence, DomainError>> + Send;
 }

--- a/crates/core/src/sequence/traits.rs
+++ b/crates/core/src/sequence/traits.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-
 use super::FormattedSequence;
 use crate::error::DomainError;
 
@@ -7,9 +5,7 @@ use crate::error::DomainError;
 ///
 /// Implementors must guarantee that concurrent calls never produce
 /// duplicate values for the same sequence name.
+#[allow(async_fn_in_trait)] // All impls are Send; single-binary app with no external consumers.
 pub trait SequenceGenerator: Send + Sync {
-    fn next_value(
-        &self,
-        sequence_name: &str,
-    ) -> impl Future<Output = Result<FormattedSequence, DomainError>> + Send;
+    async fn next_value(&self, sequence_name: &str) -> Result<FormattedSequence, DomainError>;
 }

--- a/crates/core/src/sequence/traits.rs
+++ b/crates/core/src/sequence/traits.rs
@@ -5,7 +5,11 @@ use crate::error::DomainError;
 ///
 /// Implementors must guarantee that concurrent calls never produce
 /// duplicate values for the same sequence name.
-#[allow(async_fn_in_trait)] // All impls are Send; single-binary app with no external consumers.
+///
+/// Uses `async fn` in trait (RPITIT). Dyn-incompatible by design —
+/// impls are wired via concrete types or generics (static dispatch).
+/// If dynamic dispatch is needed, migrate to `Pin<Box<dyn Future>>`.
+#[allow(async_fn_in_trait)]
 pub trait SequenceGenerator: Send + Sync {
     async fn next_value(&self, sequence_name: &str) -> Result<FormattedSequence, DomainError>;
 }

--- a/crates/core/src/sequence/traits.rs
+++ b/crates/core/src/sequence/traits.rs
@@ -1,0 +1,15 @@
+use std::future::Future;
+
+use super::FormattedSequence;
+use crate::error::DomainError;
+
+/// Port for atomic sequence number generation.
+///
+/// Implementors must guarantee that concurrent calls never produce
+/// duplicate values for the same sequence name.
+pub trait SequenceGenerator: Send + Sync {
+    fn next_value(
+        &self,
+        sequence_name: &str,
+    ) -> impl Future<Output = Result<FormattedSequence, DomainError>> + Send;
+}

--- a/crates/core/tests/bdd.rs
+++ b/crates/core/tests/bdd.rs
@@ -1,0 +1,15 @@
+use cucumber::World as _;
+
+#[path = "bdd_world/mod.rs"]
+mod bdd_world;
+
+#[tokio::main]
+async fn main() {
+    bdd_world::CoreWorld::cucumber()
+        .filter_run_and_exit("tests/features", |feature, _, sc| {
+            let dominated_by_wip =
+                feature.tags.iter().any(|t| t == "wip") || sc.tags.iter().any(|t| t == "wip");
+            !dominated_by_wip
+        })
+        .await;
+}

--- a/crates/core/tests/bdd_world/mod.rs
+++ b/crates/core/tests/bdd_world/mod.rs
@@ -1,0 +1,28 @@
+use cucumber::{World, given, then, when};
+
+#[derive(Debug, Default, World)]
+pub struct CoreWorld {
+    prefix: String,
+    padding: u32,
+    result: String,
+}
+
+#[given(expr = "a prefix {string} and padding {int}")]
+async fn given_prefix_and_padding(w: &mut CoreWorld, prefix: String, padding: i32) {
+    w.prefix = prefix;
+    w.padding = padding as u32;
+}
+
+#[when(expr = "value {int} is formatted")]
+async fn when_value_formatted(w: &mut CoreWorld, value: i64) {
+    w.result = mokumo_core::sequence::format_sequence_number(&w.prefix, value, w.padding);
+}
+
+#[then(expr = "the display number is {string}")]
+async fn then_display_number_is(w: &mut CoreWorld, expected: String) {
+    assert_eq!(
+        w.result, expected,
+        "Expected '{}', got '{}'",
+        expected, w.result
+    );
+}

--- a/crates/core/tests/features/sequence_formatting.feature
+++ b/crates/core/tests/features/sequence_formatting.feature
@@ -1,0 +1,24 @@
+Feature: Sequence Number Formatting
+
+  Display numbers follow a consistent format across all business
+  entities: a prefix, a hyphen separator, and a zero-padded value.
+  This format is recognizable to shop owners and suitable for
+  printed documents, invoices, and verbal communication.
+
+  Scenario Outline: Format display number
+    Given a prefix "<prefix>" and padding <padding>
+    When value <value> is formatted
+    Then the display number is "<expected>"
+
+    Examples:
+      | prefix | padding | value | expected   |
+      | C      | 4       | 1     | C-0001     |
+      | INV    | 6       | 42    | INV-000042 |
+      | C      | 4       | 10000 | C-10000    |
+      | Q      | 2       | 999   | Q-999      |
+      | C      | 4       | 0     | C-0000     |
+
+  Scenario: Empty prefix produces hyphen-prefixed number
+    Given a prefix "" and padding 4
+    When value 1 is formatted
+    Then the display number is "-0001"

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -9,6 +9,16 @@ sqlx = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 rusqlite = { workspace = true }
+mokumo-core = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+cucumber = { workspace = true }
+
+[features]
+bdd = []
+
+[[test]]
+name = "bdd"
+harness = false
+required-features = ["bdd"]

--- a/crates/db/migrations/20260324000000_number_sequences.sql
+++ b/crates/db/migrations/20260324000000_number_sequences.sql
@@ -1,0 +1,17 @@
+-- Number sequences: atomic generator for human-readable display identifiers.
+-- Each row defines a sequence (e.g., "customer" → C-0001, C-0002, ...).
+-- current_value tracks the LAST USED value; first call returns current_value + 1.
+--
+-- Atomicity: UPDATE...RETURNING in a single statement — no explicit transaction needed.
+-- No updated_at trigger: this is infrastructure, not a domain entity.
+
+CREATE TABLE IF NOT EXISTS number_sequences (
+    name         TEXT    PRIMARY KEY NOT NULL,
+    prefix       TEXT    NOT NULL,
+    current_value INTEGER NOT NULL DEFAULT 0,
+    padding      INTEGER NOT NULL DEFAULT 4
+);
+
+-- Seed the customer number sequence: C-0001, C-0002, ...
+INSERT INTO number_sequences (name, prefix, current_value, padding)
+VALUES ('customer', 'C', 0, 4);

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod sequence;
+
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
 /// Create a SQLite connection pool with WAL mode and run embedded migrations.

--- a/crates/db/src/sequence/mod.rs
+++ b/crates/db/src/sequence/mod.rs
@@ -1,0 +1,3 @@
+mod repo;
+
+pub use repo::SqliteSequenceGenerator;

--- a/crates/db/src/sequence/repo.rs
+++ b/crates/db/src/sequence/repo.rs
@@ -1,0 +1,50 @@
+use mokumo_core::error::DomainError;
+use mokumo_core::sequence::traits::SequenceGenerator;
+use mokumo_core::sequence::{FormattedSequence, format_sequence_number};
+use sqlx::SqlitePool;
+
+#[derive(Debug)]
+pub struct SqliteSequenceGenerator {
+    pool: SqlitePool,
+}
+
+impl SqliteSequenceGenerator {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+impl SequenceGenerator for SqliteSequenceGenerator {
+    async fn next_value(&self, sequence_name: &str) -> Result<FormattedSequence, DomainError> {
+        let row = sqlx::query_as::<_, (i64, String, i64)>(
+            "UPDATE number_sequences SET current_value = current_value + 1 \
+             WHERE name = ? \
+             RETURNING current_value, prefix, padding",
+        )
+        .bind(sequence_name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| DomainError::Internal {
+            message: e.to_string(),
+        })?;
+
+        match row {
+            Some((value, prefix, padding)) => {
+                let pad = u32::try_from(padding).map_err(|_| DomainError::Internal {
+                    message: format!(
+                        "invalid padding value {padding} for sequence '{sequence_name}'"
+                    ),
+                })?;
+                let formatted = format_sequence_number(&prefix, value, pad);
+                Ok(FormattedSequence {
+                    raw_value: value,
+                    formatted,
+                })
+            }
+            None => Err(DomainError::NotFound {
+                entity: "sequence",
+                id: sequence_name.to_string(),
+            }),
+        }
+    }
+}

--- a/crates/db/tests/bdd.rs
+++ b/crates/db/tests/bdd.rs
@@ -1,0 +1,15 @@
+use cucumber::World as _;
+
+#[path = "bdd_world/mod.rs"]
+mod bdd_world;
+
+#[tokio::main]
+async fn main() {
+    bdd_world::DbWorld::cucumber()
+        .filter_run_and_exit("tests/features", |feature, _, sc| {
+            let dominated_by_wip =
+                feature.tags.iter().any(|t| t == "wip") || sc.tags.iter().any(|t| t == "wip");
+            !dominated_by_wip
+        })
+        .await;
+}

--- a/crates/db/tests/bdd_world/mod.rs
+++ b/crates/db/tests/bdd_world/mod.rs
@@ -13,6 +13,7 @@ pub struct DbWorld {
     generator: SqliteSequenceGenerator,
     result: Option<Result<FormattedSequence, DomainError>>,
     results: Vec<Result<FormattedSequence, DomainError>>,
+    last_seeded_name: Option<String>,
     _tmp: tempfile::TempDir,
 }
 
@@ -30,6 +31,7 @@ impl DbWorld {
             generator,
             result: None,
             results: Vec::new(),
+            last_seeded_name: None,
             _tmp: tmp,
         }
     }
@@ -38,9 +40,19 @@ impl DbWorld {
 // ---- Given steps ----
 
 #[given(expr = "the customer sequence is seeded with prefix {string} and padding {int}")]
-async fn customer_sequence_seeded(_w: &mut DbWorld, _prefix: String, _padding: i32) {
-    // The migration already seeds "customer" with prefix "C" and padding 4.
-    // This step is a no-op — the seed matches the feature file expectations.
+async fn customer_sequence_seeded(w: &mut DbWorld, prefix: String, padding: i32) {
+    // Verify the migration-seeded values match what the scenario expects.
+    let row = sqlx::query_as::<_, (String, i64)>(
+        "SELECT prefix, padding FROM number_sequences WHERE name = 'customer'",
+    )
+    .fetch_one(&w.pool)
+    .await
+    .expect("customer sequence should be seeded by migration");
+    assert_eq!(row.0, prefix, "Migration prefix doesn't match scenario");
+    assert_eq!(
+        row.1, padding as i64,
+        "Migration padding doesn't match scenario"
+    );
 }
 
 #[given(expr = "a sequence with prefix {string} and padding {int}")]
@@ -54,6 +66,7 @@ async fn sequence_with_prefix(w: &mut DbWorld, prefix: String, padding: i32) {
         .execute(&w.pool)
         .await
         .expect("failed to insert sequence");
+    w.last_seeded_name = Some(name);
 }
 
 #[given(expr = "a quote sequence is seeded with prefix {string} and padding {int}")]
@@ -84,8 +97,11 @@ async fn next_customer_number(w: &mut DbWorld) {
 
 #[when("the next number is requested")]
 async fn next_number(w: &mut DbWorld) {
-    // For the "INV" scenario — derive name from lowercase prefix
-    w.result = Some(w.generator.next_value("inv").await);
+    let name = w
+        .last_seeded_name
+        .as_deref()
+        .expect("no sequence seeded — use a Given step first");
+    w.result = Some(w.generator.next_value(name).await);
 }
 
 #[when("the next quote number is requested")]

--- a/crates/db/tests/bdd_world/mod.rs
+++ b/crates/db/tests/bdd_world/mod.rs
@@ -1,0 +1,177 @@
+use cucumber::{World, given, then, when};
+use mokumo_core::error::DomainError;
+use mokumo_core::sequence::FormattedSequence;
+use mokumo_core::sequence::traits::SequenceGenerator;
+use mokumo_db::sequence::SqliteSequenceGenerator;
+use sqlx::SqlitePool;
+use std::collections::HashSet;
+
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct DbWorld {
+    pool: SqlitePool,
+    generator: SqliteSequenceGenerator,
+    result: Option<Result<FormattedSequence, DomainError>>,
+    results: Vec<Result<FormattedSequence, DomainError>>,
+    _tmp: tempfile::TempDir,
+}
+
+impl DbWorld {
+    async fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("failed to create temp dir");
+        let db_path = tmp.path().join("test.db");
+        let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
+        let pool = mokumo_db::initialize_database(&database_url)
+            .await
+            .expect("failed to initialize database");
+        let generator = SqliteSequenceGenerator::new(pool.clone());
+        Self {
+            pool,
+            generator,
+            result: None,
+            results: Vec::new(),
+            _tmp: tmp,
+        }
+    }
+}
+
+// ---- Given steps ----
+
+#[given(expr = "the customer sequence is seeded with prefix {string} and padding {int}")]
+async fn customer_sequence_seeded(_w: &mut DbWorld, _prefix: String, _padding: i32) {
+    // The migration already seeds "customer" with prefix "C" and padding 4.
+    // This step is a no-op — the seed matches the feature file expectations.
+}
+
+#[given(expr = "a sequence with prefix {string} and padding {int}")]
+async fn sequence_with_prefix(w: &mut DbWorld, prefix: String, padding: i32) {
+    // Insert a custom sequence for this scenario
+    let name = prefix.to_lowercase();
+    sqlx::query("INSERT OR REPLACE INTO number_sequences (name, prefix, current_value, padding) VALUES (?, ?, 0, ?)")
+        .bind(&name)
+        .bind(&prefix)
+        .bind(padding)
+        .execute(&w.pool)
+        .await
+        .expect("failed to insert sequence");
+}
+
+#[given(expr = "a quote sequence is seeded with prefix {string} and padding {int}")]
+async fn quote_sequence_seeded(w: &mut DbWorld, prefix: String, padding: i32) {
+    sqlx::query("INSERT INTO number_sequences (name, prefix, current_value, padding) VALUES ('quote', ?, 0, ?)")
+        .bind(&prefix)
+        .bind(padding)
+        .execute(&w.pool)
+        .await
+        .expect("failed to insert quote sequence");
+}
+
+#[given(expr = "{int} customer numbers have already been generated")]
+async fn n_customer_numbers_generated(w: &mut DbWorld, count: i32) {
+    sqlx::query("UPDATE number_sequences SET current_value = ? WHERE name = 'customer'")
+        .bind(count)
+        .execute(&w.pool)
+        .await
+        .expect("failed to advance sequence");
+}
+
+// ---- When steps ----
+
+#[when("the next customer number is requested")]
+async fn next_customer_number(w: &mut DbWorld) {
+    w.result = Some(w.generator.next_value("customer").await);
+}
+
+#[when("the next number is requested")]
+async fn next_number(w: &mut DbWorld) {
+    // For the "INV" scenario — derive name from lowercase prefix
+    w.result = Some(w.generator.next_value("inv").await);
+}
+
+#[when("the next quote number is requested")]
+async fn next_quote_number(w: &mut DbWorld) {
+    w.result = Some(w.generator.next_value("quote").await);
+}
+
+#[when(expr = "the next number is requested for a sequence named {string}")]
+async fn next_number_for_sequence(w: &mut DbWorld, name: String) {
+    w.result = Some(w.generator.next_value(&name).await);
+}
+
+#[when(expr = "{int} customer numbers are requested simultaneously")]
+async fn concurrent_customer_numbers(w: &mut DbWorld, count: i32) {
+    let mut join_set = tokio::task::JoinSet::new();
+    for _ in 0..count {
+        let pool = w.pool.clone();
+        join_set.spawn(async move {
+            let generator = SqliteSequenceGenerator::new(pool);
+            generator.next_value("customer").await
+        });
+    }
+    while let Some(res) = join_set.join_next().await {
+        let value: Result<FormattedSequence, DomainError> = res.expect("task panicked");
+        w.results.push(value);
+    }
+}
+
+// ---- Then steps ----
+
+#[then(expr = "the result is {string}")]
+async fn result_is(w: &mut DbWorld, expected: String) {
+    let result = w.result.as_ref().expect("no result");
+    let formatted = result.as_ref().expect("expected Ok result");
+    assert_eq!(
+        formatted.formatted, expected,
+        "Expected '{}', got '{}'",
+        expected, formatted.formatted
+    );
+}
+
+#[then(expr = "a {string} error is returned")]
+async fn error_returned(w: &mut DbWorld, error_type: String) {
+    let result = w.result.as_ref().expect("no result");
+    match result {
+        Err(DomainError::NotFound { .. }) if error_type == "not found" => {}
+        other => panic!("Expected '{}' error, got: {:?}", error_type, other),
+    }
+}
+
+#[then(expr = "all {int} results are unique")]
+async fn all_results_unique(w: &mut DbWorld, count: i32) {
+    let ok_results: Vec<&FormattedSequence> = w
+        .results
+        .iter()
+        .map(|r| r.as_ref().expect("expected Ok result"))
+        .collect();
+    assert_eq!(ok_results.len(), count as usize);
+    let unique: HashSet<&str> = ok_results.iter().map(|r| r.formatted.as_str()).collect();
+    assert_eq!(
+        unique.len(),
+        count as usize,
+        "Expected {} unique results, got {}",
+        count,
+        unique.len()
+    );
+}
+
+#[then(expr = "the results are {string} through {string}")]
+async fn results_are_range(w: &mut DbWorld, from: String, to: String) {
+    let mut formatted: Vec<String> = w
+        .results
+        .iter()
+        .map(|r| r.as_ref().expect("expected Ok result").formatted.clone())
+        .collect();
+    formatted.sort();
+    assert_eq!(
+        formatted.first().unwrap(),
+        &from,
+        "First result should be '{}'",
+        from
+    );
+    assert_eq!(
+        formatted.last().unwrap(),
+        &to,
+        "Last result should be '{}'",
+        to
+    );
+}

--- a/crates/db/tests/features/number_sequences.feature
+++ b/crates/db/tests/features/number_sequences.feature
@@ -1,0 +1,46 @@
+Feature: Number Sequences
+
+  Mokumo generates human-readable sequential identifiers for business
+  entities — customer numbers (C-0001), quote numbers (Q-0001), invoice
+  numbers (INV-0001). These are distinct from internal IDs and serve a
+  business purpose: customers reference them on the phone, invoices
+  need sequential numbering for accounting compliance.
+
+  Scenario: First customer number is generated
+    Given the customer sequence is seeded with prefix "C" and padding 4
+    When the next customer number is requested
+    Then the result is "C-0001"
+
+  Scenario: Numbers increment sequentially
+    Given the customer sequence is seeded with prefix "C" and padding 4
+    And 3 customer numbers have already been generated
+    When the next customer number is requested
+    Then the result is "C-0004"
+
+  Scenario: Numbers are zero-padded to the configured width
+    Given a sequence with prefix "INV" and padding 6
+    When the next number is requested
+    Then the result is "INV-000001"
+
+  Scenario: Numbers grow beyond the padding width
+    Given the customer sequence is seeded with prefix "C" and padding 4
+    And 9999 customer numbers have already been generated
+    When the next customer number is requested
+    Then the result is "C-10000"
+
+  Scenario: Requesting a nonexistent sequence returns an error
+    When the next number is requested for a sequence named "nonexistent"
+    Then a "not found" error is returned
+
+  Scenario: Different sequences increment independently
+    Given the customer sequence is seeded with prefix "C" and padding 4
+    And a quote sequence is seeded with prefix "Q" and padding 4
+    And 5 customer numbers have already been generated
+    When the next quote number is requested
+    Then the result is "Q-0001"
+
+  Scenario: Concurrent requests produce unique numbers
+    Given the customer sequence is seeded with prefix "C" and padding 4
+    When 10 customer numbers are requested simultaneously
+    Then all 10 results are unique
+    And the results are "C-0001" through "C-0010"


### PR DESCRIPTION
## Summary
- Add `number_sequences` table with atomic `UPDATE...RETURNING` for sequential display identifiers (C-0001, INV-000042, Q-0001)
- Add `FormattedSequence` struct + `format_sequence_number()` pure fn in `crates/core`
- Add `SequenceGenerator` port trait (first real port in the codebase)
- Add `SqliteSequenceGenerator` adapter in `crates/db` (first `db → core` dependency edge)
- 13 BDD scenarios: 6 formatting (core) + 7 integration including concurrent uniqueness (db)

## Key decisions
- `UPDATE...RETURNING` single statement for SQLite atomicity — no explicit transaction
- `async fn` in trait with static dispatch — dyn-incompatible by design (RPITIT); single-binary app with one impl per trait. Council R2 verdict: 5-0 unanimous. Migrate to `Pin<Box<dyn Future>>` only if dynamic dispatch is needed.
- `&str` for sequence name at M0 — newtype deferred
- Runtime-checked `sqlx::query_as()` — offline cache follow-up in #51
- No `updated_at` trigger — infrastructure table, not domain entity

## Codex review findings addressed
- **F1 (MEDIUM)**: Trait switched from `impl Future + Send` to `async fn` (ergonomic cleanup). Dyn-incompatibility acknowledged and documented — static dispatch is intentional per council decision.
- **F2 (LOW)**: Skipped BDD features — deferred, tracked in #50.
- **F3 (LOW)**: BDD step params — fixed. `customer_sequence_seeded` now asserts migration values match Gherkin params. `next_number` derives sequence name from world state instead of hardcoding.

## Quality loop
- CRAP: 100% coverage on `format_sequence_number`, near-100% on `next_value`
- Mutation: core 2/2 killed, db 1/1 unviable (compiler-enforced)
- Architecture: CAO PASS — clean port/adapter boundaries, correct dependency direction
- CEng: APPROVE WITH COMMENTS — 2 advisory (named query struct, trait form), no blockers
- CQO: PASS — healthy test suite, no flaky/redundant/slow tests

## Follow-ups
- #50 — Moon BDD test tasks for core and db crates
- #51 — SQLx offline cache for compile-time query checking
- #54 — Fix lefthook pre-push hook for worktree compatibility

## Test plan
- [ ] `cargo test -p mokumo-core --test bdd --features bdd` — 6 scenarios GREEN
- [ ] `cargo test -p mokumo-db --test bdd --features bdd` — 7 scenarios GREEN
- [ ] `cargo test -p mokumo-db` — all existing tests pass (migration is additive)
- [ ] `cargo clippy -p mokumo-core -p mokumo-db --all-targets --features bdd` — no warnings

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to generate formatted sequential business identifiers with customizable prefixes and zero-padding.
  * Support for managing multiple independent sequences concurrently with guaranteed uniqueness.

* **Tests**
  * Added comprehensive behavior-driven test coverage for sequence generation and formatting scenarios.

* **Chores**
  * Added database schema and initial sequence configuration.
  * Configured BDD testing infrastructure and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->