### PR TITLE
fix(bdd): dynamic port per Playwright worker to prevent port collisions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "bits-ui": "^2.16.3",
     "dependency-cruiser": "^17.3.9",
+    "get-port-please": "^3.2.0",
     "http-server": "^14.1.1",
     "oxfmt": "^0.41.0",
     "oxlint": "^1.56.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,10 +9,7 @@ const testDir = defineBddConfig({
 
 export default defineConfig({
 	testDir,
-	workers: 1,
-	use: {
-		baseURL: 'http://localhost:6006'
-	},
+	workers: 2,
 	projects: [
 		{
 			name: 'storybook',

--- a/apps/web/tests/support/storybook.fixture.ts
+++ b/apps/web/tests/support/storybook.fixture.ts
@@ -4,25 +4,16 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getPort } from "get-port-please";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const STORYBOOK_PORT = 6006;
-const STORYBOOK_URL = `http://localhost:${STORYBOOK_PORT}`;
-
-type StorybookFixtures = {
+type WorkerFixtures = {
   storybookUrl: string;
 };
 
-type WorkerFixtures = {
-  storybookServer: void;
-};
-
-export const test = base.extend<StorybookFixtures, WorkerFixtures>({
-  storybookUrl: STORYBOOK_URL,
-
-  storybookServer: [
+export const test = base.extend<object, WorkerFixtures>({
+  storybookUrl: [
     // oxlint-disable-next-line eslint/no-empty-pattern -- playwright-bdd requires object destructuring
     async ({}, use) => {
       const webRoot = resolve(__dirname, "../..");
@@ -33,14 +24,18 @@ export const test = base.extend<StorybookFixtures, WorkerFixtures>({
         );
       }
 
-      const server = spawn("npx", ["http-server", staticDir, "-p", String(STORYBOOK_PORT), "-s"], {
+      const port = await getPort({ portRange: [6100, 6999] });
+      const url = `http://localhost:${port}`;
+
+      const httpServerBin = resolve(webRoot, "node_modules/.bin/http-server");
+      const server = spawn(httpServerBin, [staticDir, "-p", String(port), "-s"], {
         stdio: "ignore",
         cwd: webRoot,
       });
 
       try {
-        await waitForServer(STORYBOOK_URL, server);
-        await use();
+        await waitForServer(url, server);
+        await use(url);
       } finally {
         server.kill("SIGTERM");
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       dependency-cruiser:
         specifier: ^17.3.9
         version: 17.3.9
+      get-port-please:
+        specifier: ^3.2.0
+        version: 3.2.0
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -1814,6 +1817,9 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-port-please@3.2.0:
+    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -4551,6 +4557,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-port-please@3.2.0: {}
 
   get-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Replace hardcoded port 6006 with per-worker dynamic port allocation via `get-port-please` (range 6100-6999)
- Each worker-scoped `storybookUrl` fixture allocates its own free port and yields the URL through the Playwright fixture chain
- Changed `workers: 1` → `workers: 2` for proven-stable parallelism (tested up to 3; 4+ shows resource contention from concurrent http-servers)
- Replaced `npx http-server` with direct `node_modules/.bin/http-server` binary invocation to avoid npx resolution overhead and grandchild zombie risk

## Test plan

- [x] `moon run web:test-storybook` passes (41/41, workers=2)
- [x] `playwright test --workers=2` passes consistently across multiple runs
- [x] `playwright test --workers=3` passes
- [x] No `ERR_CONNECTION_REFUSED` or `ERR_CONNECTION_RESET` errors across any run
- [x] Pre-commit hooks pass (oxlint, oxfmt)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Optimized test execution by increasing parallelism for faster test runs
  * Enhanced test environment setup with dynamic port allocation to improve reliability and reduce port conflicts during test execution
* **Chores**
  * Added development dependency to support improved testing infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->