### PR TITLE
chore(db): wire cucumber-rs BDD into Moon task (#65)

### DIFF
--- a/crates/db/moon.yml
+++ b/crates/db/moon.yml
@@ -1,2 +1,24 @@
 language: rust
 stack: backend
+fileGroups:
+  sources:
+    - src/**/*
+    - Cargo.toml
+    - /Cargo.toml
+    - /Cargo.lock
+    - /crates/core/src/**/*
+    - /crates/core/Cargo.toml
+  migrations:
+    - migrations/**/*
+  bdd:
+    - tests/**/*.rs
+    - tests/features/**/*.feature
+tasks:
+  test-bdd:
+    command: cargo test --package mokumo-db --test bdd --features bdd
+    inputs:
+      - '@group(sources)'
+      - '@group(migrations)'
+      - '@group(bdd)'
+    options:
+      runFromWorkspaceRoot: true


### PR DESCRIPTION
## Summary
- Adds `moon run db:test-bdd` task to `crates/db/moon.yml` so cucumber-rs acceptance tests run via Moon instead of manual cargo invocation
- Inputs include migrations, core sources, and feature files for correct cache invalidation
- Moon auto-classifies as `type: test`, picked up by `moon check --all`

Closes #65

## Verification
- `moon run db:test-bdd` — 20 scenarios (13 passed, 7 skipped/WIP), 51 steps passed
- `moon query tasks --project db` confirms `type: "test"`, `runInCI: true`, `persistent: false`
- Migration files in `inputGlobs` — cache invalidates on schema changes
- Cache hit on no-change re-run (28ms vs 5.7s fresh)

## Test plan
- [ ] `moon run db:test-bdd` exits 0 with all non-WIP scenarios passing
- [ ] `moon check db` includes `test-bdd` in executed tasks
- [ ] Modify a `.feature` file → re-run → cache miss
- [ ] No-change re-run → cache hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added BDD (Behavior-Driven Development) testing infrastructure with organized file groups for sources, migrations, and BDD tests.
  * Introduced a new test task enabling behavior-driven test execution with dedicated feature support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->