### PR TITLE
chore(ci): add Moon BDD test task for core crate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,7 +47,7 @@ jobs:
           path: target/nextest/ci/junit.xml
           if-no-files-found: ignore
       - name: BDD acceptance tests
-        run: moon run api:test-bdd
+        run: moon run api:test-bdd core:test-bdd
       - name: Coverage
         run: moon run api:coverage
 

--- a/crates/core/moon.yml
+++ b/crates/core/moon.yml
@@ -1,2 +1,14 @@
 language: rust
 stack: backend
+tasks:
+  test-bdd:
+    command: cargo test --package mokumo-core --test bdd --features bdd
+    inputs:
+      - src/**/*
+      - tests/**/*.rs
+      - tests/features/**/*.feature
+      - Cargo.toml
+      - /Cargo.toml
+      - /Cargo.lock
+    options:
+      runFromWorkspaceRoot: true


### PR DESCRIPTION
## Summary
- Add `test-bdd` Moon task to `crates/core/moon.yml` enabling `moon run core:test-bdd`
- Add `core:test-bdd` to CI quality pipeline BDD step (alongside existing `api:test-bdd`)

Closes #50

**Note**: `db:test-bdd` is handled separately in #65. Once that merges, its PR should add `db:test-bdd` to the CI line.

## Test plan
- [x] `moon run core:test-bdd` — 6 scenarios, 18 steps passing
- [ ] CI pipeline runs both `api:test-bdd` and `core:test-bdd` on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded BDD acceptance test coverage to include both the API and core modules in the quality workflow, ensuring broader test validation across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->