### PR TITLE
ci(db): entity-schema drift detection (#68)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -218,6 +218,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Verify ts-rs bindings in sync
         run: moon run api:bindings-check
+      - name: Verify entity-schema alignment
+        run: moon run api:entity-check
 
   verdict:
     if: always()

--- a/crates/db/tests/entity_drift.rs
+++ b/crates/db/tests/entity_drift.rs
@@ -1,0 +1,102 @@
+//! Entity-schema drift detection — verifies SeaORM entity files match the
+//! actual database schema produced by migrations.
+//!
+//! For each table that has a committed SeaORM entity, this test compares the
+//! entity's declared columns against the schema from PRAGMA table_info.
+//! Drift in either direction (schema column missing from entity, or entity
+//! column missing from schema) fails the test.
+//!
+//! See: issue #68, ADR `adr-seaorm-testing-standards.md` Decision 2
+
+use mokumo_db::initialize_database;
+use sea_orm::{Iterable, entity::prelude::*};
+use sqlx::Row;
+use std::collections::BTreeSet;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn migrated_pool() -> (sqlx::SqlitePool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("drift-check.db");
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+    let db = initialize_database(&url).await.unwrap();
+    let pool = db.get_sqlite_connection_pool().clone();
+    (pool, dir)
+}
+
+/// Get column names from the actual database schema via PRAGMA.
+async fn schema_columns(pool: &sqlx::SqlitePool, table: &str) -> BTreeSet<String> {
+    let sql = format!("PRAGMA table_info('{}')", table);
+    sqlx::query(&sql)
+        .fetch_all(pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|row| row.get::<String, _>("name"))
+        .collect()
+}
+
+/// Get column names declared by a SeaORM entity.
+fn entity_columns<E: EntityTrait>() -> BTreeSet<String>
+where
+    E::Column: Iterable,
+{
+    E::Column::iter()
+        .map(|col| col.as_str().to_owned())
+        .collect()
+}
+
+/// Assert that entity columns and schema columns match exactly.
+///
+/// Reports clearly which columns are in the schema but missing from the entity,
+/// and which are in the entity but missing from the schema.
+fn assert_columns_match(table: &str, schema: &BTreeSet<String>, entity: &BTreeSet<String>) {
+    let in_schema_not_entity: BTreeSet<_> = schema.difference(entity).collect();
+    let in_entity_not_schema: BTreeSet<_> = entity.difference(schema).collect();
+
+    if !in_schema_not_entity.is_empty() || !in_entity_not_schema.is_empty() {
+        let mut msg = format!("Entity-schema drift detected for table '{}':\n", table);
+        if !in_schema_not_entity.is_empty() {
+            msg.push_str(&format!(
+                "  Columns in schema but NOT in entity: {:?}\n",
+                in_schema_not_entity
+            ));
+            msg.push_str("  → Add these columns to the entity, or update the migration.\n");
+        }
+        if !in_entity_not_schema.is_empty() {
+            msg.push_str(&format!(
+                "  Columns in entity but NOT in schema: {:?}\n",
+                in_entity_not_schema
+            ));
+            msg.push_str("  → Remove these columns from the entity, or add a migration.\n");
+        }
+        panic!("{}", msg);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Drift checks — one test per entity
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn customer_entity_columns_match_schema() {
+    let (pool, _dir) = migrated_pool().await;
+
+    let schema = schema_columns(&pool, "customers").await;
+    let entity = entity_columns::<mokumo_db::customer::entity::Entity>();
+
+    assert_columns_match("customers", &schema, &entity);
+}
+
+// Future entity verticals: add one test function per entity following the
+// same pattern. Example:
+//
+// #[tokio::test]
+// async fn garment_entity_columns_match_schema() {
+//     let (pool, _dir) = migrated_pool().await;
+//     let schema = schema_columns(&pool, "garments").await;
+//     let entity = entity_columns::<mokumo_db::garment::entity::Entity>();
+//     assert_columns_match("garments", &schema, &entity);
+// }

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -9,7 +9,7 @@ fileGroups:
   - /Cargo.toml
   - /Cargo.lock
   migrations:
-  - /crates/db/migrations/**/*
+  - /crates/db/src/migration/**/*
   allRust:
   - /crates/*/src/**/*
   - /crates/*/Cargo.toml
@@ -124,6 +124,7 @@ tasks:
     command: cargo test --package mokumo-db --test entity_drift
     inputs:
     - '@group(allRust)'
+    - '@group(migrations)'
     - /crates/*/tests/**/*
     options:
       runFromWorkspaceRoot: true

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -120,6 +120,12 @@ tasks:
     options:
       cache: false
       runFromWorkspaceRoot: true
+  entity-check:
+    command: cargo test --package mokumo-db --test entity_drift
+    inputs:
+    - '@group(allRust)'
+    options:
+      runFromWorkspaceRoot: true
   bindings-check:
     deps:
     - web:build

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -124,6 +124,7 @@ tasks:
     command: cargo test --package mokumo-db --test entity_drift
     inputs:
     - '@group(allRust)'
+    - /crates/*/tests/**/*
     options:
       runFromWorkspaceRoot: true
   bindings-check:


### PR DESCRIPTION
## Summary

- Adds integration test (`crates/db/tests/entity_drift.rs`) that compares SeaORM entity column declarations against actual database schema via PRAGMA table_info
- Adds `entity-check` Moon task and wires it into the `seam-check` CI job
- Uses structural comparison (column name sets) instead of `sea-orm-cli generate → diff` to avoid false positives from type choices (Uuid vs String) and directory structure differences

## What it catches

| Failure Mode | Detection |
|---|---|
| Migration adds column, entity not updated | Schema has column not in entity |
| Entity has column without migration | Entity has column not in schema |
| Column renamed in migration only | Both missing + extra detected |

## Test plan

- [x] `moon run api:entity-check` passes on current codebase
- [x] All existing `mokumo-db` tests pass (24 tests)
- [x] Pre-commit (rust-fmt) and pre-push (clippy) hooks pass
- [ ] CI quality pipeline passes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated drift-detection tests to verify database entity definitions match the migrated schema.

* **Chores**
  * Added a CI quality-gate step to run the entity validation test suite as part of pipeline verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->