### PR TITLE
chore(ci): add Storybook BDD tests to quality pipeline

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -140,7 +140,9 @@ jobs:
         run: moon run web:depcruise
 
   test-storybook:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -220,15 +222,14 @@ jobs:
   verdict:
     if: always()
     runs-on: ubuntu-latest
-    needs: [lint-rust, test-rust, quality-ts, seam-check, test-storybook]
+    needs: [lint-rust, test-rust, quality-ts, seam-check]
     steps:
       - name: Check upstream results
         run: |
           if [ "${{ needs.lint-rust.result }}" != "success" ] || \
              [ "${{ needs.test-rust.result }}" != "success" ] || \
              [ "${{ needs.quality-ts.result }}" != "success" ] || \
-             [ "${{ needs.seam-check.result }}" != "success" ] || \
-             [ "${{ needs.test-storybook.result }}" != "success" ]; then
+             [ "${{ needs.seam-check.result }}" != "success" ]; then
             echo "One or more quality gates failed"
             exit 1
           fi

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -139,6 +139,34 @@ jobs:
       - name: Architecture constraints
         run: moon run web:depcruise
 
+  test-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.6.5"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          cache: pnpm
+      - uses: moonrepo/setup-toolchain@v0
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm --filter @mokumo/web exec playwright install --with-deps chromium
+      - name: Storybook BDD tests
+        run: moon run web:test-storybook
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-playwright-report
+          path: apps/web/playwright-report
+          if-no-files-found: ignore
+
   mutation-ts:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -192,14 +220,15 @@ jobs:
   verdict:
     if: always()
     runs-on: ubuntu-latest
-    needs: [lint-rust, test-rust, quality-ts, seam-check]
+    needs: [lint-rust, test-rust, quality-ts, seam-check, test-storybook]
     steps:
       - name: Check upstream results
         run: |
           if [ "${{ needs.lint-rust.result }}" != "success" ] || \
              [ "${{ needs.test-rust.result }}" != "success" ] || \
              [ "${{ needs.quality-ts.result }}" != "success" ] || \
-             [ "${{ needs.seam-check.result }}" != "success" ]; then
+             [ "${{ needs.seam-check.result }}" != "success" ] || \
+             [ "${{ needs.test-storybook.result }}" != "success" ]; then
             echo "One or more quality gates failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- New `test-storybook` CI job: installs Playwright Chromium, runs BDD suite via Moon (which builds `storybook-static` as a dep), uploads Playwright report artifact
- **Advisory gate** (`continue-on-error: true`, PR-only, not in verdict) — two pre-existing story failures (#86: Sidebar and AlertDialog render no content). Promotes to hard gate once #86 is fixed.

Closes #79

## Test plan
- [ ] `test-storybook` job appears in the workflow run
- [ ] Playwright Chromium installs successfully
- [ ] `storybook-static` builds via Moon dep chain
- [ ] BDD tests run (39 pass, 2 fail on pre-existing story issues, 4 skipped)
- [ ] Job shows as advisory (green checkmark despite failures)
- [ ] `verdict` does NOT gate on `test-storybook`
- [ ] Playwright report artifact uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated quality job to run visual/component tests and collect test reports. The job runs on pull requests and uploads test artifacts; it is non-blocking so it won't fail PRs.
  * No changes to product features or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->