### PR TITLE
chore: enable fail_on_skipped() in Rust BDD harnesses

### DIFF
--- a/crates/core/tests/bdd.rs
+++ b/crates/core/tests/bdd.rs
@@ -13,8 +13,10 @@ fn is_exempt(tags: &[String]) -> bool {
 #[tokio::main]
 async fn main() {
     bdd_world::CoreWorld::cucumber()
-        .fail_on_skipped_with(|feature, _rule, scenario| {
-            !is_exempt(&feature.tags) && !is_exempt(&scenario.tags)
+        .fail_on_skipped_with(|feature, rule, scenario| {
+            !is_exempt(&feature.tags)
+                && rule.map_or(true, |r| !is_exempt(&r.tags))
+                && !is_exempt(&scenario.tags)
         })
         .filter_run_and_exit("tests/features", |feature, _, sc| {
             let dominated_by_wip =

--- a/crates/core/tests/bdd.rs
+++ b/crates/core/tests/bdd.rs
@@ -3,9 +3,19 @@ use cucumber::World as _;
 #[path = "bdd_world/mod.rs"]
 mod bdd_world;
 
+/// Tags that exempt a scenario from the fail-on-skipped gate.
+const SKIP_EXEMPT_TAGS: &[&str] = &["wip", "allow.skipped", "future"];
+
+fn is_exempt(tags: &[String]) -> bool {
+    tags.iter().any(|t| SKIP_EXEMPT_TAGS.contains(&t.as_str()))
+}
+
 #[tokio::main]
 async fn main() {
     bdd_world::CoreWorld::cucumber()
+        .fail_on_skipped_with(|feature, _rule, scenario| {
+            !is_exempt(&feature.tags) && !is_exempt(&scenario.tags)
+        })
         .filter_run_and_exit("tests/features", |feature, _, sc| {
             let dominated_by_wip =
                 feature.tags.iter().any(|t| t == "wip") || sc.tags.iter().any(|t| t == "wip");

--- a/crates/db/tests/bdd.rs
+++ b/crates/db/tests/bdd.rs
@@ -13,11 +13,13 @@ fn is_exempt(tags: &[String]) -> bool {
 #[tokio::main]
 async fn main() {
     bdd_world::DbWorld::cucumber()
-        .fail_on_skipped_with(|feature, _rule, scenario| {
+        .fail_on_skipped_with(|feature, rule, scenario| {
             // Only fail on skipped if the scenario is NOT exempt.
             // Returning true = "yes, fail this skipped scenario".
             // Returning false = "allow this scenario to be skipped".
-            !is_exempt(&feature.tags) && !is_exempt(&scenario.tags)
+            !is_exempt(&feature.tags)
+                && rule.map_or(true, |r| !is_exempt(&r.tags))
+                && !is_exempt(&scenario.tags)
         })
         .filter_run_and_exit("tests/features", |feature, _, sc| {
             let dominated_by_wip =

--- a/crates/db/tests/bdd.rs
+++ b/crates/db/tests/bdd.rs
@@ -3,9 +3,22 @@ use cucumber::World as _;
 #[path = "bdd_world/mod.rs"]
 mod bdd_world;
 
+/// Tags that exempt a scenario from the fail-on-skipped gate.
+const SKIP_EXEMPT_TAGS: &[&str] = &["wip", "allow.skipped", "future"];
+
+fn is_exempt(tags: &[String]) -> bool {
+    tags.iter().any(|t| SKIP_EXEMPT_TAGS.contains(&t.as_str()))
+}
+
 #[tokio::main]
 async fn main() {
     bdd_world::DbWorld::cucumber()
+        .fail_on_skipped_with(|feature, _rule, scenario| {
+            // Only fail on skipped if the scenario is NOT exempt.
+            // Returning true = "yes, fail this skipped scenario".
+            // Returning false = "allow this scenario to be skipped".
+            !is_exempt(&feature.tags) && !is_exempt(&scenario.tags)
+        })
         .filter_run_and_exit("tests/features", |feature, _, sc| {
             let dominated_by_wip =
                 feature.tags.iter().any(|t| t == "wip") || sc.tags.iter().any(|t| t == "wip");

--- a/crates/db/tests/features/database_initialization.feature
+++ b/crates/db/tests/features/database_initialization.feature
@@ -7,12 +7,14 @@ Feature: Database Initialization
   # cache_size) belongs in crates/db unit tests, not in this behavioral
   # specification. See crates/db/tests/database_init.rs.
 
+  @allow.skipped
   Scenario: Database is created automatically on first run
     Given no database file exists
     When the server starts for the first time
     Then a database file is created in the data directory
     And the database is ready to accept data
 
+  @allow.skipped
   Scenario: Database initialization is idempotent
     Given the database has already been initialized
     When the server starts again

--- a/crates/db/tests/features/first_run_detection.feature
+++ b/crates/db/tests/features/first_run_detection.feature
@@ -3,11 +3,13 @@ Feature: First Run Detection
   Mokumo detects whether initial setup has been completed so it
   can guide new shop owners through the setup wizard.
 
+  @allow.skipped
   Scenario: Fresh database reports setup incomplete
     Given a freshly initialized database
     When setup status is checked
     Then setup is reported as incomplete
 
+  @allow.skipped
   Scenario: Completed setup is remembered
     Given the setup wizard has been completed
     When setup status is checked

--- a/crates/db/tests/features/migration_safety.feature
+++ b/crates/db/tests/features/migration_safety.feature
@@ -3,12 +3,14 @@ Feature: Migration Safety
   Before upgrading the database schema, Mokumo creates a backup
   so shop data is never lost during an update.
 
+  @allow.skipped
   Scenario: Database is backed up before schema upgrade
     Given an existing database at schema version 1
     When a schema upgrade to version 2 runs
     Then a backup file "mokumo.db.backup-v1" is created
     And the backup contains the original data
 
+  @allow.skipped
   Scenario: Only the last three backups are kept
     Given the database is at schema version 4
     And backups exist from previous upgrades to versions 2, 3, and 4
@@ -17,6 +19,7 @@ Feature: Migration Safety
     And the oldest backup is removed
     And three backup files remain
 
+  @allow.skipped
   Scenario: No backup on first run
     Given no database file exists
     When the database is initialized for the first time
@@ -24,6 +27,7 @@ Feature: Migration Safety
 
   # --- Migration atomicity ---
 
+  @allow.skipped
   Scenario: A failed schema upgrade leaves the database unchanged
     Given a database with all current migrations applied
     When a migration containing invalid SQL is applied
@@ -31,6 +35,7 @@ Feature: Migration Safety
     And the database schema should be identical to before the attempt
     And no partial changes should be visible
 
+  @allow.skipped
   Scenario: Every migration runs inside a transaction
     Given the migration registry
     Then every registered migration should be marked as transactional

--- a/services/api/tests/bdd.rs
+++ b/services/api/tests/bdd.rs
@@ -13,8 +13,10 @@ fn is_exempt(tags: &[String]) -> bool {
 #[tokio::main]
 async fn main() {
     bdd_world::ApiWorld::cucumber()
-        .fail_on_skipped_with(|feature, _rule, scenario| {
-            !is_exempt(&feature.tags) && !is_exempt(&scenario.tags)
+        .fail_on_skipped_with(|feature, rule, scenario| {
+            !is_exempt(&feature.tags)
+                && rule.map_or(true, |r| !is_exempt(&r.tags))
+                && !is_exempt(&scenario.tags)
         })
         .filter_run("tests/features", |feature, _, sc| {
             let dominated_by_wip =

--- a/services/api/tests/bdd.rs
+++ b/services/api/tests/bdd.rs
@@ -3,9 +3,19 @@ use cucumber::World as _;
 #[path = "bdd_world/mod.rs"]
 mod bdd_world;
 
+/// Tags that exempt a scenario from the fail-on-skipped gate.
+const SKIP_EXEMPT_TAGS: &[&str] = &["wip", "allow.skipped", "future"];
+
+fn is_exempt(tags: &[String]) -> bool {
+    tags.iter().any(|t| SKIP_EXEMPT_TAGS.contains(&t.as_str()))
+}
+
 #[tokio::main]
 async fn main() {
     bdd_world::ApiWorld::cucumber()
+        .fail_on_skipped_with(|feature, _rule, scenario| {
+            !is_exempt(&feature.tags) && !is_exempt(&scenario.tags)
+        })
         .filter_run("tests/features", |feature, _, sc| {
             let dominated_by_wip =
                 feature.tags.iter().any(|t| t == "wip") || sc.tags.iter().any(|t| t == "wip");


### PR DESCRIPTION
## Summary

- Add `fail_on_skipped_with()` to all three Rust BDD harnesses (db, core, api) so scenarios without step definitions cause test failures, catching dead specs at runtime
- Filter exempts `@allow.skipped`, `@future`, and `@wip` tagged scenarios from the failure gate
- Tag 9 intentionally-pending db scenarios with `@allow.skipped` across `database_initialization.feature`, `first_run_detection.feature`, and `migration_safety.feature`

## How it works

`fail_on_skipped_with()` (cucumber-rs 0.21) converts skipped steps into failures, unless the scenario or feature carries an exempt tag. The existing `filter_run`/`filter_run_and_exit` closures filter `@wip` scenarios *before* they reach the skip gate, so `@wip` is handled at two layers.

## Verification

| Harness | Result |
|---------|--------|
| `mokumo-db` | 13 passed, 11 skipped (all exempt: 9 `@allow.skipped` + 2 `@future`) |
| `mokumo-core` | 6 passed, 0 skipped |
| `mokumo-api` | Pre-existing compilation error (rust-embed 8 `Embed` trait rename) — not related to this change |

## Test plan

- [x] `cargo test --test bdd -p mokumo-db --features bdd` passes
- [x] `cargo test --test bdd -p mokumo-core --features bdd` passes
- [ ] `cargo test --test bdd -p mokumo-api --features bdd` blocked by pre-existing compilation error (tracked separately)
- [x] Clippy passes (`api:lint` clean)
- [x] Rustfmt passes (lefthook pre-commit)



Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Implemented a skip-exemption mechanism so tests tagged with wip, allow.skipped, or future can be skipped without failing the suite
  * Test runner updated to consider exempt tags at feature, rule (when present), and scenario levels before failing on skipped items
  * Added @allow.skipped to several database-related scenarios (initialization, first-run detection, migration safety)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
