### PR TITLE
chore(dx): establish cargo-llvm-cov coverage baseline (#47)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,6 +50,13 @@ jobs:
         run: moon run api:test-bdd
       - name: Coverage
         run: moon run api:coverage
+      - name: Upload coverage report
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-coverage
+          path: coverage.json
+          if-no-files-found: ignore
 
   quality-ts:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ dist/
 
 # Test coverage
 coverage/
+coverage.json
+lcov.info
 
 # Storybook
 apps/web/storybook-static/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ moon run api:lint         # Clippy lints
 moon run api:fmt          # Check Rust formatting (cargo fmt --check)
 moon run api:fmt-write    # Apply Rust formatting (cargo fmt)
 moon run api:gen-types    # Generate TypeScript from Rust structs (ts-rs)
+moon run api:coverage     # Rust coverage report (JSON, used by CI)
+moon run api:coverage-report  # Rust coverage report (HTML, local dev)
 moon run api:db-prepare   # Prepare SQLx offline cache (CI)
 moon check --all          # Full CI: lint, test, typecheck, build across all projects
 ```

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -1,0 +1,83 @@
+# Coverage Baseline
+
+Rust workspace coverage via [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov).
+
+## Quick Start
+
+```bash
+# JSON report (used by CI)
+moon run api:coverage
+
+# HTML report (local dev — open coverage/rust/html/index.html)
+moon run api:coverage-report
+```
+
+Both commands run unit tests only (`--lib`). Integration and BDD tests are excluded intentionally at M0 — add `--tests` when domain logic in `crates/core/` warrants full-stack coverage.
+
+## Baseline (2026-03-26)
+
+Measured against `main` at commit `b22e1b4`.
+
+### Per-Crate Summary
+
+| Crate | Lines | Functions |
+|-------|-------|-----------|
+| core | 138/176 (78.4%) | 30/42 (71.4%) |
+| db | 241/618 (39.0%) | 17/57 (29.8%) |
+| types | 169/169 (100.0%)* | 23/23 (100.0%)* |
+| api | 353/736 (48.0%) | 46/91 (50.5%) |
+| **Total** | **901/1699 (53.0%)** | **116/213 (54.5%)** |
+
+*\*types crate 100% reflects derive-macro expansion tests (ts-rs export bindings), not serialization edge-case coverage.*
+
+### WebSocket Module Detail (`services/api/src/ws/`)
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `manager.rs` | 70/70 (100%) | All public methods fully covered |
+| `mod.rs` | 62/139 (44.6%) | Sync helpers covered; async handlers (`handle_socket`, `ws_handler`) and debug endpoints uncovered |
+
+**Covered functions** in `ws/mod.rs`: `origin_host_port`, `is_allowed_origin`
+**Uncovered functions**: `ws_handler`, `handle_socket`, `debug_connections`, `debug_broadcast` — these require WebSocket integration tests.
+
+### Notable Gaps
+
+| Module | Coverage | Why |
+|--------|----------|-----|
+| `core/customer/service.rs` | 0% | Service layer not yet exercised by unit tests (tested via integration tests excluded by `--lib`) |
+| `core/sequence/mod.rs` | 0% | Trait-only module, no concrete logic to test |
+| `db/sequence/repo.rs` | 0% | No unit tests yet |
+| `api/lib.rs` | 0% | Server bootstrap — tested by integration tests |
+| `api/customer/mod.rs` | 0% | Handler layer — tested by integration tests |
+| `api/activity/mod.rs` | 0% | Handler layer — tested by integration tests |
+
+## Threshold Policy
+
+### M0 (Current): Advisory
+
+Coverage numbers are tracked and reported but **not enforced as CI gates**. The baseline establishes a reference point for measuring progress. Regressions are flagged in PR reviews but do not block merges.
+
+### M1+: Enforced
+
+Coverage gates will be introduced with per-crate thresholds:
+
+| Crate | Target | Rationale |
+|-------|--------|-----------|
+| `core` | 80%+ | Domain logic — highest value coverage |
+| `types` | 90%+ | Serialization correctness is critical |
+| `db` | 60%+ | Repository impls, constrained by test database setup |
+| `api` | 50%+ | Handler layer, much tested via integration |
+
+Enforcement via `cargo llvm-cov` `--fail-under-lines` flag added to the CI coverage step.
+
+## CI Integration
+
+The `quality-rust` job in `.github/workflows/quality.yml` runs `moon run api:coverage` and uploads `coverage.json` as an artifact (`rust-coverage`). Download from any CI run's Artifacts tab.
+
+## Interpreting the Report
+
+- **Lines**: percentage of executable lines hit by at least one test
+- **Functions**: percentage of functions entered by at least one test
+- **Branches**: LLVM branch coverage (currently 0/0 — requires `--branch` flag which is not enabled in the current configuration)
+- The `--lib` flag means only `#[cfg(test)]` unit tests contribute. Integration tests (`tests/`) and BDD tests are excluded.
+- Files appearing twice in raw JSON is expected when using shared `target-dir` across worktrees — the deduplicated per-crate numbers above are authoritative.

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -66,6 +66,17 @@ tasks:
     options:
       cache: false
       runFromWorkspaceRoot: true
+  coverage-report:
+    # Standalone alternative to `coverage` — re-runs tests with instrumentation.
+    # Keep command flags in sync with `coverage` above.
+    command: cargo llvm-cov nextest --lib --workspace --exclude mokumo-desktop --html --output-dir coverage/rust
+    deps:
+    - web:build
+    inputs:
+    - '@group(allRust)'
+    options:
+      cache: false
+      runFromWorkspaceRoot: true
   lint:
     command: cargo clippy --workspace --exclude mokumo-desktop --all-targets -- -D warnings
     deps:


### PR DESCRIPTION
## Summary
- Add `api:coverage-report` Moon task for HTML coverage reports (local dev)
- Upload `coverage.json` as CI artifact on every run
- Gitignore coverage output files (`coverage.json`, `lcov.info`)
- Document per-crate baseline and threshold policy in `COVERAGE.md`
- Add coverage commands to `CLAUDE.md`

## Baseline (53% line / 54.5% function coverage)
| Crate | Lines | Functions |
|-------|-------|-----------|
| core | 78.4% | 71.4% |
| db | 39.0% | 29.8% |
| types | 100%* | 100%* |
| api | 48.0% | 50.5% |

*types 100% reflects derive-macro export tests only

## Threshold Policy
- **M0 (current)**: advisory — tracked, not enforced
- **M1+**: enforced via `--fail-under-lines` (core 80%, types 90%, db 60%, api 50%)

## Test plan
- [x] `moon run api:coverage` produces `coverage.json`
- [x] `moon run api:coverage-report` produces HTML in `coverage/rust/`
- [x] `coverage.json` is gitignored
- [x] CI uploads coverage artifact

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated test coverage reporting to CI/CD pipeline
  * Introduced local HTML coverage reports for development

* **Documentation**
  * New coverage documentation with baseline metrics and policy guidelines

* **Chores**
  * Updated configuration to track coverage-related files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->