### PR TITLE
feat: add BDD staleness lint tool

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -6,6 +6,7 @@ projects:
   core: crates/core
   types: crates/types
   db: crates/db
+  bdd-lint: tools/bdd-lint
 vcs:
   provider: github
   defaultBranch: main

--- a/crates/core/src/customer/mod.rs
+++ b/crates/core/src/customer/mod.rs
@@ -100,7 +100,7 @@ pub struct CreateCustomer {
 ///
 /// Non-nullable fields (`display_name`, `portal_enabled`, `tax_exempt`) use plain
 /// `Option<T>` since they cannot be set to null.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UpdateCustomer {
     pub display_name: Option<String>,
     #[serde(

--- a/crates/db/src/customer/repo.rs
+++ b/crates/db/src/customer/repo.rs
@@ -338,8 +338,29 @@ mod tests {
             .unwrap();
 
         let repo = SeaOrmCustomerRepo::new(db);
-        let req = CreateCustomer {
-            display_name: "Fault Injection Corp".to_string(),
+        let result = repo.create(&sample_create()).await;
+        assert!(
+            result.is_err(),
+            "create should fail when activity_log table is missing"
+        );
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM customers")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            count.0, 0,
+            "Customer row should NOT exist after activity log failure — transaction must roll back"
+        );
+    }
+
+    fn empty_update() -> UpdateCustomer {
+        UpdateCustomer::default()
+    }
+
+    fn sample_create() -> CreateCustomer {
+        CreateCustomer {
+            display_name: "Test Corp".to_string(),
             company_name: None,
             email: None,
             phone: None,
@@ -356,20 +377,60 @@ mod tests {
             credit_limit_cents: None,
             lead_source: None,
             tags: None,
-        };
-        let result = repo.create(&req).await;
-        assert!(
-            result.is_err(),
-            "create should fail when activity_log table is missing"
-        );
+        }
+    }
 
-        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM customers")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-        assert_eq!(
-            count.0, 0,
-            "Customer row should NOT exist after activity log failure — transaction must roll back"
+    #[tokio::test]
+    async fn test_double_soft_delete_returns_not_found() {
+        let (db, _pool, _tmp) = test_db().await;
+        let repo = SeaOrmCustomerRepo::new(db);
+
+        let customer = repo.create(&sample_create()).await.unwrap();
+
+        // First soft-delete succeeds
+        repo.soft_delete(&customer.id).await.unwrap();
+
+        // Second soft-delete should return NotFound
+        let result = repo.soft_delete(&customer.id).await;
+        assert!(
+            matches!(result, Err(DomainError::NotFound { .. })),
+            "double soft-delete should return NotFound, got: {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_empty_update_is_noop() {
+        let (db, _pool, _tmp) = test_db().await;
+        let repo = SeaOrmCustomerRepo::new(db);
+
+        let customer = repo.create(&sample_create()).await.unwrap();
+        let before = repo
+            .find_by_id(&customer.id, IncludeDeleted::ExcludeDeleted)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Update with all None fields — should be a no-op
+        let after = repo.update(&customer.id, &empty_update()).await.unwrap();
+
+        assert_eq!(before.display_name, after.display_name);
+        assert_eq!(before.company_name, after.company_name);
+        assert_eq!(before.email, after.email);
+        assert_eq!(before.phone, after.phone);
+        assert_eq!(before.address_line1, after.address_line1);
+        assert_eq!(before.address_line2, after.address_line2);
+        assert_eq!(before.city, after.city);
+        assert_eq!(before.state, after.state);
+        assert_eq!(before.postal_code, after.postal_code);
+        assert_eq!(before.country, after.country);
+        assert_eq!(before.notes, after.notes);
+        assert_eq!(before.portal_enabled, after.portal_enabled);
+        assert_eq!(before.tax_exempt, after.tax_exempt);
+        assert_eq!(before.payment_terms, after.payment_terms);
+        assert_eq!(before.credit_limit_cents, after.credit_limit_cents);
+        assert_eq!(before.lead_source, after.lead_source);
+        assert_eq!(before.tags, after.tags);
+        // updated_at intentionally not asserted — SQLite trigger fires on any
+        // UPDATE, so it advances even when no business fields change.
     }
 }

--- a/crates/db/src/customer/repo.rs
+++ b/crates/db/src/customer/repo.rs
@@ -238,12 +238,10 @@ impl CustomerRepository for SeaOrmCustomerRepo {
     async fn soft_delete(&self, id: &CustomerId) -> Result<Customer, DomainError> {
         let txn = self.db.begin().await.map_err(sea_err)?;
 
-        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
-
         let result = CustomerEntity::update_many()
             .col_expr(
                 entity::Column::DeletedAt,
-                sea_orm::sea_query::Expr::value(now),
+                sea_orm::sea_query::Expr::current_timestamp(),
             )
             .filter(entity::Column::Id.eq(id.get()))
             .filter(entity::Column::DeletedAt.is_null())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,25 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
+  tools/bdd-lint:
+    dependencies:
+      '@cucumber/gherkin':
+        specifier: ^39.0.0
+        version: 39.0.0
+      '@cucumber/language-service':
+        specifier: ^1.7.0
+        version: 1.7.0(web-tree-sitter@0.24.7)
+      '@cucumber/messages':
+        specifier: ^32.2.0
+        version: 32.2.0
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: ^3.1.1
+        version: 3.2.4(vitest@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)
+
 packages:
 
   '@adobe/css-tools@4.4.4':
@@ -322,6 +341,9 @@ packages:
   '@cucumber/gherkin@32.2.0':
     resolution: {integrity: sha512-X8xuVhSIqlUjxSRifRJ7t0TycVWyX58fygJH3wDNmHINLg9sYEkvQT0SO2G5YlRZnYc11TIFr4YPenscvdlBIw==}
 
+  '@cucumber/gherkin@39.0.0':
+    resolution: {integrity: sha512-6tCR0ZIF0tVkd2iBqA3IcYUovwdpJM6oorACisgIdDJMsKufOq962qk9jncRUi5Bja1kEAAEKpxcRtvnp9k/dg==}
+
   '@cucumber/html-formatter@21.15.1':
     resolution: {integrity: sha512-tjxEpP161sQ7xc3VREc94v1ymwIckR3ySViy7lTvfi1jUpyqy2Hd/p4oE3YT1kQ9fFDvUflPwu5ugK5mA7BQLA==}
     peerDependencies:
@@ -332,11 +354,20 @@ packages:
     peerDependencies:
       '@cucumber/messages': '*'
 
+  '@cucumber/language-service@1.7.0':
+    resolution: {integrity: sha512-jZPXMgIwMI5B6kk/2ma964W+wTMq5+tKj7PHl/ia4JWbCjhfC2W34yiVh3yG/iXxrI23EcgdK6Ngr2nmJMSf1w==}
+    engines: {node: 18 || 20 || 22 || >=23}
+    peerDependencies:
+      web-tree-sitter: ^0.24.6
+
   '@cucumber/messages@26.0.1':
     resolution: {integrity: sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==}
 
   '@cucumber/messages@27.2.0':
     resolution: {integrity: sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==}
+
+  '@cucumber/messages@32.2.0':
+    resolution: {integrity: sha512-oYp1dgL2TByYWL51Z+rNm+/mFtJhiPU9WS03goes9EALb8d9GFcXRbG1JluFLFaChF1YDqIzLac0kkC3tv1DjQ==}
 
   '@cucumber/query@13.6.0':
     resolution: {integrity: sha512-tiDneuD5MoWsJ9VKPBmQok31mSX9Ybl+U4wqDoXeZgsXHDURqzM3rnpWVV3bC34y9W6vuFxrlwF/m7HdOxwqRw==}
@@ -1332,6 +1363,12 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/js-search@1.4.4':
+    resolution: {integrity: sha512-NYIBuSRTi2h6nLne0Ygx78BZaiT/q0lLU7YSkjOrDJWpSx6BioIZA/i2GZ+WmMUzEQs2VNIWcXRRAqisrG3ZNA==}
+
+  '@types/mustache@4.2.6':
+    resolution: {integrity: sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -1810,6 +1847,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2000,6 +2041,9 @@ packages:
 
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
+
+  js-search@2.0.1:
+    resolution: {integrity: sha512-8k12LiC3fPt7gLRJTc1azE1BFvlxIw+BG3J9YzjuYf4wSE65uqYSYP4VhweApcTfV51Fzq/ogBulQew5937A9A==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -2257,6 +2301,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   mutation-server-protocol@0.4.1:
     resolution: {integrity: sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==}
     engines: {node: '>=18'}
@@ -2277,6 +2325,14 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-addon-api@8.7.0:
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
   node-releases@2.0.36:
@@ -2758,6 +2814,86 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  tree-sitter-c-sharp@0.23.1:
+    resolution: {integrity: sha512-9zZ4FlcTRWWfRf6f4PgGhG8saPls6qOOt75tDfX7un9vQZJmARjPrAC6yBNCX2T/VKcCjIDbgq0evFaB3iGhQw==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-cli@0.25.4:
+    resolution: {integrity: sha512-tSOgiUuNH1xgSopWHMb+2EPuzIawj7/7/k0cNTNInBde21R0e53ElygJ+76PLjai2BOjnCzy9n8W0o7Eo9GVgA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  tree-sitter-go@0.23.4:
+    resolution: {integrity: sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-java@0.23.5:
+    resolution: {integrity: sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-javascript@0.23.1:
+    resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-php@0.23.12:
+    resolution: {integrity: sha512-VwkBVOahhC2NYXK/Fuqq30NxuL/6c2hmbxEF4jrB7AyR5rLc7nT27mzF3qoi+pqx9Gy2AbXnGezF7h4MeM6YRA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-python@0.23.4:
+    resolution: {integrity: sha512-MbmUAl7y5UCUWqHscHke7DdRDwQnVNMNKQYQc4Gq2p09j+fgPxaU8JVsuOI/0HD3BSEEe5k9j3xmdtIWbDtDgw==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-ruby@0.23.1:
+    resolution: {integrity: sha512-d9/RXgWjR6HanN7wTYhS5bpBQLz1VkH048Vm3CodPGyJVnamXMGb8oEhDypVCBq4QnHui9sTXuJBBP3WtCw5RA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-rust@0.23.1:
+    resolution: {integrity: sha512-wrMptzUAfbl3DbNrldZveyNM2CWmRw2VvEo2j/855qQbMMz4dlCF+TBwRN/1FL1S6cYvAEAJaCMesGqhocFJhQ==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-typescript@0.23.2:
+    resolution: {integrity: sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter@0.21.1:
+    resolution: {integrity: sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==}
+
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
@@ -2918,6 +3054,9 @@ packages:
       jsdom:
         optional: true
 
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
   watskeburt@5.0.3:
     resolution: {integrity: sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==}
     engines: {node: ^20.12||^22.13||>=24.0}
@@ -2925,6 +3064,9 @@ packages:
 
   weapon-regex@1.3.6:
     resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
+
+  web-tree-sitter@0.24.7:
+    resolution: {integrity: sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ==}
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
@@ -3245,6 +3387,10 @@ snapshots:
     dependencies:
       '@cucumber/messages': 27.2.0
 
+  '@cucumber/gherkin@39.0.0':
+    dependencies:
+      '@cucumber/messages': 32.2.0
+
   '@cucumber/html-formatter@21.15.1(@cucumber/messages@27.2.0)':
     dependencies:
       '@cucumber/messages': 27.2.0
@@ -3256,6 +3402,31 @@ snapshots:
       '@teppeis/multimaps': 3.0.0
       luxon: 3.7.2
       xmlbuilder: 15.1.1
+
+  '@cucumber/language-service@1.7.0(web-tree-sitter@0.24.7)':
+    dependencies:
+      '@cucumber/cucumber-expressions': 18.0.1
+      '@cucumber/gherkin': 32.2.0
+      '@cucumber/gherkin-utils': 9.2.0
+      '@cucumber/messages': 27.2.0
+      '@types/js-search': 1.4.4
+      '@types/mustache': 4.2.6
+      fuse.js: 7.1.0
+      js-search: 2.0.1
+      mustache: 4.2.0
+      vscode-languageserver-types: 3.17.5
+      web-tree-sitter: 0.24.7
+    optionalDependencies:
+      tree-sitter: 0.21.1
+      tree-sitter-c-sharp: 0.23.1(tree-sitter@0.21.1)
+      tree-sitter-cli: 0.25.4
+      tree-sitter-go: 0.23.4(tree-sitter@0.21.1)
+      tree-sitter-java: 0.23.5(tree-sitter@0.21.1)
+      tree-sitter-php: 0.23.12(tree-sitter@0.21.1)
+      tree-sitter-python: 0.23.4(tree-sitter@0.21.1)
+      tree-sitter-ruby: 0.23.1(tree-sitter@0.21.1)
+      tree-sitter-rust: 0.23.1(tree-sitter@0.21.1)
+      tree-sitter-typescript: 0.23.2(tree-sitter@0.21.1)
 
   '@cucumber/messages@26.0.1':
     dependencies:
@@ -3270,6 +3441,11 @@ snapshots:
       class-transformer: 0.5.1
       reflect-metadata: 0.2.2
       uuid: 11.0.5
+
+  '@cucumber/messages@32.2.0':
+    dependencies:
+      class-transformer: 0.5.1
+      reflect-metadata: 0.2.2
 
   '@cucumber/query@13.6.0(@cucumber/messages@27.2.0)':
     dependencies:
@@ -4067,6 +4243,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/js-search@1.4.4': {}
+
+  '@types/mustache@4.2.6': {}
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -4543,6 +4723,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  fuse.js@7.1.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.3.0:
@@ -4729,6 +4911,8 @@ snapshots:
   jiti@2.6.1: {}
 
   js-md4@0.3.2: {}
+
+  js-search@2.0.1: {}
 
   js-tokens@10.0.0: {}
 
@@ -4917,6 +5101,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mustache@4.2.0: {}
+
   mutation-server-protocol@0.4.1:
     dependencies:
       zod: 4.3.6
@@ -4932,6 +5118,12 @@ snapshots:
   mute-stream@3.0.0: {}
 
   nanoid@3.3.11: {}
+
+  node-addon-api@8.7.0:
+    optional: true
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-releases@2.0.36: {}
 
@@ -5464,6 +5656,88 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  tree-sitter-c-sharp@0.23.1(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-cli@0.25.4:
+    optional: true
+
+  tree-sitter-go@0.23.4(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-java@0.23.5(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-javascript@0.23.1(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-php@0.23.12(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-python@0.23.4(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-ruby@0.23.1(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-rust@0.23.1(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter-typescript@0.23.2(tree-sitter@0.21.1):
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+      tree-sitter-javascript: 0.23.1(tree-sitter@0.21.1)
+    optionalDependencies:
+      tree-sitter: 0.21.1
+    optional: true
+
+  tree-sitter@0.21.1:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+    optional: true
+
   ts-dedent@2.2.0: {}
 
   tsconfig-paths-webpack-plugin@4.2.0:
@@ -5612,9 +5886,13 @@ snapshots:
       - tsx
       - yaml
 
+  vscode-languageserver-types@3.17.5: {}
+
   watskeburt@5.0.3: {}
 
   weapon-regex@1.3.6: {}
+
+  web-tree-sitter@0.24.7: {}
 
   webpack-virtual-modules@0.6.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'apps/*'
+  - 'tools/*'

--- a/tools/bdd-lint/moon.yml
+++ b/tools/bdd-lint/moon.yml
@@ -1,0 +1,11 @@
+tasks:
+  check-staleness:
+    command: node --experimental-strip-types tools/bdd-lint/src/index.ts --format ci
+    inputs:
+      - apps/web/tests/features/**/*.feature
+      - apps/web/tests/steps/**/*.steps.ts
+      - crates/*/tests/features/**/*.feature
+      - services/*/tests/features/**/*.feature
+      - tools/bdd-lint/src/**
+    options:
+      runFromWorkspaceRoot: true

--- a/tools/bdd-lint/package.json
+++ b/tools/bdd-lint/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@mokumo/bdd-lint",
+  "version": "0.1.0",
+  "description": "BDD staleness lint — detects dead specs and orphan step definitions",
+  "type": "module",
+  "scripts": {
+    "lint": "node --experimental-strip-types src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@cucumber/gherkin": "^39.0.0",
+    "@cucumber/language-service": "^1.7.0",
+    "@cucumber/messages": "^32.2.0"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^3.1.1",
+    "vitest": "^3.1.1"
+  }
+}

--- a/tools/bdd-lint/src/detect.ts
+++ b/tools/bdd-lint/src/detect.ts
@@ -1,0 +1,69 @@
+import type { StepInfo, StepDefInfo, DeadSpec, OrphanDef } from "./types.ts";
+import type { MatchResult } from "./match.ts";
+import { isExcluded } from "./parse.ts";
+
+export function findDeadSpecs(
+  matchResult: MatchResult,
+  excludeTags: string[],
+): DeadSpec[] {
+  // Group unmatched steps by scenario, excluding @wip etc.
+  const scenarioMap = new Map<string, {
+    featureFile: string;
+    scenario: string;
+    scenarioLine: number;
+    steps: { keyword: string; text: string; line: number }[];
+  }>();
+
+  for (const step of matchResult.unmatchedSteps) {
+    if (isExcluded(step.tags, excludeTags)) continue;
+
+    const key = `${step.featureFile}:${step.scenarioLine}`;
+    if (!scenarioMap.has(key)) {
+      scenarioMap.set(key, {
+        featureFile: step.featureFile,
+        scenario: step.scenario,
+        scenarioLine: step.scenarioLine,
+        steps: [],
+      });
+    }
+    scenarioMap.get(key)!.steps.push({
+      keyword: step.keyword,
+      text: step.text,
+      line: step.line,
+    });
+  }
+
+  return [...scenarioMap.values()].map((s) => ({
+    featureFile: s.featureFile,
+    scenario: s.scenario,
+    scenarioLine: s.scenarioLine,
+    unmatchedSteps: s.steps,
+  }));
+}
+
+export function findOrphanStepDefs(
+  stepDefs: StepDefInfo[],
+  matchResult: MatchResult,
+  excludeTags: string[],
+): OrphanDef[] {
+  const orphans: OrphanDef[] = [];
+
+  for (const def of stepDefs) {
+    const matchingSteps = matchResult.defToSteps.get(def.pattern) ?? [];
+
+    // Filter out steps from excluded scenarios
+    const activeMatches = matchingSteps.filter(
+      (s) => !isExcluded(s.tags, excludeTags),
+    );
+
+    if (activeMatches.length === 0) {
+      orphans.push({
+        file: def.file,
+        pattern: def.pattern,
+        line: def.line,
+      });
+    }
+  }
+
+  return orphans;
+}

--- a/tools/bdd-lint/src/discover.ts
+++ b/tools/bdd-lint/src/discover.ts
@@ -1,9 +1,6 @@
 import { globSync } from "node:fs";
 
-export function discoverFeatureFiles(
-  baseDir: string,
-  globs: string[],
-): string[] {
+function discoverFiles(baseDir: string, globs: string[]): string[] {
   const files: string[] = [];
   for (const pattern of globs) {
     files.push(...globSync(pattern, { cwd: baseDir }));
@@ -11,15 +8,18 @@ export function discoverFeatureFiles(
   return [...new Set(files)].sort().map((f) => `${baseDir}/${f}`);
 }
 
+export function discoverFeatureFiles(
+  baseDir: string,
+  globs: string[],
+): string[] {
+  return discoverFiles(baseDir, globs);
+}
+
 export function discoverStepDefFiles(
   baseDir: string,
   globs: string[],
 ): string[] {
-  const files: string[] = [];
-  for (const pattern of globs) {
-    files.push(...globSync(pattern, { cwd: baseDir }));
-  }
-  return [...new Set(files)].sort().map((f) => `${baseDir}/${f}`);
+  return discoverFiles(baseDir, globs);
 }
 
 export function isSharedStepFile(

--- a/tools/bdd-lint/src/discover.ts
+++ b/tools/bdd-lint/src/discover.ts
@@ -1,0 +1,35 @@
+import { globSync } from "node:fs";
+
+export function discoverFeatureFiles(
+  baseDir: string,
+  globs: string[],
+): string[] {
+  const files: string[] = [];
+  for (const pattern of globs) {
+    files.push(...globSync(pattern, { cwd: baseDir }));
+  }
+  return [...new Set(files)].sort().map((f) => `${baseDir}/${f}`);
+}
+
+export function discoverStepDefFiles(
+  baseDir: string,
+  globs: string[],
+): string[] {
+  const files: string[] = [];
+  for (const pattern of globs) {
+    files.push(...globSync(pattern, { cwd: baseDir }));
+  }
+  return [...new Set(files)].sort().map((f) => `${baseDir}/${f}`);
+}
+
+export function isSharedStepFile(
+  filePath: string,
+  pattern: string,
+): boolean {
+  const basename = filePath.split("/").pop() ?? "";
+  // Default pattern: *-shared.steps.ts
+  const regex = new RegExp(
+    pattern.replace("*", ".*").replace("{feature}", "[^/]+"),
+  );
+  return regex.test(basename);
+}

--- a/tools/bdd-lint/src/extract.ts
+++ b/tools/bdd-lint/src/extract.ts
@@ -37,6 +37,7 @@ export async function extractStepDefs(
   const adapter = await initParserAdapter();
   const builder = new ExpressionBuilder(adapter);
 
+  // tree-sitter language name — "tsx" handles both .ts and .tsx syntax
   const sources: Source<LanguageName>[] = stepDefFiles.map((path) => ({
     languageName: "tsx" as const,
     uri: `file://${path}`,

--- a/tools/bdd-lint/src/extract.ts
+++ b/tools/bdd-lint/src/extract.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { WasmParserAdapter } from "@cucumber/language-service/wasm";
+import { ExpressionBuilder } from "@cucumber/language-service";
+import type { Source, LanguageName, ExpressionLink } from "@cucumber/language-service";
+import type { StepDefInfo } from "./types.ts";
+import { isSharedStepFile } from "./discover.ts";
+
+let cachedAdapter: WasmParserAdapter | null = null;
+
+export async function initParserAdapter(): Promise<WasmParserAdapter> {
+  if (cachedAdapter) return cachedAdapter;
+
+  // Resolve WASM files — they live in the package's dist/ directory
+  const require = createRequire(import.meta.url);
+  const langServiceEntry = require.resolve("@cucumber/language-service");
+  // Entry resolves to dist/cjs/src/index.js; WASM files are in dist/
+  const langServiceDir = resolve(dirname(langServiceEntry), "../..");
+
+  const adapter = new WasmParserAdapter(langServiceDir);
+  await adapter.init();
+  cachedAdapter = adapter;
+  return adapter;
+}
+
+export type ExtractResult = {
+  stepDefs: StepDefInfo[];
+  expressionLinks: ExpressionLink[];
+};
+
+export async function extractStepDefs(
+  stepDefFiles: string[],
+  sharedPattern: string,
+): Promise<ExtractResult> {
+  const adapter = await initParserAdapter();
+  const builder = new ExpressionBuilder(adapter);
+
+  const sources: Source<LanguageName>[] = stepDefFiles.map((path) => ({
+    languageName: "tsx" as const,
+    uri: `file://${path}`,
+    content: readFileSync(path, "utf-8"),
+  }));
+
+  const result = builder.build(sources, []);
+
+  const stepDefs: StepDefInfo[] = result.expressionLinks.map((link) => {
+    const uri = link.locationLink.targetUri;
+    const filePath = uri.startsWith("file://") ? fileURLToPath(uri) : uri;
+    const line = (link.locationLink.targetRange?.start?.line ?? 0) + 1; // 0-indexed → 1-indexed
+
+    return {
+      file: filePath,
+      pattern: link.expression.source,
+      line,
+      isShared: isSharedStepFile(filePath, sharedPattern),
+    };
+  });
+
+  return { stepDefs, expressionLinks: result.expressionLinks };
+}

--- a/tools/bdd-lint/src/index.ts
+++ b/tools/bdd-lint/src/index.ts
@@ -1,0 +1,46 @@
+import { parseArgs } from "node:util";
+import { resolve } from "node:path";
+import { discoverFeatureFiles, discoverStepDefFiles } from "./discover.ts";
+import { parseFeatures } from "./parse.ts";
+import { extractStepDefs } from "./extract.ts";
+import { matchStepsToDefinitions } from "./match.ts";
+import { findDeadSpecs, findOrphanStepDefs } from "./detect.ts";
+import { formatReport } from "./report.ts";
+import { lint } from "./lint.ts";
+import type { LintOptions } from "./types.ts";
+
+const { values } = parseArgs({
+  options: {
+    format: { type: "string", default: "text" },
+    "exclude-tags": { type: "string", default: "@wip" },
+    "base-dir": { type: "string", default: "." },
+  },
+});
+
+const format = (values.format ?? "text") as "text" | "json" | "ci";
+const excludeTags = (values["exclude-tags"] ?? "@wip")
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean);
+const baseDir = resolve(values["base-dir"] ?? ".");
+
+const options: LintOptions = {
+  featureGlobs: [
+    "apps/web/tests/features/**/*.feature",
+    "crates/*/tests/features/**/*.feature",
+    "services/*/tests/features/**/*.feature",
+  ],
+  stepDefGlobs: [
+    "apps/web/tests/steps/**/*.steps.ts",
+  ],
+  sharedStepPattern: "*-shared.steps.ts",
+  excludeTags,
+  format,
+};
+
+const result = await lint(baseDir, options);
+const output = formatReport(result, format);
+
+console.log(output);
+
+process.exit(0);

--- a/tools/bdd-lint/src/index.ts
+++ b/tools/bdd-lint/src/index.ts
@@ -5,7 +5,7 @@ import { parseFeatures } from "./parse.ts";
 import { extractStepDefs } from "./extract.ts";
 import { matchStepsToDefinitions } from "./match.ts";
 import { findDeadSpecs, findOrphanStepDefs } from "./detect.ts";
-import { formatReport } from "./report.ts";
+import { formatReport, formatWarnings } from "./report.ts";
 import { lint } from "./lint.ts";
 import type { LintOptions } from "./types.ts";
 
@@ -39,8 +39,14 @@ const options: LintOptions = {
 };
 
 const result = await lint(baseDir, options);
-const output = formatReport(result, format);
 
+// Surface warnings to stderr (text/ci) or included in JSON output
+const warningOutput = formatWarnings(result.warnings, format);
+if (warningOutput) {
+  console.error(warningOutput);
+}
+
+const output = formatReport(result, format);
 console.log(output);
 
 process.exit(0);

--- a/tools/bdd-lint/src/lint.ts
+++ b/tools/bdd-lint/src/lint.ts
@@ -1,0 +1,66 @@
+import { discoverFeatureFiles, discoverStepDefFiles } from "./discover.ts";
+import { parseFeatures, isExcluded } from "./parse.ts";
+import { extractStepDefs } from "./extract.ts";
+import { matchStepsToDefinitions } from "./match.ts";
+import { findDeadSpecs, findOrphanStepDefs } from "./detect.ts";
+import type { LintOptions, LintResult } from "./types.ts";
+
+export async function lint(
+  baseDir: string,
+  options: LintOptions,
+): Promise<LintResult> {
+  // 1. Discover files
+  const featureFiles = discoverFeatureFiles(baseDir, options.featureGlobs);
+  const stepDefFiles = discoverStepDefFiles(baseDir, options.stepDefGlobs);
+
+  // 2. Parse features
+  const features = parseFeatures(featureFiles, options.excludeTags);
+  const allSteps = features.flatMap((f) => f.steps);
+
+  // 3. Extract step definitions
+  const { stepDefs, expressionLinks } = await extractStepDefs(
+    stepDefFiles,
+    options.sharedStepPattern,
+  );
+
+  // 4. Match steps to definitions
+  const matchResult = matchStepsToDefinitions(allSteps, expressionLinks);
+
+  // 5. Detect dead specs and orphans
+  const deadSpecs = findDeadSpecs(matchResult, options.excludeTags);
+  const orphanDefs = findOrphanStepDefs(stepDefs, matchResult, options.excludeTags);
+
+  // Count unique scenarios (excluding filtered)
+  const activeScenarios = new Set<string>();
+  for (const step of allSteps) {
+    if (!isExcluded(step.tags, options.excludeTags)) {
+      activeScenarios.add(`${step.featureFile}:${step.scenarioLine}`);
+    }
+  }
+
+  const activeSteps = allSteps.filter(
+    (s) => !isExcluded(s.tags, options.excludeTags),
+  );
+
+  return {
+    deadSpecs,
+    orphanDefs,
+    stats: {
+      featureFiles: featureFiles.length,
+      stepDefFiles: stepDefFiles.length,
+      totalScenarios: activeScenarios.size,
+      totalStepDefs: stepDefs.length,
+      totalSteps: activeSteps.length,
+      matchedSteps: activeSteps.filter((s) =>
+        matchResult.matchedSteps.some(
+          (m) => m.featureFile === s.featureFile && m.line === s.line,
+        ),
+      ).length,
+      unmatchedSteps: activeSteps.filter((s) =>
+        matchResult.unmatchedSteps.some(
+          (m) => m.featureFile === s.featureFile && m.line === s.line,
+        ),
+      ).length,
+    },
+  };
+}

--- a/tools/bdd-lint/src/lint.ts
+++ b/tools/bdd-lint/src/lint.ts
@@ -14,7 +14,7 @@ export async function lint(
   const stepDefFiles = discoverStepDefFiles(baseDir, options.stepDefGlobs);
 
   // 2. Parse features
-  const features = parseFeatures(featureFiles, options.excludeTags);
+  const { features, warnings: parseWarnings } = parseFeatures(featureFiles, options.excludeTags);
   const allSteps = features.flatMap((f) => f.steps);
 
   // 3. Extract step definitions
@@ -45,6 +45,7 @@ export async function lint(
   return {
     deadSpecs,
     orphanDefs,
+    warnings: [...parseWarnings, ...matchResult.warnings],
     stats: {
       featureFiles: featureFiles.length,
       stepDefFiles: stepDefFiles.length,

--- a/tools/bdd-lint/src/match.ts
+++ b/tools/bdd-lint/src/match.ts
@@ -8,6 +8,8 @@ export type MatchResult = {
   unmatchedSteps: StepInfo[];
   /** Steps with at least one matching definition */
   matchedSteps: StepInfo[];
+  /** Warnings from expression matching errors */
+  warnings: string[];
 };
 
 export function matchStepsToDefinitions(
@@ -17,6 +19,7 @@ export function matchStepsToDefinitions(
   const defToSteps = new Map<string, StepInfo[]>();
   const unmatchedSteps: StepInfo[] = [];
   const matchedSteps: StepInfo[] = [];
+  const warnings: string[] = [];
 
   // Initialize map for all definitions
   for (const link of expressionLinks) {
@@ -32,8 +35,11 @@ export function matchStepsToDefinitions(
           found = true;
           defToSteps.get(link.expression.source)!.push(step);
         }
-      } catch {
-        // Skip expressions that error during matching
+      } catch (e) {
+        const uri = link.locationLink.targetUri;
+        const file = uri.startsWith("file://") ? uri.slice(7) : uri;
+        const line = (link.locationLink.targetRange?.start?.line ?? 0) + 1;
+        warnings.push(`Expression error matching step '${step.text}' against def at ${file}:${line}: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
     if (found) {
@@ -43,5 +49,5 @@ export function matchStepsToDefinitions(
     }
   }
 
-  return { defToSteps, unmatchedSteps, matchedSteps };
+  return { defToSteps, unmatchedSteps, matchedSteps, warnings };
 }

--- a/tools/bdd-lint/src/match.ts
+++ b/tools/bdd-lint/src/match.ts
@@ -1,0 +1,47 @@
+import type { ExpressionLink } from "@cucumber/language-service";
+import type { StepInfo } from "./types.ts";
+
+export type MatchResult = {
+  /** Map of step def pattern → set of step texts that matched it */
+  defToSteps: Map<string, StepInfo[]>;
+  /** Steps with no matching definition */
+  unmatchedSteps: StepInfo[];
+  /** Steps with at least one matching definition */
+  matchedSteps: StepInfo[];
+};
+
+export function matchStepsToDefinitions(
+  steps: StepInfo[],
+  expressionLinks: ExpressionLink[],
+): MatchResult {
+  const defToSteps = new Map<string, StepInfo[]>();
+  const unmatchedSteps: StepInfo[] = [];
+  const matchedSteps: StepInfo[] = [];
+
+  // Initialize map for all definitions
+  for (const link of expressionLinks) {
+    defToSteps.set(link.expression.source, []);
+  }
+
+  for (const step of steps) {
+    let found = false;
+    for (const link of expressionLinks) {
+      try {
+        const m = link.expression.match(step.text);
+        if (m !== null) {
+          found = true;
+          defToSteps.get(link.expression.source)!.push(step);
+        }
+      } catch {
+        // Skip expressions that error during matching
+      }
+    }
+    if (found) {
+      matchedSteps.push(step);
+    } else {
+      unmatchedSteps.push(step);
+    }
+  }
+
+  return { defToSteps, unmatchedSteps, matchedSteps };
+}

--- a/tools/bdd-lint/src/parse.ts
+++ b/tools/bdd-lint/src/parse.ts
@@ -9,12 +9,18 @@ export type ParsedFeature = {
   steps: StepInfo[];
 };
 
+export type ParseFeaturesResult = {
+  features: ParsedFeature[];
+  warnings: string[];
+};
+
 export function parseFeatures(
   featureFiles: string[],
   excludeTags: string[],
-): ParsedFeature[] {
+): ParseFeaturesResult {
   const uuidFn = Messages.IdGenerator.uuid();
   const results: ParsedFeature[] = [];
+  const warnings: string[] = [];
 
   for (const file of featureFiles) {
     const content = readFileSync(file, "utf-8");
@@ -25,7 +31,8 @@ export function parseFeatures(
     let doc;
     try {
       doc = parser.parse(content);
-    } catch {
+    } catch (e) {
+      warnings.push(`Failed to parse feature file: ${file}: ${e instanceof Error ? e.message : String(e)}`);
       continue;
     }
 
@@ -67,7 +74,7 @@ export function parseFeatures(
     });
   }
 
-  return results;
+  return { features: results, warnings };
 }
 
 export function isExcluded(tags: string[], excludeTags: string[]): boolean {

--- a/tools/bdd-lint/src/parse.ts
+++ b/tools/bdd-lint/src/parse.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import * as Gherkin from "@cucumber/gherkin";
+import * as Messages from "@cucumber/messages";
+import type { StepInfo } from "./types.ts";
+
+export type ParsedFeature = {
+  file: string;
+  name: string;
+  steps: StepInfo[];
+};
+
+export function parseFeatures(
+  featureFiles: string[],
+  excludeTags: string[],
+): ParsedFeature[] {
+  const uuidFn = Messages.IdGenerator.uuid();
+  const results: ParsedFeature[] = [];
+
+  for (const file of featureFiles) {
+    const content = readFileSync(file, "utf-8");
+    const astBuilder = new Gherkin.AstBuilder(uuidFn);
+    const matcher = new Gherkin.GherkinClassicTokenMatcher();
+    const parser = new Gherkin.Parser(astBuilder, matcher);
+
+    let doc;
+    try {
+      doc = parser.parse(content);
+    } catch {
+      continue;
+    }
+
+    if (!doc.feature) continue;
+
+    const featureTags = doc.feature.tags.map((t) => t.name);
+    const featureExcluded = featureTags.some((t) => excludeTags.includes(t));
+
+    const steps: StepInfo[] = [];
+
+    for (const child of doc.feature.children) {
+      if (!child.scenario) continue;
+
+      const scenarioTags = [
+        ...featureTags,
+        ...child.scenario.tags.map((t) => t.name),
+      ];
+      const excluded = featureExcluded ||
+        child.scenario.tags.some((t) => excludeTags.includes(t.name));
+
+      for (const step of child.scenario.steps) {
+        steps.push({
+          featureFile: file,
+          featureName: doc.feature.name,
+          scenario: child.scenario.name,
+          scenarioLine: child.scenario.location.line,
+          keyword: step.keyword.trim(),
+          text: step.text,
+          line: step.location.line,
+          tags: scenarioTags,
+        });
+      }
+    }
+
+    results.push({
+      file,
+      name: doc.feature.name,
+      steps,
+    });
+  }
+
+  return results;
+}
+
+export function isExcluded(tags: string[], excludeTags: string[]): boolean {
+  return tags.some((t) => excludeTags.includes(t));
+}

--- a/tools/bdd-lint/src/report.ts
+++ b/tools/bdd-lint/src/report.ts
@@ -1,0 +1,86 @@
+import type { LintResult } from "./types.ts";
+
+export function formatReport(result: LintResult, format: "text" | "json" | "ci"): string {
+  switch (format) {
+    case "json":
+      return JSON.stringify(result, null, 2);
+    case "ci":
+      return formatCi(result);
+    case "text":
+    default:
+      return formatText(result);
+  }
+}
+
+function formatText(result: LintResult): string {
+  const lines: string[] = [];
+
+  lines.push("BDD Staleness Lint Report");
+  lines.push("=".repeat(50));
+  lines.push("");
+
+  // Stats
+  lines.push(`Feature files:     ${result.stats.featureFiles}`);
+  lines.push(`Step def files:    ${result.stats.stepDefFiles}`);
+  lines.push(`Total scenarios:   ${result.stats.totalScenarios}`);
+  lines.push(`Total steps:       ${result.stats.totalSteps}`);
+  lines.push(`Matched steps:     ${result.stats.matchedSteps}`);
+  lines.push(`Unmatched steps:   ${result.stats.unmatchedSteps}`);
+  lines.push(`Step definitions:  ${result.stats.totalStepDefs}`);
+  lines.push("");
+
+  // Dead specs
+  if (result.deadSpecs.length > 0) {
+    lines.push(`Dead Specs (${result.deadSpecs.length})`);
+    lines.push("-".repeat(40));
+    for (const spec of result.deadSpecs) {
+      lines.push(`  ${spec.featureFile}:${spec.scenarioLine} — ${spec.scenario}`);
+      for (const step of spec.unmatchedSteps) {
+        lines.push(`    ${step.keyword} ${step.text} (line ${step.line})`);
+      }
+    }
+    lines.push("");
+  } else {
+    lines.push("Dead Specs: none");
+    lines.push("");
+  }
+
+  // Orphan defs
+  if (result.orphanDefs.length > 0) {
+    lines.push(`Orphan Step Definitions (${result.orphanDefs.length})`);
+    lines.push("-".repeat(40));
+    for (const orphan of result.orphanDefs) {
+      lines.push(`  ${orphan.file}:${orphan.line} — "${orphan.pattern}"`);
+    }
+    lines.push("");
+  } else {
+    lines.push("Orphan Step Definitions: none");
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function formatCi(result: LintResult): string {
+  const lines: string[] = [];
+
+  for (const spec of result.deadSpecs) {
+    for (const step of spec.unmatchedSteps) {
+      lines.push(
+        `::warning file=${spec.featureFile},line=${step.line}::Dead spec: ${step.keyword} ${step.text} (scenario: ${spec.scenario})`,
+      );
+    }
+  }
+
+  for (const orphan of result.orphanDefs) {
+    lines.push(
+      `::warning file=${orphan.file},line=${orphan.line}::Orphan step def: "${orphan.pattern}"`,
+    );
+  }
+
+  if (lines.length === 0) {
+    lines.push("BDD lint: all clean");
+  }
+
+  return lines.join("\n");
+}

--- a/tools/bdd-lint/src/report.ts
+++ b/tools/bdd-lint/src/report.ts
@@ -12,6 +12,19 @@ export function formatReport(result: LintResult, format: "text" | "json" | "ci")
   }
 }
 
+export function formatWarnings(warnings: string[], format: "text" | "json" | "ci"): string {
+  if (warnings.length === 0) return "";
+  switch (format) {
+    case "json":
+      return ""; // warnings are included in the JSON output directly
+    case "ci":
+      return warnings.map((w) => `::warning::${w}`).join("\n");
+    case "text":
+    default:
+      return warnings.map((w) => `[warn] ${w}`).join("\n");
+  }
+}
+
 function formatText(result: LintResult): string {
   const lines: string[] = [];
 

--- a/tools/bdd-lint/src/types.ts
+++ b/tools/bdd-lint/src/types.ts
@@ -1,0 +1,52 @@
+export type StepInfo = {
+  featureFile: string;
+  featureName: string;
+  scenario: string;
+  scenarioLine: number;
+  keyword: string;
+  text: string;
+  line: number;
+  tags: string[];
+};
+
+export type StepDefInfo = {
+  file: string;
+  pattern: string;
+  line: number;
+  isShared: boolean;
+};
+
+export type DeadSpec = {
+  featureFile: string;
+  scenario: string;
+  scenarioLine: number;
+  unmatchedSteps: { keyword: string; text: string; line: number }[];
+};
+
+export type OrphanDef = {
+  file: string;
+  pattern: string;
+  line: number;
+};
+
+export type LintResult = {
+  deadSpecs: DeadSpec[];
+  orphanDefs: OrphanDef[];
+  stats: {
+    featureFiles: number;
+    stepDefFiles: number;
+    totalScenarios: number;
+    totalStepDefs: number;
+    totalSteps: number;
+    matchedSteps: number;
+    unmatchedSteps: number;
+  };
+};
+
+export type LintOptions = {
+  featureGlobs: string[];
+  stepDefGlobs: string[];
+  sharedStepPattern: string;
+  excludeTags: string[];
+  format: "text" | "json" | "ci";
+};

--- a/tools/bdd-lint/src/types.ts
+++ b/tools/bdd-lint/src/types.ts
@@ -32,6 +32,7 @@ export type OrphanDef = {
 export type LintResult = {
   deadSpecs: DeadSpec[];
   orphanDefs: OrphanDef[];
+  warnings: string[];
   stats: {
     featureFiles: number;
     stepDefFiles: number;

--- a/tools/bdd-lint/tests/fixtures/clean/auth.feature
+++ b/tools/bdd-lint/tests/fixtures/clean/auth.feature
@@ -1,0 +1,11 @@
+Feature: Authentication
+
+  Scenario: User logs in
+    Given a user with email "test@example.com"
+    When the user enters their password
+    Then the user is logged in
+
+  Scenario: User logs out
+    Given a logged-in user
+    When the user clicks logout
+    Then the user is logged out

--- a/tools/bdd-lint/tests/fixtures/clean/auth.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/clean/auth.steps.ts
@@ -1,0 +1,8 @@
+import { Given, When, Then } from "./support.ts";
+
+Given("a user with email {string}", async () => {});
+When("the user enters their password", async () => {});
+Then("the user is logged in", async () => {});
+Given("a logged-in user", async () => {});
+When("the user clicks logout", async () => {});
+Then("the user is logged out", async () => {});

--- a/tools/bdd-lint/tests/fixtures/dead-spec/checkout.feature
+++ b/tools/bdd-lint/tests/fixtures/dead-spec/checkout.feature
@@ -1,0 +1,11 @@
+Feature: Checkout
+
+  Scenario: User completes checkout
+    Given a cart with 3 items
+    When the user enters their shipping address
+    Then the order is placed
+
+  Scenario: User applies coupon
+    Given a cart with items
+    When the user applies coupon "SAVE10"
+    Then the total is reduced by 10 percent

--- a/tools/bdd-lint/tests/fixtures/dead-spec/checkout.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/dead-spec/checkout.steps.ts
@@ -1,0 +1,8 @@
+import { Given, When, Then } from "./support.ts";
+
+Given("a cart with {int} items", async () => {});
+// "the user enters their shipping address" — deliberately missing
+// "the order is placed" — deliberately missing
+Given("a cart with items", async () => {});
+When("the user applies coupon {string}", async () => {});
+Then("the total is reduced by 10 percent", async () => {});

--- a/tools/bdd-lint/tests/fixtures/mixed/orders.feature
+++ b/tools/bdd-lint/tests/fixtures/mixed/orders.feature
@@ -1,0 +1,11 @@
+Feature: Orders
+
+  Scenario: User places order
+    Given a cart with items
+    When the user places the order
+    Then an order confirmation is shown
+
+  Scenario: User tracks order
+    Given an existing order
+    When the user views tracking info
+    Then the tracking status is shown

--- a/tools/bdd-lint/tests/fixtures/mixed/orders.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/mixed/orders.steps.ts
@@ -1,0 +1,12 @@
+import { Given, When, Then } from "./support.ts";
+
+Given("a cart with items", async () => {});
+When("the user places the order", async () => {});
+Then("an order confirmation is shown", async () => {});
+// "an existing order" — missing (dead spec trigger)
+// "the user views tracking info" — missing (dead spec trigger)
+// "the tracking status is shown" — missing (dead spec trigger)
+
+// Orphan definitions
+Given("the user has store credit", async () => {});
+When("the user applies store credit", async () => {});

--- a/tools/bdd-lint/tests/fixtures/orphan-def/billing.feature
+++ b/tools/bdd-lint/tests/fixtures/orphan-def/billing.feature
@@ -1,0 +1,6 @@
+Feature: Billing
+
+  Scenario: User views invoice
+    Given a user with an active subscription
+    When the user opens the billing page
+    Then the invoice is displayed

--- a/tools/bdd-lint/tests/fixtures/orphan-def/billing.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/orphan-def/billing.steps.ts
@@ -1,0 +1,10 @@
+import { Given, When, Then } from "./support.ts";
+
+Given("a user with an active subscription", async () => {});
+When("the user opens the billing page", async () => {});
+Then("the invoice is displayed", async () => {});
+
+// Orphan definitions — no scenario references these
+Given("the user has a payment method on file", async () => {});
+When("the user cancels their subscription", async () => {});
+Then("the refund is processed", async () => {});

--- a/tools/bdd-lint/tests/fixtures/shared/auth-shared.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/shared/auth-shared.steps.ts
@@ -1,0 +1,7 @@
+import { Given, When, Then } from "./support.ts";
+
+// Shared: matches scenarios in both auth.feature and billing.feature
+Given("the user is authenticated", async () => {});
+
+// Shared: only match is in billing.feature @wip scenario — should be orphan
+Given("the system is under maintenance", async () => {});

--- a/tools/bdd-lint/tests/fixtures/shared/auth.feature
+++ b/tools/bdd-lint/tests/fixtures/shared/auth.feature
@@ -1,0 +1,6 @@
+Feature: Authentication
+
+  Scenario: User views profile
+    Given the user is authenticated
+    When the user opens the profile page
+    Then the profile is displayed

--- a/tools/bdd-lint/tests/fixtures/shared/auth.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/shared/auth.steps.ts
@@ -1,0 +1,4 @@
+import { Given, When, Then } from "./support.ts";
+
+When("the user opens the profile page", async () => {});
+Then("the profile is displayed", async () => {});

--- a/tools/bdd-lint/tests/fixtures/shared/billing.feature
+++ b/tools/bdd-lint/tests/fixtures/shared/billing.feature
@@ -1,0 +1,12 @@
+Feature: Billing
+
+  Scenario: User views billing
+    Given the user is authenticated
+    When the user opens the billing page
+    Then the billing summary is displayed
+
+  @wip
+  Scenario: User triggers maintenance check
+    Given the system is under maintenance
+    When the user opens the billing page
+    Then a maintenance message is shown

--- a/tools/bdd-lint/tests/fixtures/shared/billing.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/shared/billing.steps.ts
@@ -1,0 +1,5 @@
+import { Given, When, Then } from "./support.ts";
+
+When("the user opens the billing page", async () => {});
+Then("the billing summary is displayed", async () => {});
+Then("a maintenance message is shown", async () => {});

--- a/tools/bdd-lint/tests/fixtures/wip/login.feature
+++ b/tools/bdd-lint/tests/fixtures/wip/login.feature
@@ -1,0 +1,12 @@
+Feature: Login flows
+
+  @wip
+  Scenario: Future login flow
+    Given a user with SSO enabled
+    When the user authenticates via SSO
+    Then the user is redirected to the dashboard
+
+  Scenario: Current login flow
+    Given a user with email "user@test.com"
+    When the user enters their password
+    Then the user is logged in

--- a/tools/bdd-lint/tests/fixtures/wip/login.steps.ts
+++ b/tools/bdd-lint/tests/fixtures/wip/login.steps.ts
@@ -1,0 +1,11 @@
+import { Given, When, Then } from "./support.ts";
+
+// Matches current login flow
+Given("a user with email {string}", async () => {});
+When("the user enters their password", async () => {});
+Then("the user is logged in", async () => {});
+
+// Only matches @wip scenario — should be detected as orphan
+Given("a user with SSO enabled", async () => {});
+When("the user authenticates via SSO", async () => {});
+Then("the user is redirected to the dashboard", async () => {});

--- a/tools/bdd-lint/tests/lint.test.ts
+++ b/tools/bdd-lint/tests/lint.test.ts
@@ -31,6 +31,7 @@ describe("clean fixture", () => {
 
     expect(result.deadSpecs).toHaveLength(0);
     expect(result.orphanDefs).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
     expect(result.stats.featureFiles).toBe(1);
     expect(result.stats.stepDefFiles).toBe(1);
     expect(result.stats.matchedSteps).toBeGreaterThan(0);

--- a/tools/bdd-lint/tests/lint.test.ts
+++ b/tools/bdd-lint/tests/lint.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { lint } from "../src/lint.ts";
+import type { LintOptions } from "../src/types.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function fixtureOptions(
+  fixture: string,
+  overrides?: Partial<LintOptions>,
+): { baseDir: string; options: LintOptions } {
+  const baseDir = resolve(__dirname, "fixtures", fixture);
+  return {
+    baseDir,
+    options: {
+      featureGlobs: ["**/*.feature"],
+      stepDefGlobs: ["**/*.steps.ts"],
+      sharedStepPattern: "*-shared.steps.ts",
+      excludeTags: ["@wip"],
+      format: "text",
+      ...overrides,
+    },
+  };
+}
+
+describe("clean fixture", () => {
+  it("reports zero dead specs and zero orphans", async () => {
+    const { baseDir, options } = fixtureOptions("clean");
+    const result = await lint(baseDir, options);
+
+    expect(result.deadSpecs).toHaveLength(0);
+    expect(result.orphanDefs).toHaveLength(0);
+    expect(result.stats.featureFiles).toBe(1);
+    expect(result.stats.stepDefFiles).toBe(1);
+    expect(result.stats.matchedSteps).toBeGreaterThan(0);
+    expect(result.stats.unmatchedSteps).toBe(0);
+  });
+});
+
+describe("dead-spec fixture", () => {
+  it("detects scenarios with unmatched steps", async () => {
+    const { baseDir, options } = fixtureOptions("dead-spec");
+    const result = await lint(baseDir, options);
+
+    expect(result.deadSpecs).toHaveLength(1);
+    expect(result.deadSpecs[0].scenario).toBe("User completes checkout");
+    expect(result.deadSpecs[0].unmatchedSteps).toHaveLength(2);
+
+    const stepTexts = result.deadSpecs[0].unmatchedSteps.map((s) => s.text);
+    expect(stepTexts).toContain("the user enters their shipping address");
+    expect(stepTexts).toContain("the order is placed");
+  });
+
+  it("includes file path and line numbers in dead spec", async () => {
+    const { baseDir, options } = fixtureOptions("dead-spec");
+    const result = await lint(baseDir, options);
+
+    expect(result.deadSpecs[0].featureFile).toContain("checkout.feature");
+    expect(result.deadSpecs[0].scenarioLine).toBeGreaterThan(0);
+    for (const step of result.deadSpecs[0].unmatchedSteps) {
+      expect(step.line).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("orphan-def fixture", () => {
+  it("detects step definitions with no matching scenario", async () => {
+    const { baseDir, options } = fixtureOptions("orphan-def");
+    const result = await lint(baseDir, options);
+
+    expect(result.deadSpecs).toHaveLength(0);
+    expect(result.orphanDefs).toHaveLength(3);
+
+    const orphanPatterns = result.orphanDefs.map((o) => o.pattern);
+    expect(orphanPatterns).toContain("the user has a payment method on file");
+    expect(orphanPatterns).toContain("the user cancels their subscription");
+    expect(orphanPatterns).toContain("the refund is processed");
+  });
+
+  it("includes file path and line in orphan report", async () => {
+    const { baseDir, options } = fixtureOptions("orphan-def");
+    const result = await lint(baseDir, options);
+
+    for (const orphan of result.orphanDefs) {
+      expect(orphan.file).toContain("billing.steps.ts");
+      expect(orphan.line).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("wip fixture", () => {
+  it("excludes @wip scenarios from dead spec detection", async () => {
+    const { baseDir, options } = fixtureOptions("wip");
+    const result = await lint(baseDir, options);
+
+    // The @wip scenario "Future login flow" should NOT appear as dead spec
+    // The non-wip scenario "Current login flow" should be fully matched
+    expect(result.deadSpecs).toHaveLength(0);
+  });
+
+  it("detects step defs whose only match is a @wip scenario as orphan", async () => {
+    const { baseDir, options } = fixtureOptions("wip");
+    const result = await lint(baseDir, options);
+
+    // The SSO-related defs only match @wip scenario → orphans
+    expect(result.orphanDefs.length).toBe(3);
+    const orphanPatterns = result.orphanDefs.map((o) => o.pattern);
+    expect(orphanPatterns).toContain("a user with SSO enabled");
+    expect(orphanPatterns).toContain("the user authenticates via SSO");
+    expect(orphanPatterns).toContain("the user is redirected to the dashboard");
+  });
+
+  it("supports custom exclude tags", async () => {
+    const { baseDir, options } = fixtureOptions("wip", {
+      excludeTags: ["@custom-tag"],
+    });
+    const result = await lint(baseDir, options);
+
+    // With @custom-tag (not @wip), the @wip scenario IS analyzed
+    // SSO defs now match → not orphans
+    // But SSO steps have no definitions... wait, they DO have defs
+    // So actually everything should match and no orphans
+    expect(result.orphanDefs).toHaveLength(0);
+    expect(result.deadSpecs).toHaveLength(0);
+  });
+});
+
+describe("shared fixture", () => {
+  it("shared step def matching across features is not orphan", async () => {
+    const { baseDir, options } = fixtureOptions("shared");
+    const result = await lint(baseDir, options);
+
+    // "the user is authenticated" is shared, matches auth.feature and billing.feature
+    const orphanPatterns = result.orphanDefs.map((o) => o.pattern);
+    expect(orphanPatterns).not.toContain("the user is authenticated");
+  });
+
+  it("shared step def whose only match is @wip is orphan", async () => {
+    const { baseDir, options } = fixtureOptions("shared");
+    const result = await lint(baseDir, options);
+
+    // "the system is under maintenance" only matches billing @wip scenario → orphan
+    const orphanPatterns = result.orphanDefs.map((o) => o.pattern);
+    expect(orphanPatterns).toContain("the system is under maintenance");
+  });
+
+  it("billing @wip step defs that only match wip scenario are orphans", async () => {
+    const { baseDir, options } = fixtureOptions("shared");
+    const result = await lint(baseDir, options);
+
+    // "a maintenance message is shown" only matches @wip scenario → orphan
+    const orphanPatterns = result.orphanDefs.map((o) => o.pattern);
+    expect(orphanPatterns).toContain("a maintenance message is shown");
+  });
+
+  it("reports zero dead specs for shared fixture", async () => {
+    const { baseDir, options } = fixtureOptions("shared");
+    const result = await lint(baseDir, options);
+
+    expect(result.deadSpecs).toHaveLength(0);
+  });
+});
+
+describe("mixed fixture", () => {
+  it("detects both dead specs and orphan defs", async () => {
+    const { baseDir, options } = fixtureOptions("mixed");
+    const result = await lint(baseDir, options);
+
+    // Dead spec: "User tracks order" has 3 unmatched steps
+    expect(result.deadSpecs).toHaveLength(1);
+    expect(result.deadSpecs[0].scenario).toBe("User tracks order");
+    expect(result.deadSpecs[0].unmatchedSteps).toHaveLength(3);
+
+    // Orphans: "the user has store credit" and "the user applies store credit"
+    expect(result.orphanDefs).toHaveLength(2);
+    const orphanPatterns = result.orphanDefs.map((o) => o.pattern);
+    expect(orphanPatterns).toContain("the user has store credit");
+    expect(orphanPatterns).toContain("the user applies store credit");
+  });
+});

--- a/tools/bdd-lint/tests/match.test.ts
+++ b/tools/bdd-lint/tests/match.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractStepDefs } from "../src/extract.ts";
+import { matchStepsToDefinitions } from "../src/match.ts";
+import type { StepInfo } from "../src/types.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function makeStep(text: string, overrides?: Partial<StepInfo>): StepInfo {
+  return {
+    featureFile: "test.feature",
+    featureName: "Test",
+    scenario: "Test scenario",
+    scenarioLine: 1,
+    keyword: "Given",
+    text,
+    line: 1,
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("matchStepsToDefinitions", () => {
+  it("matches string pattern step definitions", async () => {
+    const fixtureDir = resolve(__dirname, "fixtures/clean");
+    const stepDefFile = resolve(fixtureDir, "auth.steps.ts");
+    const { expressionLinks } = await extractStepDefs([stepDefFile], "*-shared.steps.ts");
+
+    const steps = [
+      makeStep("the user enters their password"),
+      makeStep("the user is logged in"),
+    ];
+
+    const result = matchStepsToDefinitions(steps, expressionLinks);
+    expect(result.matchedSteps).toHaveLength(2);
+    expect(result.unmatchedSteps).toHaveLength(0);
+  });
+
+  it("matches parameterized cucumber expressions", async () => {
+    const fixtureDir = resolve(__dirname, "fixtures/clean");
+    const stepDefFile = resolve(fixtureDir, "auth.steps.ts");
+    const { expressionLinks } = await extractStepDefs([stepDefFile], "*-shared.steps.ts");
+
+    const steps = [
+      makeStep('a user with email "alice@example.com"'),
+      makeStep('a user with email "bob@test.org"'),
+    ];
+
+    const result = matchStepsToDefinitions(steps, expressionLinks);
+    expect(result.matchedSteps).toHaveLength(2);
+    expect(result.unmatchedSteps).toHaveLength(0);
+  });
+
+  it("reports unmatched steps when no definition exists", async () => {
+    const fixtureDir = resolve(__dirname, "fixtures/clean");
+    const stepDefFile = resolve(fixtureDir, "auth.steps.ts");
+    const { expressionLinks } = await extractStepDefs([stepDefFile], "*-shared.steps.ts");
+
+    const steps = [
+      makeStep("the user enters their password"),
+      makeStep("this step has no definition"),
+    ];
+
+    const result = matchStepsToDefinitions(steps, expressionLinks);
+    expect(result.matchedSteps).toHaveLength(1);
+    expect(result.unmatchedSteps).toHaveLength(1);
+    expect(result.unmatchedSteps[0].text).toBe("this step has no definition");
+  });
+});

--- a/tools/bdd-lint/tests/report.test.ts
+++ b/tools/bdd-lint/tests/report.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { formatReport } from "../src/report.ts";
+import type { LintResult } from "../src/types.ts";
+
+const emptyResult: LintResult = {
+  deadSpecs: [],
+  orphanDefs: [],
+  stats: {
+    featureFiles: 2,
+    stepDefFiles: 3,
+    totalScenarios: 5,
+    totalStepDefs: 10,
+    totalSteps: 20,
+    matchedSteps: 20,
+    unmatchedSteps: 0,
+  },
+};
+
+const resultWithIssues: LintResult = {
+  deadSpecs: [
+    {
+      featureFile: "auth.feature",
+      scenario: "User logs in",
+      scenarioLine: 3,
+      unmatchedSteps: [
+        { keyword: "When", text: "the user enters their password", line: 5 },
+      ],
+    },
+  ],
+  orphanDefs: [
+    {
+      file: "billing.steps.ts",
+      pattern: "the refund is processed",
+      line: 24,
+    },
+  ],
+  stats: {
+    featureFiles: 2,
+    stepDefFiles: 3,
+    totalScenarios: 5,
+    totalStepDefs: 10,
+    totalSteps: 20,
+    matchedSteps: 19,
+    unmatchedSteps: 1,
+  },
+};
+
+describe("formatReport", () => {
+  it("text format shows clean report", () => {
+    const output = formatReport(emptyResult, "text");
+    expect(output).toContain("BDD Staleness Lint Report");
+    expect(output).toContain("Dead Specs: none");
+    expect(output).toContain("Orphan Step Definitions: none");
+    expect(output).toContain("Feature files:     2");
+  });
+
+  it("text format shows dead specs and orphans", () => {
+    const output = formatReport(resultWithIssues, "text");
+    expect(output).toContain("Dead Specs (1)");
+    expect(output).toContain("auth.feature:3");
+    expect(output).toContain("User logs in");
+    expect(output).toContain("Orphan Step Definitions (1)");
+    expect(output).toContain("billing.steps.ts:24");
+  });
+
+  it("json format returns valid JSON", () => {
+    const output = formatReport(resultWithIssues, "json");
+    const parsed = JSON.parse(output);
+    expect(parsed.deadSpecs).toHaveLength(1);
+    expect(parsed.orphanDefs).toHaveLength(1);
+  });
+
+  it("ci format uses GitHub annotations", () => {
+    const output = formatReport(resultWithIssues, "ci");
+    expect(output).toContain("::warning file=auth.feature,line=5::");
+    expect(output).toContain("::warning file=billing.steps.ts,line=24::");
+  });
+
+  it("ci format shows clean message when no issues", () => {
+    const output = formatReport(emptyResult, "ci");
+    expect(output).toBe("BDD lint: all clean");
+  });
+});

--- a/tools/bdd-lint/tests/report.test.ts
+++ b/tools/bdd-lint/tests/report.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { formatReport } from "../src/report.ts";
+import { formatReport, formatWarnings } from "../src/report.ts";
 import type { LintResult } from "../src/types.ts";
 
 const emptyResult: LintResult = {
   deadSpecs: [],
   orphanDefs: [],
+  warnings: [],
   stats: {
     featureFiles: 2,
     stepDefFiles: 3,
@@ -12,6 +13,21 @@ const emptyResult: LintResult = {
     totalStepDefs: 10,
     totalSteps: 20,
     matchedSteps: 20,
+    unmatchedSteps: 0,
+  },
+};
+
+const resultWithWarnings: LintResult = {
+  deadSpecs: [],
+  orphanDefs: [],
+  warnings: ["Failed to parse feature file: bad.feature: unexpected token"],
+  stats: {
+    featureFiles: 1,
+    stepDefFiles: 1,
+    totalScenarios: 0,
+    totalStepDefs: 0,
+    totalSteps: 0,
+    matchedSteps: 0,
     unmatchedSteps: 0,
   },
 };
@@ -34,6 +50,7 @@ const resultWithIssues: LintResult = {
       line: 24,
     },
   ],
+  warnings: [],
   stats: {
     featureFiles: 2,
     stepDefFiles: 3,
@@ -79,5 +96,35 @@ describe("formatReport", () => {
   it("ci format shows clean message when no issues", () => {
     const output = formatReport(emptyResult, "ci");
     expect(output).toBe("BDD lint: all clean");
+  });
+
+  it("json format includes warnings array", () => {
+    const output = formatReport(resultWithWarnings, "json");
+    const parsed = JSON.parse(output);
+    expect(parsed.warnings).toHaveLength(1);
+    expect(parsed.warnings[0]).toContain("Failed to parse feature file");
+  });
+});
+
+describe("formatWarnings", () => {
+  it("returns empty string when no warnings", () => {
+    expect(formatWarnings([], "text")).toBe("");
+    expect(formatWarnings([], "ci")).toBe("");
+    expect(formatWarnings([], "json")).toBe("");
+  });
+
+  it("text format prefixes with [warn]", () => {
+    const output = formatWarnings(["some warning"], "text");
+    expect(output).toBe("[warn] some warning");
+  });
+
+  it("ci format uses ::warning:: annotation", () => {
+    const output = formatWarnings(["some warning"], "ci");
+    expect(output).toBe("::warning::some warning");
+  });
+
+  it("json format returns empty (warnings are in JSON output)", () => {
+    const output = formatWarnings(["some warning"], "json");
+    expect(output).toBe("");
   });
 });

--- a/tools/bdd-lint/tsconfig.json
+++ b/tools/bdd-lint/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/tools/bdd-lint/vitest.config.ts
+++ b/tools/bdd-lint/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/index.ts"],
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});

--- a/tools/bdd-lint/vitest.config.ts
+++ b/tools/bdd-lint/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/index.ts"],
       thresholds: {
-        lines: 80,
+        lines: 90,
       },
     },
   },


### PR DESCRIPTION
## Summary
- New `tools/bdd-lint/` Moon project: static analysis detecting dead specs (scenarios without step defs) and orphan step definitions
- Uses `@cucumber/language-service` tree-sitter for pattern extraction from playwright-bdd step files
- Pipeline: discover → parse → extract → match → detect → report
- Advisory mode (always exit 0), supports `--format text|json|ci` (CI = GitHub Actions `::warning` annotations)
- Handles `@wip` tag filtering, shared step conventions (`*-shared.steps.ts`), parameterized cucumber expressions
- Moon task `bdd-lint:check-staleness` wired into workspace

## Test plan
- [ ] `moon run bdd-lint:check-staleness` exits 0 and produces `::warning` annotations
- [ ] `cd tools/bdd-lint && pnpm vitest run` — 21 tests pass, 99% line coverage
- [ ] `--format text` produces human-readable report
- [ ] `--format json` produces machine-readable JSON
- [ ] `--format ci` produces GitHub Actions annotation format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new BDD linting tool that validates behavior-driven development features against their step definitions, detecting dead specs (unmatched steps) and orphan definitions (unused steps). Supports text, JSON, and CI output formats.

* **Bug Fixes**
  * Improved database soft-delete to use database-side timestamp generation.

* **Chores**
  * Extended workspace configuration to support new tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->