### PR TITLE
chore(ci): split quality-rust into parallel lint, test, and coverage jobs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality-rust:
+  lint-rust:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.6.5"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          cache: pnpm
+      - uses: moonrepo/setup-toolchain@v0
+      - uses: moonrepo/setup-rust@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "mokumo-rust"
+          save-if: "false"
+      - name: Install JS dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint + format
+        run: moon run api:lint api:fmt
+
+  test-rust:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.6.5"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          cache: pnpm
+      - uses: moonrepo/setup-toolchain@v0
+      - uses: moonrepo/setup-rust@v1
+        with:
+          bins: cargo-nextest
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "mokumo-rust"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install JS dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Unit + integration tests
+        run: moon run api:test
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-results
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: ignore
+      - name: BDD acceptance tests
+        run: moon run api:test-bdd core:test-bdd
+
+  coverage-rust:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
@@ -32,22 +99,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "mokumo-rust"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: "false"
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
-      - name: Lint + format
-        run: moon run api:lint api:fmt
-      - name: Unit + integration tests
-        run: moon run api:test
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: nextest-results
-          path: target/nextest/ci/junit.xml
-          if-no-files-found: ignore
-      - name: BDD acceptance tests
-        run: moon run api:test-bdd core:test-bdd
       - name: Coverage
         run: moon run api:coverage
       - name: Upload coverage report
@@ -108,7 +162,7 @@ jobs:
 
   seam-check:
     runs-on: ubuntu-latest
-    needs: [quality-rust]
+    needs: [test-rust]
     env:
       CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
     steps:
@@ -138,11 +192,12 @@ jobs:
   verdict:
     if: always()
     runs-on: ubuntu-latest
-    needs: [quality-rust, quality-ts, seam-check]
+    needs: [lint-rust, test-rust, quality-ts, seam-check]
     steps:
       - name: Check upstream results
         run: |
-          if [ "${{ needs.quality-rust.result }}" != "success" ] || \
+          if [ "${{ needs.lint-rust.result }}" != "success" ] || \
+             [ "${{ needs.test-rust.result }}" != "success" ] || \
              [ "${{ needs.quality-ts.result }}" != "success" ] || \
              [ "${{ needs.seam-check.result }}" != "success" ]; then
             echo "One or more quality gates failed"

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -72,7 +72,7 @@ Enforcement via `cargo llvm-cov` `--fail-under-lines` flag added to the CI cover
 
 ## CI Integration
 
-The `quality-rust` job in `.github/workflows/quality.yml` runs `moon run api:coverage` and uploads `coverage.json` as an artifact (`rust-coverage`). Download from any CI run's Artifacts tab.
+The `coverage-rust` job in `.github/workflows/quality.yml` runs `moon run api:coverage` and uploads `coverage.json` as an artifact (`rust-coverage`). This job only runs on pushes to `main` (not on PRs). Download from any main-branch CI run's Artifacts tab.
 
 ## Interpreting the Report
 


### PR DESCRIPTION
## Summary

- Split monolithic `quality-rust` job into 3 parallel jobs: `lint-rust`, `test-rust`, `coverage-rust`
- Coverage runs only on pushes to `main` (not on PRs) — saves ~1-2 min of instrumentation overhead per PR
- Lint and test run as independent parallel jobs for faster CI feedback
- `verdict` gates on `lint-rust` + `test-rust` + `quality-ts` + `seam-check`; `coverage-rust` is informational only
- Updated `COVERAGE.md` to reflect new job name and main-only behavior

## Test plan

- [ ] Push to feature branch → verify `lint-rust` and `test-rust` run in parallel, `coverage-rust` does NOT run
- [ ] `seam-check` waits for `test-rust` only
- [ ] `verdict` gates on `lint-rust`, `test-rust`, `quality-ts`, `seam-check`
- [ ] After merge to main → verify `coverage-rust` runs and produces `coverage.json` artifact

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured continuous integration workflow to separate testing and coverage reporting into distinct jobs.
  * Updated documentation to reflect CI workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->