### PR TITLE
feat(customers): customer management UI (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Customer management UI: list page with search/filter/pagination, detail page with tab navigation (overview, activity, contacts, artwork, pricing, communication), create/edit form sheet, and archive flow
+- Server-side customer search across display name, company name, and email
+- Per-vertical frontend module pattern: API wrapper, Zod schemas, context class, tab navigation
 - WebSocket broadcast infrastructure for real-time server-to-client updates
 - `BroadcastEvent` wire format with version field for forward compatibility
 - `ConnectionManager` with pre-serialized fan-out (`Arc<str>`) for efficient broadcasting

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,8 +55,10 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "mode-watcher": "^1.1.0",
+    "runed": "0.37.1",
     "svelte-sonner": "^1.1.0",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.1.0"
   },
   "packageManager": "pnpm@10.6.5"
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 import { defineBddConfig } from 'playwright-bdd';
 
 const testDir = defineBddConfig({
-	features: 'tests/features/*.feature',
+	features: 'tests/features/**/*.feature',
 	steps: ['tests/steps/*.ts', 'tests/support/*.ts'],
 	tags: 'not @wip'
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,14 @@
 import type { ErrorBody } from "./types/ErrorBody";
 
+/** Builds a URL query string, filtering out undefined, empty, and false values. */
+export function buildQuery(params: Record<string, string | number | boolean | undefined>): string {
+  const entries = Object.entries(params).filter(
+    ([, v]) => v !== undefined && v !== "" && v !== false,
+  );
+  if (entries.length === 0) return "";
+  return "?" + new URLSearchParams(entries.map(([k, v]) => [k, String(v)])).toString();
+}
+
 export type ApiResult<T> =
   | { ok: true; status: 204 }
   | { ok: true; status: number; data: T }

--- a/apps/web/src/lib/api/customers.ts
+++ b/apps/web/src/lib/api/customers.ts
@@ -1,0 +1,84 @@
+import { apiFetch, buildQuery, type ApiResult } from "$lib/api";
+import type { ActivityEntryResponse } from "$lib/types/ActivityEntryResponse";
+import type { CustomerResponse } from "$lib/types/CustomerResponse";
+import type { PaginatedList } from "$lib/types/PaginatedList";
+
+interface ListCustomersParams {
+  page?: number;
+  per_page?: number;
+  search?: string;
+  include_deleted?: boolean;
+}
+
+interface PaginationParams {
+  page?: number;
+  per_page?: number;
+}
+
+export function listCustomers(
+  params: ListCustomersParams = {},
+): Promise<ApiResult<PaginatedList<CustomerResponse>>> {
+  const query = buildQuery({
+    page: params.page,
+    per_page: params.per_page,
+    search: params.search,
+    include_deleted: params.include_deleted,
+  });
+  return apiFetch<PaginatedList<CustomerResponse>>(`/api/customers${query}`);
+}
+
+export function getCustomer(
+  id: string,
+  includeDeleted = false,
+): Promise<ApiResult<CustomerResponse>> {
+  const query = includeDeleted ? "?include_deleted=true" : "";
+  return apiFetch<CustomerResponse>(`/api/customers/${id}${query}`);
+}
+
+export function createCustomer(
+  data: Record<string, unknown>,
+): Promise<ApiResult<CustomerResponse>> {
+  return apiFetch<CustomerResponse>("/api/customers", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateCustomer(
+  id: string,
+  data: Record<string, unknown>,
+): Promise<ApiResult<CustomerResponse>> {
+  return apiFetch<CustomerResponse>(`/api/customers/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteCustomer(id: string): Promise<ApiResult<CustomerResponse>> {
+  return apiFetch<CustomerResponse>(`/api/customers/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export function getEntityActivity(
+  entityType: string,
+  entityId: string,
+  params: PaginationParams = {},
+): Promise<ApiResult<PaginatedList<ActivityEntryResponse>>> {
+  const query = buildQuery({
+    entity_type: entityType,
+    entity_id: entityId,
+    page: params.page,
+    per_page: params.per_page,
+  });
+  return apiFetch<PaginatedList<ActivityEntryResponse>>(`/api/activity${query}`);
+}
+
+export function getCustomerActivity(
+  id: string,
+  params: PaginationParams = {},
+): Promise<ApiResult<PaginatedList<ActivityEntryResponse>>> {
+  return getEntityActivity("customer", id, params);
+}

--- a/apps/web/src/lib/components/app-sidebar.svelte
+++ b/apps/web/src/lib/components/app-sidebar.svelte
@@ -8,20 +8,77 @@
   import * as Popover from "$lib/components/ui/popover";
   import * as Sidebar from "$lib/components/ui/sidebar";
   import { useSidebar } from "$lib/components/ui/sidebar";
-  import { setMode, userPrefersMode } from "mode-watcher";
+  import { mode, setMode } from "mode-watcher";
   import LogOut from "@lucide/svelte/icons/log-out";
-  import Monitor from "@lucide/svelte/icons/monitor";
   import Moon from "@lucide/svelte/icons/moon";
   import Sun from "@lucide/svelte/icons/sun";
   import UserRound from "@lucide/svelte/icons/user-round";
 
   const visibleItems = navItems.filter((item) => !item.hidden);
 
-  const themeOptions = [
-    { label: "Light", value: "light", icon: Sun },
-    { label: "Dark", value: "dark", icon: Moon },
-    { label: "System", value: "system", icon: Monitor },
+  const themes = [
+    { value: "niji", label: "Niji", swatch: "oklch(0.56 0.158 249.8)" },
+    {
+      value: "tangerine",
+      label: "Tangerine",
+      swatch: "oklch(0.6397 0.172 36.4421)",
+    },
+    {
+      value: "midnight-bloom",
+      label: "Midnight",
+      swatch: "oklch(0.5676 0.2021 283.0838)",
+    },
+    {
+      value: "solar-dusk",
+      label: "Solar",
+      swatch: "oklch(0.5553 0.1455 48.9975)",
+    },
+    {
+      value: "soft-pop",
+      label: "Soft Pop",
+      swatch: "oklch(0.5106 0.2301 276.9656)",
+    },
+    {
+      value: "sunset-horizon",
+      label: "Sunset",
+      swatch: "oklch(0.7357 0.1641 34.7091)",
+    },
   ] as const;
+
+  const THEME_CLASSES = [
+    "theme-tangerine",
+    "theme-midnight-bloom",
+    "theme-solar-dusk",
+    "theme-soft-pop",
+    "theme-sunset-horizon",
+  ];
+
+  let activeTheme = $state(
+    (typeof localStorage !== "undefined" &&
+      localStorage.getItem("mokumo-theme")) ||
+      "niji",
+  );
+
+  function applyTheme(value: string) {
+    activeTheme = value;
+    const root = document.documentElement;
+    for (const cls of THEME_CLASSES) {
+      root.classList.remove(cls);
+    }
+    if (value !== "niji") {
+      root.classList.add(`theme-${value}`);
+    }
+    localStorage.setItem("mokumo-theme", value);
+  }
+
+  // Apply saved theme on mount
+  $effect(() => {
+    applyTheme(activeTheme);
+  });
+
+  function toggleMode() {
+    setMode(mode.current === "dark" ? "light" : "dark");
+  }
 
   function handleLogout() {
     goto("/");
@@ -79,22 +136,58 @@
             >
           </Popover.Trigger>
           <Popover.Content side="top" align="start" class="w-56 p-2">
-            <div class="space-y-1">
+            <div class="space-y-2">
+              <p class="px-2 py-1 text-xs font-medium text-muted-foreground">
+                Mode
+              </p>
+              <button
+                onclick={toggleMode}
+                class="mx-2 flex h-8 w-full max-w-[calc(100%-1rem)] items-center rounded-full bg-muted p-0.5"
+                aria-label="Toggle light/dark mode"
+              >
+                <span
+                  class="flex h-7 w-1/2 items-center justify-center rounded-full transition-colors {mode.current !==
+                  'dark'
+                    ? 'bg-background shadow-sm'
+                    : ''}"
+                >
+                  <Sun class="size-4" />
+                </span>
+                <span
+                  class="flex h-7 w-1/2 items-center justify-center rounded-full transition-colors {mode.current ===
+                  'dark'
+                    ? 'bg-background shadow-sm'
+                    : ''}"
+                >
+                  <Moon class="size-4" />
+                </span>
+              </button>
+            </div>
+            <div class="mt-2 space-y-2">
               <p class="px-2 py-1 text-xs font-medium text-muted-foreground">
                 Theme
               </p>
-              {#each themeOptions as option (option.value)}
-                <button
-                  onclick={() => setMode(option.value)}
-                  class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent {userPrefersMode.current ===
-                  option.value
-                    ? 'bg-accent font-medium'
-                    : ''}"
-                >
-                  <option.icon class="size-4" />
-                  {option.label}
-                </button>
-              {/each}
+              <div class="grid grid-cols-3 gap-1.5 px-2">
+                {#each themes as theme (theme.value)}
+                  <button
+                    onclick={() => applyTheme(theme.value)}
+                    class="flex flex-col items-center gap-1 rounded-md p-1.5 text-xs transition-colors {activeTheme ===
+                    theme.value
+                      ? 'bg-accent font-medium'
+                      : 'hover:bg-accent/50'}"
+                    title={theme.label}
+                  >
+                    <span
+                      class="size-6 rounded-full border-2 transition-transform {activeTheme ===
+                      theme.value
+                        ? 'border-primary scale-110'
+                        : 'border-transparent'}"
+                      style="background-color: {theme.swatch}"
+                    ></span>
+                    <span class="truncate max-w-full">{theme.label}</span>
+                  </button>
+                {/each}
+              </div>
             </div>
             <div class="my-1 h-px bg-border"></div>
             <button

--- a/apps/web/src/lib/components/customer-form-sheet.svelte
+++ b/apps/web/src/lib/components/customer-form-sheet.svelte
@@ -124,6 +124,12 @@
     try {
       if (isEdit && customer) {
         const payload = buildUpdatePayload(parsed.data, customer);
+        if (Object.keys(payload).length === 0) {
+          toast.info("No changes to save");
+          open = false;
+          onClose();
+          return;
+        }
         const result = await updateCustomer(customer.id, payload);
         if (result.ok) {
           toast.success(`"${parsed.data.display_name}" updated`);
@@ -134,7 +140,12 @@
           applyApiErrors(result.error);
         }
       } else {
-        const result = await createCustomer(parsed.data);
+        // Strip empty strings to undefined so backend applies defaults
+        const createData: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(parsed.data)) {
+          createData[key] = value === "" ? undefined : value;
+        }
+        const result = await createCustomer(createData);
         if (result.ok) {
           toast.success(`"${parsed.data.display_name}" created`);
           open = false;

--- a/apps/web/src/lib/components/customer-form-sheet.svelte
+++ b/apps/web/src/lib/components/customer-form-sheet.svelte
@@ -1,0 +1,331 @@
+<script lang="ts">
+  import { invalidate } from "$app/navigation";
+  import { createCustomer, updateCustomer } from "$lib/api/customers";
+  import { toast } from "$lib/components/toast";
+  import { Button } from "$lib/components/ui/button";
+  import { Checkbox } from "$lib/components/ui/checkbox";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+  } from "$lib/components/ui/select";
+  import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+  } from "$lib/components/ui/sheet";
+  import { Textarea } from "$lib/components/ui/textarea";
+  import {
+    customerFormSchema,
+    PAYMENT_TERMS_OPTIONS,
+    type CustomerFormData,
+  } from "$lib/schemas/customer";
+  import type { CustomerResponse } from "$lib/types/CustomerResponse";
+  import type { ErrorBody } from "$lib/types/ErrorBody";
+  import { buildUpdatePayload } from "$lib/utils/update-payload";
+  import Loader2 from "@lucide/svelte/icons/loader-circle";
+
+  interface Props {
+    open: boolean;
+    customer?: CustomerResponse;
+    onClose: () => void;
+  }
+
+  let { open = $bindable(), customer, onClose }: Props = $props();
+
+  let isEdit = $derived(!!customer);
+  let submitting = $state(false);
+  let fieldErrors = $state<Record<string, string[]>>({});
+
+  const emptyForm: CustomerFormData = {
+    display_name: "",
+    company_name: "",
+    email: "",
+    phone: "",
+    address_line1: "",
+    address_line2: "",
+    city: "",
+    state: "",
+    postal_code: "",
+    country: "",
+    notes: "",
+    payment_terms: "",
+    tax_exempt: false,
+    credit_limit_cents: undefined,
+  };
+
+  let formData = $state<CustomerFormData>({ ...emptyForm });
+
+  let selectedTermsLabel = $derived(
+    PAYMENT_TERMS_OPTIONS.find((o) => o.value === formData.payment_terms)
+      ?.label ?? "Select terms",
+  );
+
+  function customerToForm(c: CustomerResponse): CustomerFormData {
+    return {
+      display_name: c.display_name,
+      company_name: c.company_name ?? "",
+      email: c.email ?? "",
+      phone: c.phone ?? "",
+      address_line1: c.address_line1 ?? "",
+      address_line2: c.address_line2 ?? "",
+      city: c.city ?? "",
+      state: c.state ?? "",
+      postal_code: c.postal_code ?? "",
+      country: c.country ?? "",
+      notes: c.notes ?? "",
+      payment_terms: c.payment_terms ?? "",
+      tax_exempt: c.tax_exempt,
+      credit_limit_cents: c.credit_limit_cents ?? undefined,
+    };
+  }
+
+  $effect(() => {
+    if (!open) return;
+    formData = customer ? customerToForm(customer) : { ...emptyForm };
+    fieldErrors = {};
+  });
+
+  function applyApiErrors(error: ErrorBody) {
+    if (error.details) {
+      fieldErrors = Object.fromEntries(
+        Object.entries(error.details).filter(
+          (entry): entry is [string, string[]] =>
+            entry[1] !== null && entry[1] !== undefined,
+        ),
+      );
+    } else {
+      toast.error(error.message);
+    }
+  }
+
+  async function handleSubmit() {
+    const parsed = customerFormSchema.safeParse(formData);
+    if (!parsed.success) {
+      const errors: Record<string, string[]> = {};
+      for (const issue of parsed.error.issues) {
+        const key = String(issue.path[0]);
+        if (!errors[key]) errors[key] = [];
+        errors[key].push(issue.message);
+      }
+      fieldErrors = errors;
+      return;
+    }
+
+    submitting = true;
+    fieldErrors = {};
+
+    try {
+      if (isEdit && customer) {
+        const payload = buildUpdatePayload(parsed.data, customer);
+        const result = await updateCustomer(customer.id, payload);
+        if (result.ok) {
+          toast.success(`"${parsed.data.display_name}" updated`);
+          open = false;
+          onClose();
+          await invalidate((url) => url.pathname.startsWith("/api/customers"));
+        } else {
+          applyApiErrors(result.error);
+        }
+      } else {
+        const result = await createCustomer(parsed.data);
+        if (result.ok) {
+          toast.success(`"${parsed.data.display_name}" created`);
+          open = false;
+          onClose();
+          await invalidate((url) => url.pathname.startsWith("/api/customers"));
+        } else {
+          applyApiErrors(result.error);
+        }
+      }
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function errorFor(field: string): string | undefined {
+    return fieldErrors[field]?.[0];
+  }
+</script>
+
+<Sheet bind:open>
+  <SheetContent side="right" class="overflow-y-auto sm:max-w-lg">
+    <SheetHeader>
+      <SheetTitle>{isEdit ? "Edit Customer" : "Add Customer"}</SheetTitle>
+      <SheetDescription>
+        {isEdit
+          ? "Update the customer's information."
+          : "Enter the new customer's details."}
+      </SheetDescription>
+    </SheetHeader>
+
+    <form
+      class="space-y-4 py-4"
+      onsubmit={(e) => {
+        e.preventDefault();
+        handleSubmit();
+      }}
+    >
+      <div class="space-y-1">
+        <Label for="display_name">Display Name *</Label>
+        <Input
+          id="display_name"
+          bind:value={formData.display_name}
+          disabled={submitting}
+          class={errorFor("display_name") ? "border-destructive" : ""}
+        />
+        {#if errorFor("display_name")}
+          <p class="text-sm text-destructive">{errorFor("display_name")}</p>
+        {/if}
+      </div>
+
+      <div class="space-y-1">
+        <Label for="company_name">Company Name</Label>
+        <Input
+          id="company_name"
+          bind:value={formData.company_name}
+          disabled={submitting}
+        />
+      </div>
+
+      <div class="space-y-1">
+        <Label for="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          bind:value={formData.email}
+          disabled={submitting}
+          class={errorFor("email") ? "border-destructive" : ""}
+        />
+        {#if errorFor("email")}
+          <p class="text-sm text-destructive">{errorFor("email")}</p>
+        {/if}
+      </div>
+
+      <div class="space-y-1">
+        <Label for="phone">Phone</Label>
+        <Input
+          id="phone"
+          type="tel"
+          bind:value={formData.phone}
+          disabled={submitting}
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label>Address</Label>
+        <Input
+          placeholder="Street address"
+          bind:value={formData.address_line1}
+          disabled={submitting}
+        />
+        <Input
+          placeholder="Apt, suite, etc."
+          bind:value={formData.address_line2}
+          disabled={submitting}
+        />
+        <div class="grid grid-cols-2 gap-2">
+          <Input
+            placeholder="City"
+            bind:value={formData.city}
+            disabled={submitting}
+          />
+          <Input
+            placeholder="State"
+            bind:value={formData.state}
+            disabled={submitting}
+          />
+        </div>
+        <div class="grid grid-cols-2 gap-2">
+          <Input
+            placeholder="Postal code"
+            bind:value={formData.postal_code}
+            disabled={submitting}
+          />
+          <Input
+            placeholder="Country"
+            bind:value={formData.country}
+            disabled={submitting}
+          />
+        </div>
+      </div>
+
+      <div class="space-y-1">
+        <Label for="notes">Notes</Label>
+        <Textarea
+          id="notes"
+          bind:value={formData.notes}
+          disabled={submitting}
+        />
+      </div>
+
+      <div class="space-y-1">
+        <Label for="payment_terms">Payment Terms</Label>
+        <Select
+          type="single"
+          value={formData.payment_terms || undefined}
+          onValueChange={(v) => {
+            formData.payment_terms = v ?? "";
+          }}
+          disabled={submitting}
+        >
+          <SelectTrigger id="payment_terms">
+            <span data-slot="select-value">{selectedTermsLabel}</span>
+          </SelectTrigger>
+          <SelectContent>
+            {#each PAYMENT_TERMS_OPTIONS as opt (opt.value)}
+              <SelectItem value={opt.value}>{opt.label}</SelectItem>
+            {/each}
+          </SelectContent>
+        </Select>
+      </div>
+      <div class="flex items-center gap-2">
+        <Checkbox
+          id="tax_exempt"
+          checked={formData.tax_exempt}
+          onCheckedChange={(checked) => {
+            formData.tax_exempt = checked === true;
+          }}
+          disabled={submitting}
+        />
+        <Label for="tax_exempt">Tax Exempt</Label>
+      </div>
+
+      <div class="space-y-1">
+        <Label for="credit_limit">Credit Limit (cents)</Label>
+        <Input
+          id="credit_limit"
+          type="number"
+          min="0"
+          value={formData.credit_limit_cents ?? ""}
+          oninput={(e) => {
+            const val = e.currentTarget.value;
+            formData.credit_limit_cents = val === "" ? undefined : Number(val);
+          }}
+          disabled={submitting}
+          class={errorFor("credit_limit_cents") ? "border-destructive" : ""}
+        />
+        {#if errorFor("credit_limit_cents")}
+          <p class="text-sm text-destructive">
+            {errorFor("credit_limit_cents")}
+          </p>
+        {/if}
+      </div>
+
+      <SheetFooter>
+        <Button type="submit" disabled={submitting}>
+          {#if submitting}
+            <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+          {/if}
+          {isEdit ? "Save Changes" : "Create"}
+        </Button>
+      </SheetFooter>
+    </form>
+  </SheetContent>
+</Sheet>

--- a/apps/web/src/lib/components/tab-nav.svelte
+++ b/apps/web/src/lib/components/tab-nav.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { cn } from "$lib/utils";
+
+  interface Tab {
+    label: string;
+    href: string;
+    count?: number;
+  }
+
+  interface Props {
+    tabs: Tab[];
+    class?: string;
+  }
+
+  let { tabs, class: className }: Props = $props();
+
+  function isActive(href: string): boolean {
+    const path = page.url.pathname;
+    // Exact match for the base path (overview), prefix match for sub-tabs
+    if (href.endsWith("/")) {
+      return path === href.slice(0, -1) || path === href;
+    }
+    return path === href || path.startsWith(href + "/");
+  }
+</script>
+
+<nav
+  class={cn("flex overflow-x-auto border-b", className)}
+  aria-label="Tab navigation"
+>
+  {#each tabs as tab (tab.href)}
+    <a
+      href={tab.href}
+      class={cn(
+        "whitespace-nowrap border-b-2 px-4 py-2.5 text-sm font-medium transition-colors",
+        isActive(tab.href)
+          ? "border-primary text-primary"
+          : "border-transparent text-muted-foreground hover:border-muted-foreground/30 hover:text-foreground",
+      )}
+      aria-current={isActive(tab.href) ? "page" : undefined}
+    >
+      {tab.label}
+      {#if tab.count != null}
+        <span class="ml-1.5 rounded-full bg-muted px-2 py-0.5 text-xs">
+          {tab.count}
+        </span>
+      {/if}
+    </a>
+  {/each}
+</nav>

--- a/apps/web/src/lib/components/tab-nav.svelte
+++ b/apps/web/src/lib/components/tab-nav.svelte
@@ -17,11 +17,7 @@
 
   function isActive(href: string): boolean {
     const path = page.url.pathname;
-    // Exact match for the base path (overview), prefix match for sub-tabs
-    if (href.endsWith("/")) {
-      return path === href.slice(0, -1) || path === href;
-    }
-    return path === href || path.startsWith(href + "/");
+    return path === href || path === href + "/";
   }
 </script>
 

--- a/apps/web/src/lib/components/ui/alert-dialog/AlertDialog.stories.svelte
+++ b/apps/web/src/lib/components/ui/alert-dialog/AlertDialog.stories.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <Story name="Default">
-  <AlertDialog>
+  <AlertDialog open={true}>
     <AlertDialogTrigger>
       <Button variant="outline">Delete Item</Button>
     </AlertDialogTrigger>

--- a/apps/web/src/lib/components/ui/sidebar/Sidebar.stories.svelte
+++ b/apps/web/src/lib/components/ui/sidebar/Sidebar.stories.svelte
@@ -20,26 +20,28 @@
 </script>
 
 <Story name="Default">
-  <SidebarProvider>
-    <Sidebar>
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton>Dashboard</SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton>Orders</SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton>Customers</SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-    </Sidebar>
-  </SidebarProvider>
+  <div style="height: 400px; display: flex;">
+    <SidebarProvider open={true}>
+      <Sidebar>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Dashboard</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Orders</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Customers</SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+      </Sidebar>
+    </SidebarProvider>
+  </div>
 </Story>

--- a/apps/web/src/lib/config/breadcrumb-overrides.svelte.ts
+++ b/apps/web/src/lib/config/breadcrumb-overrides.svelte.ts
@@ -1,0 +1,18 @@
+/**
+ * Module-level state for breadcrumb label overrides.
+ * Child layouts can set a human-readable label for dynamic URL segments
+ * (e.g., replacing a UUID with a customer name).
+ */
+const overrides = $state<Record<string, string>>({});
+
+export function setBreadcrumbLabel(segment: string, label: string): void {
+  overrides[segment] = label;
+}
+
+export function clearBreadcrumbLabel(segment: string): void {
+  delete overrides[segment];
+}
+
+export function getBreadcrumbLabel(segment: string): string | undefined {
+  return overrides[segment];
+}

--- a/apps/web/src/lib/config/nav-utils.ts
+++ b/apps/web/src/lib/config/nav-utils.ts
@@ -1,3 +1,4 @@
+import { getBreadcrumbLabel } from "./breadcrumb-overrides.svelte";
 import { navItems } from "./nav-items";
 
 export function isActive(url: string, pathname: string): boolean {
@@ -10,7 +11,11 @@ const titleBySlug = new Map(
 );
 
 export function labelForSlug(slug: string): string {
-  return titleBySlug.get(slug) ?? slug.charAt(0).toUpperCase() + slug.slice(1);
+  return (
+    getBreadcrumbLabel(slug) ??
+    titleBySlug.get(slug) ??
+    slug.charAt(0).toUpperCase() + slug.slice(1)
+  );
 }
 
 export interface BreadcrumbSegment {

--- a/apps/web/src/lib/contexts/customer-context.svelte.ts
+++ b/apps/web/src/lib/contexts/customer-context.svelte.ts
@@ -1,0 +1,22 @@
+import { getContext, setContext } from "svelte";
+import type { CustomerResponse } from "$lib/types/CustomerResponse";
+
+const CUSTOMER_KEY = Symbol("customer");
+
+export class CustomerContext {
+  customer = $state<CustomerResponse | null>(null);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  get isArchived(): boolean {
+    return this.customer?.deleted_at !== null && this.customer?.deleted_at !== undefined;
+  }
+}
+
+export function setCustomerContext(ctx: CustomerContext): void {
+  setContext(CUSTOMER_KEY, ctx);
+}
+
+export function getCustomerContext(): CustomerContext {
+  return getContext<CustomerContext>(CUSTOMER_KEY);
+}

--- a/apps/web/src/lib/hooks/use-url-params.svelte.ts
+++ b/apps/web/src/lib/hooks/use-url-params.svelte.ts
@@ -1,0 +1,6 @@
+/**
+ * Isolation wrapper around Runed's useSearchParams.
+ * If Runed breaks or the API changes, swap the internals of this file.
+ * Every vertical imports from here, never from runed/kit directly.
+ */
+export { useSearchParams } from "runed/kit";

--- a/apps/web/src/lib/mocks/customer-artwork.ts
+++ b/apps/web/src/lib/mocks/customer-artwork.ts
@@ -1,0 +1,38 @@
+export interface MockArtwork {
+  id: string;
+  name: string;
+  type: string;
+  uploadedAt: string;
+  dimensions: string;
+}
+
+export const mockArtwork: MockArtwork[] = [
+  {
+    id: "a1",
+    name: "Company Logo - Full Color",
+    type: "Vector (AI)",
+    uploadedAt: "2026-02-15",
+    dimensions: '4" x 3"',
+  },
+  {
+    id: "a2",
+    name: "Event T-Shirt Design 2026",
+    type: "Raster (PSD)",
+    uploadedAt: "2026-03-01",
+    dimensions: '12" x 14"',
+  },
+  {
+    id: "a3",
+    name: "Left Chest Logo",
+    type: "Vector (SVG)",
+    uploadedAt: "2026-01-20",
+    dimensions: '3.5" x 3.5"',
+  },
+  {
+    id: "a4",
+    name: "Back Print - Team Roster",
+    type: "Raster (PNG)",
+    uploadedAt: "2026-03-10",
+    dimensions: '10" x 14"',
+  },
+];

--- a/apps/web/src/lib/mocks/customer-communication.ts
+++ b/apps/web/src/lib/mocks/customer-communication.ts
@@ -1,0 +1,43 @@
+export interface MockMessage {
+  id: string;
+  direction: "inbound" | "outbound";
+  channel: string;
+  subject: string;
+  preview: string;
+  timestamp: string;
+}
+
+export const mockMessages: MockMessage[] = [
+  {
+    id: "m1",
+    direction: "outbound",
+    channel: "Email",
+    subject: "Quote #1042 - Spring Collection",
+    preview: "Hi Sarah, please find attached the quote for your spring collection order...",
+    timestamp: "2026-03-25T14:30:00Z",
+  },
+  {
+    id: "m2",
+    direction: "inbound",
+    channel: "Email",
+    subject: "Re: Quote #1042 - Spring Collection",
+    preview: "Looks good! Can we adjust the qty on the polo shirts to 150?",
+    timestamp: "2026-03-25T16:45:00Z",
+  },
+  {
+    id: "m3",
+    direction: "outbound",
+    channel: "Email",
+    subject: "Invoice #2089",
+    preview: "Please find attached your invoice for the completed order...",
+    timestamp: "2026-03-20T09:00:00Z",
+  },
+  {
+    id: "m4",
+    direction: "inbound",
+    channel: "Portal",
+    subject: "Artwork uploaded",
+    preview: "Customer uploaded new artwork file: event-tshirt-2026-v2.ai",
+    timestamp: "2026-03-18T11:20:00Z",
+  },
+];

--- a/apps/web/src/lib/mocks/customer-contacts.ts
+++ b/apps/web/src/lib/mocks/customer-contacts.ts
@@ -1,0 +1,35 @@
+export interface MockContact {
+  id: string;
+  name: string;
+  role: string;
+  email: string;
+  phone: string;
+  isPrimary: boolean;
+}
+
+export const mockContacts: MockContact[] = [
+  {
+    id: "c1",
+    name: "Sarah Johnson",
+    role: "Owner",
+    email: "sarah@acmeprinting.com",
+    phone: "(555) 123-4567",
+    isPrimary: true,
+  },
+  {
+    id: "c2",
+    name: "Mike Rodriguez",
+    role: "Production Manager",
+    email: "mike@acmeprinting.com",
+    phone: "(555) 234-5678",
+    isPrimary: false,
+  },
+  {
+    id: "c3",
+    name: "Emily Chen",
+    role: "Accounts Payable",
+    email: "ap@acmeprinting.com",
+    phone: "(555) 345-6789",
+    isPrimary: false,
+  },
+];

--- a/apps/web/src/lib/mocks/customer-pricing.ts
+++ b/apps/web/src/lib/mocks/customer-pricing.ts
@@ -1,0 +1,31 @@
+export interface MockPricingTemplate {
+  id: string;
+  name: string;
+  method: string;
+  basePrice: string;
+  discount: string;
+}
+
+export const mockPricingTemplates: MockPricingTemplate[] = [
+  {
+    id: "p1",
+    name: "Standard Screen Print",
+    method: "Screen Print",
+    basePrice: "$8.50/unit",
+    discount: "10% volume (100+)",
+  },
+  {
+    id: "p2",
+    name: "DTG Premium",
+    method: "Direct to Garment",
+    basePrice: "$15.00/unit",
+    discount: "None",
+  },
+  {
+    id: "p3",
+    name: "Embroidery - Left Chest",
+    method: "Embroidery",
+    basePrice: "$6.00/unit",
+    discount: "15% repeat order",
+  },
+];

--- a/apps/web/src/lib/schemas/customer.ts
+++ b/apps/web/src/lib/schemas/customer.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const PAYMENT_TERMS_OPTIONS = [
+  { value: "due_on_receipt", label: "Due on Receipt" },
+  { value: "net_15", label: "Net 15" },
+  { value: "net_30", label: "Net 30" },
+  { value: "net_60", label: "Net 60" },
+] as const;
+
+export const customerFormSchema = z.object({
+  display_name: z.string().min(1, "Display name is required"),
+  company_name: z.string().optional(),
+  email: z.string().email("Invalid email address").optional().or(z.literal("")),
+  phone: z.string().optional(),
+  address_line1: z.string().optional(),
+  address_line2: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  postal_code: z.string().optional(),
+  country: z.string().optional(),
+  notes: z.string().optional(),
+  payment_terms: z.string().optional(),
+  tax_exempt: z.boolean().optional(),
+  credit_limit_cents: z.coerce.number().int().min(0, "Must be 0 or greater").optional(),
+});
+
+export type CustomerFormData = z.infer<typeof customerFormSchema>;
+
+/**
+ * Schema for customer list URL parameters.
+ * Used with useSearchParams (component-side) for two-way URL binding.
+ * All fields have defaults so useSearchParams can initialize from empty URL.
+ */
+export const customerListParamsSchema = z.object({
+  search: z.string().default(""),
+  page: z.coerce.number().int().min(1).default(1),
+  per_page: z.coerce.number().int().min(1).max(100).default(25),
+  include_deleted: z.boolean().default(false),
+});
+
+export type CustomerListParams = z.infer<typeof customerListParamsSchema>;

--- a/apps/web/src/lib/schemas/customer.ts
+++ b/apps/web/src/lib/schemas/customer.ts
@@ -8,7 +8,7 @@ export const PAYMENT_TERMS_OPTIONS = [
 ] as const;
 
 export const customerFormSchema = z.object({
-  display_name: z.string().min(1, "Display name is required"),
+  display_name: z.string().trim().min(1, "Display name is required"),
   company_name: z.string().optional(),
   email: z.string().email("Invalid email address").optional().or(z.literal("")),
   phone: z.string().optional(),

--- a/apps/web/src/lib/utils/format.ts
+++ b/apps/web/src/lib/utils/format.ts
@@ -1,0 +1,7 @@
+export function formatCurrency(cents: number | null): string {
+  if (cents === null || cents === undefined) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100);
+}

--- a/apps/web/src/lib/utils/update-payload.test.ts
+++ b/apps/web/src/lib/utils/update-payload.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { buildUpdatePayload } from "./update-payload";
+import type { CustomerFormData } from "$lib/schemas/customer";
+import type { CustomerResponse } from "$lib/types/CustomerResponse";
+
+function makeCustomer(overrides: Partial<CustomerResponse> = {}): CustomerResponse {
+  return {
+    id: "test-id",
+    display_name: "Acme Corp",
+    company_name: "Acme LLC",
+    email: "info@acme.com",
+    phone: "(555) 123-4567",
+    address_line1: "123 Main St",
+    address_line2: null,
+    city: "Springfield",
+    state: "IL",
+    postal_code: "62701",
+    country: "US",
+    notes: "Good customer",
+    portal_enabled: false,
+    portal_user_id: null,
+    tax_exempt: false,
+    tax_exemption_certificate_path: null,
+    tax_exemption_expires_at: null,
+    payment_terms: "net_30",
+    credit_limit_cents: 50000,
+    stripe_customer_id: null,
+    quickbooks_customer_id: null,
+    lead_source: null,
+    tags: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function makeFormData(overrides: Partial<CustomerFormData> = {}): CustomerFormData {
+  return {
+    display_name: "Acme Corp",
+    company_name: "Acme LLC",
+    email: "info@acme.com",
+    phone: "(555) 123-4567",
+    address_line1: "123 Main St",
+    address_line2: "",
+    city: "Springfield",
+    state: "IL",
+    postal_code: "62701",
+    country: "US",
+    notes: "Good customer",
+    payment_terms: "net_30",
+    tax_exempt: false,
+    credit_limit_cents: 50000,
+    ...overrides,
+  };
+}
+
+describe("buildUpdatePayload", () => {
+  it("returns empty object when nothing changed", () => {
+    const payload = buildUpdatePayload(makeFormData(), makeCustomer());
+    expect(payload).toEqual({});
+  });
+
+  it("includes display_name when changed (non-nullable)", () => {
+    const payload = buildUpdatePayload(makeFormData({ display_name: "New Name" }), makeCustomer());
+    expect(payload).toEqual({ display_name: "New Name" });
+  });
+
+  it("sends new value when clearable string field is changed", () => {
+    const payload = buildUpdatePayload(makeFormData({ email: "new@acme.com" }), makeCustomer());
+    expect(payload).toEqual({ email: "new@acme.com" });
+  });
+
+  it("sends null when clearable string field is cleared", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ email: "" }),
+      makeCustomer({ email: "info@acme.com" }),
+    );
+    expect(payload).toEqual({ email: null });
+  });
+
+  it("omits clearable string field when unchanged", () => {
+    const payload = buildUpdatePayload(makeFormData(), makeCustomer());
+    expect(payload).not.toHaveProperty("email");
+    expect(payload).not.toHaveProperty("company_name");
+  });
+
+  it("handles field going from null to value", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ address_line2: "Suite 200" }),
+      makeCustomer({ address_line2: null }),
+    );
+    expect(payload).toEqual({ address_line2: "Suite 200" });
+  });
+
+  it("treats both null original and empty form as no change", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ address_line2: "" }),
+      makeCustomer({ address_line2: null }),
+    );
+    expect(payload).not.toHaveProperty("address_line2");
+  });
+
+  it("includes tax_exempt when changed", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ tax_exempt: true }),
+      makeCustomer({ tax_exempt: false }),
+    );
+    expect(payload).toEqual({ tax_exempt: true });
+  });
+
+  it("omits tax_exempt when unchanged", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ tax_exempt: false }),
+      makeCustomer({ tax_exempt: false }),
+    );
+    expect(payload).not.toHaveProperty("tax_exempt");
+  });
+
+  it("sends new credit_limit_cents when changed", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ credit_limit_cents: 100000 }),
+      makeCustomer({ credit_limit_cents: 50000 }),
+    );
+    expect(payload).toEqual({ credit_limit_cents: 100000 });
+  });
+
+  it("sends null for credit_limit_cents when cleared", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ credit_limit_cents: undefined }),
+      makeCustomer({ credit_limit_cents: 50000 }),
+    );
+    expect(payload).toEqual({ credit_limit_cents: null });
+  });
+
+  it("omits credit_limit_cents when unchanged", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({ credit_limit_cents: 50000 }),
+      makeCustomer({ credit_limit_cents: 50000 }),
+    );
+    expect(payload).not.toHaveProperty("credit_limit_cents");
+  });
+
+  it("handles multiple changes at once", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({
+        display_name: "New Corp",
+        email: "",
+        phone: "(555) 999-0000",
+        tax_exempt: true,
+      }),
+      makeCustomer(),
+    );
+    expect(payload).toEqual({
+      display_name: "New Corp",
+      email: null,
+      phone: "(555) 999-0000",
+      tax_exempt: true,
+    });
+  });
+
+  it("handles all clearable fields being cleared", () => {
+    const payload = buildUpdatePayload(
+      makeFormData({
+        company_name: "",
+        email: "",
+        phone: "",
+        address_line1: "",
+        city: "",
+        state: "",
+        postal_code: "",
+        country: "",
+        notes: "",
+        payment_terms: "",
+        credit_limit_cents: undefined,
+      }),
+      makeCustomer(),
+    );
+    expect(payload.company_name).toBeNull();
+    expect(payload.email).toBeNull();
+    expect(payload.phone).toBeNull();
+    expect(payload.address_line1).toBeNull();
+    expect(payload.city).toBeNull();
+    expect(payload.state).toBeNull();
+    expect(payload.postal_code).toBeNull();
+    expect(payload.country).toBeNull();
+    expect(payload.notes).toBeNull();
+    expect(payload.payment_terms).toBeNull();
+    expect(payload.credit_limit_cents).toBeNull();
+  });
+});

--- a/apps/web/src/lib/utils/update-payload.ts
+++ b/apps/web/src/lib/utils/update-payload.ts
@@ -1,0 +1,75 @@
+import type { CustomerFormData } from "$lib/schemas/customer";
+import type { CustomerResponse } from "$lib/types/CustomerResponse";
+
+/**
+ * Build an update payload from form data and the original customer.
+ *
+ * Implements the 3-state serialization required by the Rust UpdateCustomer struct
+ * (crates/core/src/customer/mod.rs:94-192):
+ * - Unchanged field → omit from JSON (backend: outer None → keep current value)
+ * - Cleared field (had value, now empty) → send null (backend: Some(None) → set NULL)
+ * - Changed field → send new value (backend: Some(Some(v)) → set value)
+ *
+ * Non-nullable fields (display_name) use simple Option<T> (omit or value, never null).
+ * Boolean fields (tax_exempt) also use simple Option<bool>.
+ *
+ * COUPLING NOTE: This function is coupled to the Rust UpdateCustomer struct.
+ * If new clearable fields are added to the backend, they must be handled here.
+ * See PATTERNS.md for the sync protocol.
+ */
+export function buildUpdatePayload(
+  formData: CustomerFormData,
+  original: CustomerResponse,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  // Non-nullable string: display_name (Option<String>)
+  if (formData.display_name !== original.display_name) {
+    payload.display_name = formData.display_name;
+  }
+
+  // Clearable string fields (Option<Option<String>>)
+  const clearableStringFields = [
+    "company_name",
+    "email",
+    "phone",
+    "address_line1",
+    "address_line2",
+    "city",
+    "state",
+    "postal_code",
+    "country",
+    "notes",
+    "payment_terms",
+  ] as const;
+
+  for (const field of clearableStringFields) {
+    const formVal = formData[field] ?? "";
+    const origVal = original[field] ?? "";
+
+    if (formVal === origVal) continue;
+
+    if (formVal === "" && origVal !== "") {
+      // Cleared: send null
+      payload[field] = null;
+    } else {
+      // Changed: send new value
+      payload[field] = formVal;
+    }
+  }
+
+  // Boolean fields (Option<bool>)
+  const taxExempt = formData.tax_exempt ?? false;
+  if (taxExempt !== original.tax_exempt) {
+    payload.tax_exempt = taxExempt;
+  }
+
+  // Clearable number: credit_limit_cents (Option<Option<i64>>)
+  const formCredit = formData.credit_limit_cents ?? null;
+  const origCredit = original.credit_limit_cents ?? null;
+  if (formCredit !== origCredit) {
+    payload.credit_limit_cents = formCredit === null ? null : formCredit;
+  }
+
+  return payload;
+}

--- a/apps/web/src/routes/(app)/customers/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/+page.svelte
@@ -203,7 +203,15 @@
             {#each customers.items as customer (customer.id)}
               <TableRow
                 class="cursor-pointer {customer.deleted_at ? 'opacity-50' : ''}"
-                onclick={() => handleRowClick(customer.id)}
+                onclick={(e) => {
+                  const target = e.target as HTMLElement;
+                  if (
+                    target.closest('[data-slot="dropdown-menu-trigger"]') ||
+                    target.closest('[role="menu"]')
+                  )
+                    return;
+                  handleRowClick(customer.id);
+                }}
               >
                 <TableCell class="font-medium">
                   {customer.display_name}

--- a/apps/web/src/routes/(app)/customers/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/+page.svelte
@@ -1,10 +1,345 @@
 <script lang="ts">
+  import { goto, invalidate } from "$app/navigation";
+  import { deleteCustomer } from "$lib/api/customers";
+  import ConfirmDialog from "$lib/components/confirm-dialog/confirm-dialog.svelte";
+  import CustomerFormSheet from "$lib/components/customer-form-sheet.svelte";
   import EmptyState from "$lib/components/empty-state.svelte";
+  import { toast } from "$lib/components/toast";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Button } from "$lib/components/ui/button";
+  import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+  } from "$lib/components/ui/dropdown-menu";
+  import { Input } from "$lib/components/ui/input";
+  import { Label } from "$lib/components/ui/label";
+  import {
+    Pagination,
+    PaginationContent,
+    PaginationEllipsis,
+    PaginationItem,
+    PaginationLink,
+  } from "$lib/components/ui/pagination";
+  import { Skeleton } from "$lib/components/ui/skeleton";
+  import { Switch } from "$lib/components/ui/switch";
+  import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+  } from "$lib/components/ui/table";
+  import { useSearchParams } from "$lib/hooks/use-url-params.svelte";
+  import { customerListParamsSchema } from "$lib/schemas/customer";
+  import type { CustomerResponse } from "$lib/types/CustomerResponse";
+  import type { PaginatedList } from "$lib/types/PaginatedList";
+  import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+  import ChevronRight from "@lucide/svelte/icons/chevron-right";
+  import EllipsisIcon from "@lucide/svelte/icons/ellipsis";
   import Users from "@lucide/svelte/icons/users";
+
+  let { data } = $props();
+
+  const params = useSearchParams(customerListParamsSchema, {
+    debounce: 300,
+    pushHistory: false,
+    noScroll: true,
+  });
+
+  let formSheetOpen = $state(false);
+  let archiveDialogOpen = $state(false);
+  let archiveTarget = $state<CustomerResponse | null>(null);
+
+  let customers = $derived(
+    data.customers as PaginatedList<CustomerResponse> | null,
+  );
+  let error = $derived(data.error as string | null);
+  let isLoading = $derived(!customers && !error);
+  let isEmpty = $derived(
+    customers?.total === 0 && !params.search && !params.include_deleted,
+  );
+  let isFilteredEmpty = $derived(
+    customers?.total === 0 && (!!params.search || params.include_deleted),
+  );
+
+  function handleRowClick(id: string) {
+    goto(`/customers/${id}`);
+  }
+
+  function handleAddCustomer() {
+    formSheetOpen = true;
+  }
+
+  function openArchiveDialog(customer: CustomerResponse) {
+    archiveTarget = customer;
+    archiveDialogOpen = true;
+  }
+
+  async function handleArchiveConfirm() {
+    if (!archiveTarget) return;
+    const result = await deleteCustomer(archiveTarget.id);
+    if (result.ok) {
+      toast.success(`"${archiveTarget.display_name}" archived`);
+      archiveDialogOpen = false;
+      archiveTarget = null;
+      await invalidate((url) => url.pathname === "/api/customers");
+    } else {
+      throw new Error(result.error.message);
+    }
+  }
 </script>
 
-<EmptyState
-  icon={Users}
-  title="Customers"
-  subtitle="This is where your customers will live. Coming in the next session."
+{#if error}
+  <div class="flex flex-col items-center justify-center py-24 text-center">
+    <div class="bg-destructive/10 text-destructive rounded-lg p-6 max-w-md">
+      <h2 class="text-lg font-semibold">Could not load customers</h2>
+      <p class="mt-2 text-sm">{error}</p>
+      <Button
+        variant="outline"
+        class="mt-4"
+        onclick={() => invalidate((url) => url.pathname === "/api/customers")}
+      >
+        Try again
+      </Button>
+    </div>
+  </div>
+{:else if isLoading}
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <Skeleton class="h-8 w-32" />
+      <Skeleton class="h-10 w-36" />
+    </div>
+    <div class="flex items-center gap-4">
+      <Skeleton class="h-10 w-64" />
+      <Skeleton class="h-6 w-32" />
+    </div>
+    <div class="rounded-md border">
+      {#each Array(6) as _}
+        <div class="flex items-center gap-4 border-b p-4">
+          <Skeleton class="h-4 w-48" />
+          <Skeleton class="h-4 w-32" />
+          <Skeleton class="h-4 w-40" />
+          <Skeleton class="h-4 w-28" />
+        </div>
+      {/each}
+    </div>
+  </div>
+{:else if isEmpty}
+  <EmptyState
+    icon={Users}
+    title="No customers yet"
+    subtitle="Add your first customer to get started."
+  />
+  <div class="flex justify-center -mt-12">
+    <Button onclick={handleAddCustomer}>Add Customer</Button>
+  </div>
+{:else if customers}
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold tracking-tight">Customers</h1>
+        <p class="text-sm text-muted-foreground">
+          {customers.total} total customer{customers.total !== 1 ? "s" : ""}
+        </p>
+      </div>
+      <Button onclick={handleAddCustomer}>Add Customer</Button>
+    </div>
+
+    <div class="flex items-center gap-4">
+      <Input
+        type="search"
+        placeholder="Search customers…"
+        class="max-w-xs"
+        value={params.search}
+        oninput={(e) => {
+          params.search = e.currentTarget.value;
+          params.page = 1;
+        }}
+      />
+      <div class="flex items-center gap-2">
+        <Switch
+          id="show-deleted"
+          checked={params.include_deleted}
+          onCheckedChange={(checked) => {
+            params.include_deleted = checked;
+            params.page = 1;
+          }}
+        />
+        <Label for="show-deleted" class="text-sm">Show archived</Label>
+      </div>
+    </div>
+
+    {#if isFilteredEmpty}
+      <div class="flex flex-col items-center justify-center py-16 text-center">
+        <p class="text-muted-foreground">No customers match your filters.</p>
+        <Button
+          variant="link"
+          class="mt-2"
+          onclick={() => {
+            params.search = "";
+            params.include_deleted = false;
+            params.page = 1;
+          }}
+        >
+          Clear filters
+        </Button>
+      </div>
+    {:else}
+      <div class="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Company</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Phone</TableHead>
+              <TableHead class="w-10"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {#each customers.items as customer (customer.id)}
+              <TableRow
+                class="cursor-pointer {customer.deleted_at ? 'opacity-50' : ''}"
+                onclick={() => handleRowClick(customer.id)}
+              >
+                <TableCell class="font-medium">
+                  {customer.display_name}
+                  {#if customer.deleted_at}
+                    <Badge variant="destructive" class="ml-2 text-xs"
+                      >Archived</Badge
+                    >
+                  {/if}
+                </TableCell>
+                <TableCell>{customer.company_name ?? "—"}</TableCell>
+                <TableCell>{customer.email ?? "—"}</TableCell>
+                <TableCell>{customer.phone ?? "—"}</TableCell>
+                <TableCell>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger>
+                      {#snippet child({ props })}
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          class="h-8 w-8"
+                          {...props}
+                        >
+                          <EllipsisIcon class="h-4 w-4" />
+                          <span class="sr-only">Actions</span>
+                        </Button>
+                      {/snippet}
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onclick={(e) => {
+                          e.stopPropagation();
+                          goto(`/customers/${customer.id}`);
+                        }}
+                      >
+                        View
+                      </DropdownMenuItem>
+                      {#if !customer.deleted_at}
+                        <DropdownMenuItem
+                          class="text-destructive"
+                          onclick={(e) => {
+                            e.stopPropagation();
+                            openArchiveDialog(customer);
+                          }}
+                        >
+                          Archive
+                        </DropdownMenuItem>
+                      {/if}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            {/each}
+          </TableBody>
+        </Table>
+      </div>
+
+      {#if customers.total_pages > 1}
+        <div class="flex justify-center">
+          <Pagination
+            count={customers.total}
+            perPage={customers.per_page}
+            page={params.page}
+            onPageChange={(p) => {
+              params.page = p;
+            }}
+          >
+            {#snippet children({ pages, currentPage })}
+              <PaginationContent>
+                <PaginationItem>
+                  <Button
+                    variant="ghost"
+                    size="default"
+                    class="gap-1 pl-2.5"
+                    disabled={currentPage <= 1}
+                    onclick={() => {
+                      params.page = currentPage - 1;
+                    }}
+                  >
+                    <ChevronLeft class="h-4 w-4" />
+                    <span class="hidden sm:block">Previous</span>
+                  </Button>
+                </PaginationItem>
+                {#each pages as page (page.key)}
+                  {#if page.type === "ellipsis"}
+                    <PaginationItem>
+                      <PaginationEllipsis />
+                    </PaginationItem>
+                  {:else}
+                    <PaginationItem>
+                      <PaginationLink
+                        {page}
+                        isActive={currentPage === page.value}
+                        onclick={() => {
+                          params.page = page.value;
+                        }}
+                      >
+                        {page.value}
+                      </PaginationLink>
+                    </PaginationItem>
+                  {/if}
+                {/each}
+                <PaginationItem>
+                  <Button
+                    variant="ghost"
+                    size="default"
+                    class="gap-1 pr-2.5"
+                    disabled={currentPage >= (customers?.total_pages ?? 1)}
+                    onclick={() => {
+                      params.page = currentPage + 1;
+                    }}
+                  >
+                    <span class="hidden sm:block">Next</span>
+                    <ChevronRight class="h-4 w-4" />
+                  </Button>
+                </PaginationItem>
+              </PaginationContent>
+            {/snippet}
+          </Pagination>
+        </div>
+      {/if}
+    {/if}
+  </div>
+{/if}
+
+<CustomerFormSheet
+  bind:open={formSheetOpen}
+  onClose={() => {
+    formSheetOpen = false;
+  }}
+/>
+
+<ConfirmDialog
+  bind:open={archiveDialogOpen}
+  title="Archive customer"
+  description="Are you sure you want to archive {archiveTarget?.display_name}? This action can be undone later."
+  variant="destructive"
+  confirmLabel="Archive"
+  onConfirm={handleArchiveConfirm}
 />

--- a/apps/web/src/routes/(app)/customers/+page.ts
+++ b/apps/web/src/routes/(app)/customers/+page.ts
@@ -1,0 +1,33 @@
+import { listCustomers } from "$lib/api/customers";
+import type { CustomerResponse } from "$lib/types/CustomerResponse";
+import type { PaginatedList } from "$lib/types/PaginatedList";
+
+export async function load({ url }) {
+  const search = url.searchParams.get("search") ?? "";
+  const page = Number(url.searchParams.get("page") ?? "1") || 1;
+  const perPage = Number(url.searchParams.get("per_page") ?? "25") || 25;
+  const includeDeleted = url.searchParams.get("include_deleted") === "true";
+
+  const result = await listCustomers({
+    search: search || undefined,
+    page,
+    per_page: perPage,
+    include_deleted: includeDeleted || undefined,
+  });
+
+  if (!result.ok) {
+    return {
+      customers: null as PaginatedList<CustomerResponse> | null,
+      error: result.error.message,
+    };
+  }
+
+  if ("data" in result) {
+    return { customers: result.data, error: null as string | null };
+  }
+
+  return {
+    customers: null as PaginatedList<CustomerResponse> | null,
+    error: "Unexpected empty response",
+  };
+}

--- a/apps/web/src/routes/(app)/customers/[id]/+layout.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/+layout.svelte
@@ -12,6 +12,10 @@
     CustomerContext,
     setCustomerContext,
   } from "$lib/contexts/customer-context.svelte";
+  import {
+    clearBreadcrumbLabel,
+    setBreadcrumbLabel,
+  } from "$lib/config/breadcrumb-overrides.svelte";
   import ArrowLeft from "@lucide/svelte/icons/arrow-left";
 
   let { data, children } = $props();
@@ -23,6 +27,14 @@
     ctx.customer = data.customer;
     ctx.error = data.error;
     ctx.loading = false;
+    if (data.customer) {
+      setBreadcrumbLabel(data.customer.id, data.customer.display_name);
+    }
+    return () => {
+      if (data.customer) {
+        clearBreadcrumbLabel(data.customer.id);
+      }
+    };
   });
 
   let tabs = $derived(

--- a/apps/web/src/routes/(app)/customers/[id]/+layout.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/+layout.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import { goto, invalidate } from "$app/navigation";
+  import { deleteCustomer } from "$lib/api/customers";
+  import ConfirmDialog from "$lib/components/confirm-dialog/confirm-dialog.svelte";
+  import CustomerFormSheet from "$lib/components/customer-form-sheet.svelte";
+  import TabNav from "$lib/components/tab-nav.svelte";
+  import { toast } from "$lib/components/toast";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Button } from "$lib/components/ui/button";
+  import { Skeleton } from "$lib/components/ui/skeleton";
+  import {
+    CustomerContext,
+    setCustomerContext,
+  } from "$lib/contexts/customer-context.svelte";
+  import ArrowLeft from "@lucide/svelte/icons/arrow-left";
+
+  let { data, children } = $props();
+
+  const ctx = new CustomerContext();
+  setCustomerContext(ctx);
+
+  $effect(() => {
+    ctx.customer = data.customer;
+    ctx.error = data.error;
+    ctx.loading = false;
+  });
+
+  let tabs = $derived(
+    data.customer
+      ? [
+          { label: "Overview", href: `/customers/${data.customer.id}` },
+          {
+            label: "Activity",
+            href: `/customers/${data.customer.id}/activity`,
+          },
+          {
+            label: "Contacts",
+            href: `/customers/${data.customer.id}/contacts`,
+          },
+          { label: "Artwork", href: `/customers/${data.customer.id}/artwork` },
+          { label: "Pricing", href: `/customers/${data.customer.id}/pricing` },
+          {
+            label: "Communication",
+            href: `/customers/${data.customer.id}/communication`,
+          },
+        ]
+      : [],
+  );
+
+  let editSheetOpen = $state(false);
+  let archiveDialogOpen = $state(false);
+
+  function handleEdit() {
+    editSheetOpen = true;
+  }
+
+  function handleArchiveClick() {
+    archiveDialogOpen = true;
+  }
+
+  async function handleArchiveConfirm() {
+    if (!ctx.customer) return;
+    const result = await deleteCustomer(ctx.customer.id);
+    if (result.ok) {
+      toast.success(`"${ctx.customer.display_name}" archived`);
+      archiveDialogOpen = false;
+      goto("/customers");
+    } else {
+      throw new Error(result.error.message);
+    }
+  }
+</script>
+
+{#if ctx.loading}
+  <div class="space-y-4">
+    <Skeleton class="h-8 w-64" />
+    <Skeleton class="h-4 w-48" />
+    <Skeleton class="h-10 w-full" />
+    <Skeleton class="h-64 w-full" />
+  </div>
+{:else if ctx.error || !ctx.customer}
+  <div class="flex flex-col items-center justify-center py-24 text-center">
+    <div class="bg-destructive/10 text-destructive rounded-lg p-6 max-w-md">
+      <h2 class="text-lg font-semibold">Customer not found</h2>
+      <p class="mt-2 text-sm">
+        {ctx.error ?? "The customer could not be loaded."}
+      </p>
+      <Button variant="outline" class="mt-4" onclick={() => goto("/customers")}>
+        Back to customers
+      </Button>
+    </div>
+  </div>
+{:else}
+  <div class="space-y-4">
+    <Button
+      variant="ghost"
+      size="sm"
+      class="gap-1"
+      onclick={() => goto("/customers")}
+    >
+      <ArrowLeft class="h-4 w-4" />
+      Customers
+    </Button>
+
+    <div class="flex items-start justify-between">
+      <div>
+        <div class="flex items-center gap-3">
+          <h1 class="text-2xl font-semibold tracking-tight">
+            {ctx.customer.display_name}
+          </h1>
+          {#if ctx.isArchived}
+            <Badge variant="destructive">Archived</Badge>
+          {/if}
+        </div>
+        {#if ctx.customer.company_name}
+          <p class="text-muted-foreground">{ctx.customer.company_name}</p>
+        {/if}
+        <div class="mt-1 flex items-center gap-4 text-sm text-muted-foreground">
+          {#if ctx.customer.email}
+            <span>{ctx.customer.email}</span>
+          {/if}
+          {#if ctx.customer.phone}
+            <span>{ctx.customer.phone}</span>
+          {/if}
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        {#if !ctx.isArchived}
+          <Button variant="outline" onclick={handleEdit}>Edit</Button>
+          <Button variant="destructive" onclick={handleArchiveClick}
+            >Archive</Button
+          >
+        {/if}
+      </div>
+    </div>
+
+    <TabNav {tabs} />
+
+    {@render children()}
+  </div>
+
+  <CustomerFormSheet
+    bind:open={editSheetOpen}
+    customer={ctx.customer}
+    onClose={() => {
+      editSheetOpen = false;
+    }}
+  />
+
+  <ConfirmDialog
+    bind:open={archiveDialogOpen}
+    title="Archive customer"
+    description="Are you sure you want to archive {ctx.customer
+      .display_name}? This action can be undone later."
+    variant="destructive"
+    confirmLabel="Archive"
+    onConfirm={handleArchiveConfirm}
+  />
+{/if}

--- a/apps/web/src/routes/(app)/customers/[id]/+layout.ts
+++ b/apps/web/src/routes/(app)/customers/[id]/+layout.ts
@@ -1,0 +1,16 @@
+import { getCustomer } from "$lib/api/customers";
+import type { CustomerResponse } from "$lib/types/CustomerResponse";
+
+export async function load({ params }) {
+  const result = await getCustomer(params.id, true);
+
+  if (!result.ok) {
+    return { customer: null as CustomerResponse | null, error: result.error.message };
+  }
+
+  if ("data" in result) {
+    return { customer: result.data, error: null as string | null };
+  }
+
+  return { customer: null as CustomerResponse | null, error: "Customer not found" };
+}

--- a/apps/web/src/routes/(app)/customers/[id]/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/+page.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { Separator } from "$lib/components/ui/separator";
+  import { getCustomerContext } from "$lib/contexts/customer-context.svelte";
+  import { PAYMENT_TERMS_OPTIONS } from "$lib/schemas/customer";
+  import { formatCurrency } from "$lib/utils/format";
+
+  const ctx = getCustomerContext();
+
+  function formatPaymentTerms(terms: string | null): string {
+    if (!terms) return "—";
+    return PAYMENT_TERMS_OPTIONS.find((o) => o.value === terms)?.label ?? terms;
+  }
+</script>
+
+{#if ctx.customer}
+  <div class="grid gap-4 md:grid-cols-2 pt-4">
+    <Card>
+      <CardHeader>
+        <CardTitle>Contact Information</CardTitle>
+      </CardHeader>
+      <CardContent class="space-y-3">
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Display Name</p>
+          <p>{ctx.customer.display_name}</p>
+        </div>
+        {#if ctx.customer.company_name}
+          <div>
+            <p class="text-sm font-medium text-muted-foreground">Company</p>
+            <p>{ctx.customer.company_name}</p>
+          </div>
+        {/if}
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Email</p>
+          <p>{ctx.customer.email ?? "—"}</p>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Phone</p>
+          <p>{ctx.customer.phone ?? "—"}</p>
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Address</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {#if ctx.customer.address_line1}
+          <p>{ctx.customer.address_line1}</p>
+          {#if ctx.customer.address_line2}
+            <p>{ctx.customer.address_line2}</p>
+          {/if}
+          <p>
+            {[ctx.customer.city, ctx.customer.state, ctx.customer.postal_code]
+              .filter(Boolean)
+              .join(", ")}
+          </p>
+          <p>{ctx.customer.country ?? ""}</p>
+        {:else}
+          <p class="text-muted-foreground">No address on file</p>
+        {/if}
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Financial Defaults</CardTitle>
+      </CardHeader>
+      <CardContent class="space-y-3">
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Payment Terms</p>
+          <p>{formatPaymentTerms(ctx.customer.payment_terms)}</p>
+        </div>
+        <Separator />
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Credit Limit</p>
+          <p>{formatCurrency(ctx.customer.credit_limit_cents)}</p>
+        </div>
+        <Separator />
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Tax Exempt</p>
+          <p>{ctx.customer.tax_exempt ? "Yes" : "No"}</p>
+        </div>
+      </CardContent>
+    </Card>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>Notes</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {#if ctx.customer.notes}
+          <p class="whitespace-pre-wrap">{ctx.customer.notes}</p>
+        {:else}
+          <p class="text-muted-foreground">No notes</p>
+        {/if}
+      </CardContent>
+    </Card>
+  </div>
+{/if}

--- a/apps/web/src/routes/(app)/customers/[id]/activity/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/activity/+page.svelte
@@ -42,14 +42,17 @@
     return new Date(ts).toLocaleString();
   }
 
-  function describeChanges(entry: ActivityEntryResponse): string | null {
-    if (entry.action !== "updated" || !entry.payload) return null;
-    const payload = entry.payload as Record<string, unknown>;
-    const keys = Object.keys(payload).filter(
-      (k) => !["id", "created_at", "updated_at", "deleted_at"].includes(k),
-    );
-    if (keys.length === 0) return null;
-    return `Changed: ${keys.join(", ")}`;
+  function describeAction(entry: ActivityEntryResponse): string | null {
+    switch (entry.action) {
+      case "created":
+        return "Customer record created";
+      case "updated":
+        return "Customer record updated";
+      case "soft_deleted":
+        return "Customer archived";
+      default:
+        return null;
+    }
   }
 
   function navigatePage(newPage: number) {
@@ -83,20 +86,16 @@
   {:else}
     <div class="space-y-3">
       {#each data.activity.items as entry (entry.id)}
-        {@const changes = describeChanges(entry)}
+        {@const description = describeAction(entry)}
         <div class="flex items-start gap-3 rounded-lg border p-4">
           <Badge variant={actionVariant(entry.action)}>
             {actionLabel(entry.action)}
           </Badge>
           <div class="flex-1 min-w-0">
             <p class="text-sm font-medium">
-              {actionLabel(entry.action)} by {entry.actor_type}
+              {description ??
+                `${actionLabel(entry.action)} by ${entry.actor_type}`}
             </p>
-            {#if changes}
-              <p class="text-xs text-muted-foreground mt-0.5">
-                {changes}
-              </p>
-            {/if}
             <p class="text-xs text-muted-foreground mt-1">
               {formatTimestamp(entry.created_at)}
             </p>

--- a/apps/web/src/routes/(app)/customers/[id]/activity/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/activity/+page.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import { page as pageState } from "$app/state";
+  import { goto } from "$app/navigation";
+  import { Badge } from "$lib/components/ui/badge";
+  import { Button } from "$lib/components/ui/button";
+  import { Skeleton } from "$lib/components/ui/skeleton";
+  import type { ActivityEntryResponse } from "$lib/types/ActivityEntryResponse";
+  import ChevronLeft from "@lucide/svelte/icons/chevron-left";
+  import ChevronRight from "@lucide/svelte/icons/chevron-right";
+
+  let { data } = $props();
+
+  function actionVariant(
+    action: string,
+  ): "default" | "secondary" | "destructive" | "outline" {
+    switch (action) {
+      case "created":
+        return "default";
+      case "updated":
+        return "secondary";
+      case "soft_deleted":
+        return "destructive";
+      default:
+        return "outline";
+    }
+  }
+
+  function actionLabel(action: string): string {
+    switch (action) {
+      case "created":
+        return "Created";
+      case "updated":
+        return "Updated";
+      case "soft_deleted":
+        return "Archived";
+      default:
+        return action;
+    }
+  }
+
+  function formatTimestamp(ts: string): string {
+    return new Date(ts).toLocaleString();
+  }
+
+  function describeChanges(entry: ActivityEntryResponse): string | null {
+    if (entry.action !== "updated" || !entry.payload) return null;
+    const payload = entry.payload as Record<string, unknown>;
+    const keys = Object.keys(payload).filter(
+      (k) => !["id", "created_at", "updated_at", "deleted_at"].includes(k),
+    );
+    if (keys.length === 0) return null;
+    return `Changed: ${keys.join(", ")}`;
+  }
+
+  function navigatePage(newPage: number) {
+    const url = new URL(pageState.url);
+    url.searchParams.set("page", String(newPage));
+    goto(url.toString());
+  }
+</script>
+
+<div class="space-y-4 pt-4">
+  {#if data.error}
+    <div class="bg-destructive/10 text-destructive rounded-lg p-4">
+      <p>{data.error}</p>
+    </div>
+  {:else if !data.activity}
+    <div class="space-y-3">
+      {#each Array(4) as _}
+        <div class="flex items-start gap-3 rounded-lg border p-4">
+          <Skeleton class="h-6 w-20" />
+          <div class="flex-1 space-y-1">
+            <Skeleton class="h-4 w-48" />
+            <Skeleton class="h-3 w-32" />
+          </div>
+        </div>
+      {/each}
+    </div>
+  {:else if data.activity.items.length === 0}
+    <p class="text-muted-foreground text-center py-8">
+      No activity recorded yet.
+    </p>
+  {:else}
+    <div class="space-y-3">
+      {#each data.activity.items as entry (entry.id)}
+        {@const changes = describeChanges(entry)}
+        <div class="flex items-start gap-3 rounded-lg border p-4">
+          <Badge variant={actionVariant(entry.action)}>
+            {actionLabel(entry.action)}
+          </Badge>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium">
+              {actionLabel(entry.action)} by {entry.actor_type}
+            </p>
+            {#if changes}
+              <p class="text-xs text-muted-foreground mt-0.5">
+                {changes}
+              </p>
+            {/if}
+            <p class="text-xs text-muted-foreground mt-1">
+              {formatTimestamp(entry.created_at)}
+            </p>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    {#if data.activity.total_pages > 1}
+      <div class="flex items-center justify-center gap-2 pt-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={data.activity.page <= 1}
+          onclick={() => navigatePage(data.activity!.page - 1)}
+        >
+          <ChevronLeft class="h-4 w-4" />
+          Previous
+        </Button>
+        <span class="text-sm text-muted-foreground">
+          Page {data.activity.page} of {data.activity.total_pages}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={data.activity.page >= data.activity.total_pages}
+          onclick={() => navigatePage(data.activity!.page + 1)}
+        >
+          Next
+          <ChevronRight class="h-4 w-4" />
+        </Button>
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/apps/web/src/routes/(app)/customers/[id]/activity/+page.ts
+++ b/apps/web/src/routes/(app)/customers/[id]/activity/+page.ts
@@ -1,0 +1,26 @@
+import { getCustomerActivity } from "$lib/api/customers";
+import type { ActivityEntryResponse } from "$lib/types/ActivityEntryResponse";
+import type { PaginatedList } from "$lib/types/PaginatedList";
+
+export async function load({ params, url }) {
+  const page = Number(url.searchParams.get("page") ?? "1") || 1;
+  const perPage = Number(url.searchParams.get("per_page") ?? "20") || 20;
+
+  const result = await getCustomerActivity(params.id, { page, per_page: perPage });
+
+  if (!result.ok) {
+    return {
+      activity: null as PaginatedList<ActivityEntryResponse> | null,
+      error: result.error.message,
+    };
+  }
+
+  if ("data" in result) {
+    return { activity: result.data, error: null as string | null };
+  }
+
+  return {
+    activity: null as PaginatedList<ActivityEntryResponse> | null,
+    error: "Could not load activity",
+  };
+}

--- a/apps/web/src/routes/(app)/customers/[id]/artwork/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/artwork/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { Card, CardContent } from "$lib/components/ui/card";
+  import { Badge } from "$lib/components/ui/badge";
+  import { mockArtwork } from "$lib/mocks/customer-artwork";
+  import Image from "@lucide/svelte/icons/image";
+</script>
+
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 pt-4">
+  {#each mockArtwork as art (art.id)}
+    <Card class="overflow-hidden">
+      <div class="flex h-32 items-center justify-center bg-muted">
+        <Image class="h-10 w-10 text-muted-foreground" />
+      </div>
+      <CardContent class="p-3 space-y-1">
+        <p class="text-sm font-medium truncate">{art.name}</p>
+        <div class="flex items-center justify-between">
+          <Badge variant="outline" class="text-xs">{art.type}</Badge>
+          <span class="text-xs text-muted-foreground">{art.dimensions}</span>
+        </div>
+        <p class="text-xs text-muted-foreground">
+          Uploaded {new Date(art.uploadedAt).toLocaleDateString()}
+        </p>
+      </CardContent>
+    </Card>
+  {/each}
+</div>

--- a/apps/web/src/routes/(app)/customers/[id]/communication/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/communication/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { Badge } from "$lib/components/ui/badge";
+  import { mockMessages } from "$lib/mocks/customer-communication";
+  import ArrowDownLeft from "@lucide/svelte/icons/arrow-down-left";
+  import ArrowUpRight from "@lucide/svelte/icons/arrow-up-right";
+</script>
+
+<div class="space-y-3 pt-4">
+  {#each mockMessages as message (message.id)}
+    <div class="flex items-start gap-3 rounded-lg border p-4">
+      <div class="mt-0.5">
+        {#if message.direction === "inbound"}
+          <ArrowDownLeft class="h-4 w-4 text-blue-500" />
+        {:else}
+          <ArrowUpRight class="h-4 w-4 text-green-500" />
+        {/if}
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <p class="text-sm font-medium truncate">{message.subject}</p>
+          <Badge variant="outline" class="text-xs shrink-0"
+            >{message.channel}</Badge
+          >
+        </div>
+        <p class="text-sm text-muted-foreground mt-0.5 truncate">
+          {message.preview}
+        </p>
+        <p class="text-xs text-muted-foreground mt-1">
+          {new Date(message.timestamp).toLocaleString()}
+        </p>
+      </div>
+    </div>
+  {/each}
+</div>

--- a/apps/web/src/routes/(app)/customers/[id]/contacts/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/contacts/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { Badge } from "$lib/components/ui/badge";
+  import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { mockContacts } from "$lib/mocks/customer-contacts";
+  import Mail from "@lucide/svelte/icons/mail";
+  import Phone from "@lucide/svelte/icons/phone";
+</script>
+
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 pt-4">
+  {#each mockContacts as contact (contact.id)}
+    <Card>
+      <CardHeader>
+        <div class="flex items-center justify-between">
+          <CardTitle class="text-base">{contact.name}</CardTitle>
+          <div class="flex items-center gap-2">
+            {#if contact.isPrimary}
+              <Badge>Primary</Badge>
+            {/if}
+            <Badge variant="outline">{contact.role}</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent class="space-y-2">
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <Mail class="h-4 w-4" />
+          <span>{contact.email}</span>
+        </div>
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <Phone class="h-4 w-4" />
+          <span>{contact.phone}</span>
+        </div>
+      </CardContent>
+    </Card>
+  {/each}
+</div>

--- a/apps/web/src/routes/(app)/customers/[id]/pricing/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/[id]/pricing/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card";
+  import { Badge } from "$lib/components/ui/badge";
+  import { mockPricingTemplates } from "$lib/mocks/customer-pricing";
+</script>
+
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 pt-4">
+  {#each mockPricingTemplates as template (template.id)}
+    <Card>
+      <CardHeader>
+        <div class="flex items-center justify-between">
+          <CardTitle class="text-base">{template.name}</CardTitle>
+          <Badge variant="outline">{template.method}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent class="space-y-2">
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Base Price</p>
+          <p class="text-lg font-semibold">{template.basePrice}</p>
+        </div>
+        <div>
+          <p class="text-sm font-medium text-muted-foreground">Discount</p>
+          <p class="text-sm">{template.discount}</p>
+        </div>
+      </CardContent>
+    </Card>
+  {/each}
+</div>

--- a/apps/web/src/routes/+layout.ts
+++ b/apps/web/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+// SPA mode — all load functions run client-side only
+export const ssr = false;

--- a/apps/web/tests/features/customers/customer-activity.feature
+++ b/apps/web/tests/features/customers/customer-activity.feature
@@ -1,0 +1,38 @@
+Feature: Customer activity log
+
+  The Activity tab on a customer's detail page shows a chronological
+  record of every mutation — creation, updates, and archival. This is
+  a competitive differentiator: shop owners can audit who changed what
+  and when for any customer record.
+
+  Scenario: Activity tab shows a history of customer actions
+    Given customer "Acme Printing" has been created and then updated
+    When I navigate to the Activity tab for "Acme Printing"
+    Then I see activity entries for both actions
+
+  Scenario: Each entry shows the action type and a timestamp
+    Given customer "Acme Printing" was recently created
+    When I view the Activity tab
+    Then the most recent entry shows a "created" action
+    And the entry shows a recent timestamp
+
+  Scenario: Update entries describe what changed
+    Given customer "Acme Printing" had their email updated
+    When I view the Activity tab
+    Then I see an update entry that describes the email change
+
+  Scenario: Loading indicator appears while fetching activity
+    When I navigate to the Activity tab for a customer
+    Then I see a loading skeleton before the entries appear
+
+  Scenario: New customer shows only a creation entry
+    Given customer "Fresh Start" was just created
+    When I view the Activity tab for "Fresh Start"
+    Then I see exactly one activity entry
+    And the entry shows a "created" action
+
+  Scenario: Activity list paginates for customers with long histories
+    Given customer "Acme Printing" has more activity entries than fit on one page
+    When I view the Activity tab
+    Then I see pagination controls
+    And I can navigate to the next page of activity entries

--- a/apps/web/tests/features/customers/customer-archive.feature
+++ b/apps/web/tests/features/customers/customer-archive.feature
@@ -1,0 +1,43 @@
+Feature: Customer archiving
+
+  Customers are soft-deleted (archived) rather than permanently removed.
+  A confirmation dialog guards the action to prevent accidental data loss.
+  Archived customers disappear from the default list view but remain
+  accessible via the show-deleted toggle.
+
+  Scenario: Archive button on the detail page opens a confirmation dialog
+    Given I am on the detail page for customer "Acme Printing"
+    When I click "Archive"
+    Then a confirmation dialog appears
+    And the dialog asks "Are you sure? This will archive the customer."
+
+  Scenario: Archive action in list row opens a confirmation dialog
+    Given I am on the Customers page
+    When I open the action menu for "Acme Printing"
+    And I click "Archive"
+    Then a confirmation dialog appears
+
+  Scenario: Confirming archive removes the customer from the list
+    Given I am on the Customers page
+    And the confirmation dialog is open for archiving "Acme Printing"
+    When I confirm the archive
+    Then I see a "Customer archived" toast notification
+    And "Acme Printing" no longer appears in the customer list
+
+  Scenario: Cancelling the confirmation returns without archiving
+    Given the confirmation dialog is open for archiving "Acme Printing"
+    When I cancel the dialog
+    Then "Acme Printing" is still in the customer list
+
+  Scenario: Archiving from the detail page redirects to the list
+    Given I am on the detail page for customer "Acme Printing"
+    And the confirmation dialog is open
+    When I confirm the archive
+    Then I am redirected to the Customers page
+    And I see a "Customer archived" toast notification
+
+  Scenario: Archived customer reappears with the show-deleted toggle
+    Given "Acme Printing" has been archived
+    And I am on the Customers page
+    When I toggle "Show deleted"
+    Then "Acme Printing" appears in the table

--- a/apps/web/tests/features/customers/customer-detail.feature
+++ b/apps/web/tests/features/customers/customer-detail.feature
@@ -1,0 +1,79 @@
+Feature: Customer detail page and tab navigation
+
+  The detail page shows a single customer's complete information organized
+  across tabbed sections. The header and tab navigation persist while tab
+  content changes with the URL. Each tab is a real route — bookmarkable,
+  shareable, and accessible via direct navigation.
+
+  # --- Header (V4) ---
+
+  Scenario: Detail page shows the customer name and company
+    Given a customer "Acme Printing" with company "Acme Corp" exists
+    When I navigate to the Acme Printing detail page
+    Then the header shows "Acme Printing"
+    And the header shows "Acme Corp"
+
+  Scenario: Archived customer shows a deleted badge
+    Given an archived customer "Old Corp" exists
+    When I navigate to the Old Corp detail page
+    Then I see a deleted badge on the header
+
+  # --- Overview Tab (V4) ---
+
+  Scenario: Overview tab shows contact information
+    Given a customer with email "acme@example.com" and phone "555-1234"
+    When I view the customer's overview tab
+    Then the overview shows email "acme@example.com"
+    And the overview shows phone "555-1234"
+
+  Scenario: Overview tab shows the mailing address
+    Given a customer with address "123 Main St, Springfield, IL 62701"
+    When I view the customer's overview tab
+    Then the overview shows the full mailing address
+
+  Scenario: Overview tab shows notes
+    Given a customer with notes "Prefers rush delivery"
+    When I view the customer's overview tab
+    Then the overview shows notes "Prefers rush delivery"
+
+  Scenario: Overview tab shows financial defaults
+    Given a customer with payment terms "Net 30" and credit limit "$5,000"
+    When I view the customer's overview tab
+    Then the overview shows payment terms "Net 30"
+    And the overview shows credit limit "$5,000"
+
+  Scenario: Overview tab shows tax-exempt status
+    Given a customer who is tax exempt
+    When I view the customer's overview tab
+    Then the overview indicates the customer is tax exempt
+
+  # --- Tab Navigation (V5) ---
+
+  Scenario: Detail page shows six navigation tabs
+    Given I am on a customer's detail page
+    Then I see tabs for Overview, Activity, Contacts, Artwork, Pricing, and Communication
+
+  Scenario Outline: Clicking a tab navigates to its route
+    Given I am on customer "Acme Printing"'s detail page
+    When I click the "<tab>" tab
+    Then the URL path includes "<segment>"
+    And the "<tab>" tab is active
+
+    Examples:
+      | tab           | segment       |
+      | Activity      | /activity     |
+      | Contacts      | /contacts     |
+      | Artwork       | /artwork      |
+      | Pricing       | /pricing      |
+      | Communication | /communication|
+
+  Scenario: Overview is the default tab
+    When I navigate to a customer's detail page
+    Then the Overview tab is active
+    And no tab segment appears in the URL
+
+  Scenario: Tab routes are directly accessible via URL
+    When I navigate directly to a customer's activity tab URL
+    Then the Activity tab content is displayed
+    And the Activity tab is active
+    And the customer header is visible

--- a/apps/web/tests/features/customers/customer-discovery-tabs.feature
+++ b/apps/web/tests/features/customers/customer-discovery-tabs.feature
@@ -1,0 +1,31 @@
+Feature: Customer discovery tabs
+
+  The Contacts, Artwork, Pricing, and Communication tabs display mock
+  data during M0 to establish the tab navigation pattern. Real data will
+  replace these mocks as each domain ships in later milestones. All tabs
+  must render content, not empty states — this validates the vertical
+  pattern is complete end-to-end.
+
+  Scenario: Contacts tab shows mock contact cards
+    When I navigate to the Contacts tab for a customer
+    Then I see contact cards with names and role badges
+
+  Scenario: A primary contact is indicated
+    When I view the Contacts tab for a customer
+    Then one contact card is flagged as the primary contact
+
+  Scenario: Contact cards show contact details
+    When I view the Contacts tab for a customer
+    Then each contact card shows an email address and phone number
+
+  Scenario: Artwork tab shows a placeholder gallery
+    When I navigate to the Artwork tab for a customer
+    Then I see a gallery grid with placeholder artwork items
+
+  Scenario: Pricing tab shows placeholder pricing templates
+    When I navigate to the Pricing tab for a customer
+    Then I see pricing template cards
+
+  Scenario: Communication tab shows a placeholder timeline
+    When I navigate to the Communication tab for a customer
+    Then I see a timeline of placeholder messages

--- a/apps/web/tests/features/customers/customer-form.feature
+++ b/apps/web/tests/features/customers/customer-form.feature
@@ -1,0 +1,99 @@
+Feature: Customer create and edit forms
+
+  A slide-in sheet for creating new customers and editing existing ones.
+  The same form handles both modes: empty for create, pre-populated for edit.
+  Validation runs client-side for immediate feedback; the server is authoritative
+  and its errors are mapped back to the relevant form fields.
+
+  # --- Create (V3) ---
+
+  Scenario: Creating a customer with required fields
+    Given I am on the Customers page
+    And I open the create customer form
+    When I fill in "Display name" with "Acme Printing"
+    And I submit the form
+    Then I see a "Customer created" toast notification
+    And the form sheet closes
+    And "Acme Printing" appears in the customer list
+
+  Scenario: Creating a customer with all fields
+    Given I open the create customer form
+    When I fill in the following fields:
+      | field           | value               |
+      | Display name    | Acme Printing       |
+      | Company name    | Acme Corp           |
+      | Email           | info@acme.com       |
+      | Phone           | 555-1234            |
+      | Address line 1  | 123 Main St         |
+      | City            | Springfield         |
+      | State           | IL                  |
+      | Postal code     | 62701               |
+      | Notes           | Prefers rush orders |
+      | Payment terms   | Net 30              |
+      | Credit limit    | 5000                |
+    And I submit the form
+    Then I see a "Customer created" toast notification
+
+  Scenario: Display name is required
+    Given I open the create customer form
+    When I leave "Display name" empty
+    And I submit the form
+    Then I see a validation error on "Display name"
+    And the form sheet remains open
+
+  Scenario: Invalid email shows a validation error
+    Given I open the create customer form
+    When I fill in "Display name" with "Test Customer"
+    And I fill in "Email" with "not-an-email"
+    And I submit the form
+    Then I see a validation error on "Email"
+
+  Scenario: Server validation errors appear on the correct fields
+    Given I open the create customer form
+    When the server rejects my submission with a field error on "email"
+    Then I see the server's error message on the "Email" field
+
+  Scenario: Cancelling the form discards changes
+    Given I open the create customer form
+    And I fill in "Display name" with "Draft Customer"
+    When I close the form sheet
+    Then "Draft Customer" does not appear in the customer list
+
+  Scenario: Creating a customer with a duplicate name succeeds
+    Given a customer "Acme Printing" already exists
+    When I create another customer named "Acme Printing"
+    Then I see a "Customer created" toast notification
+    And both customers appear in the list
+
+  # --- Edit (V6) ---
+
+  Scenario: Edit button opens a pre-populated form
+    Given I am on the detail page for customer "Acme Printing"
+    When I click "Edit"
+    Then the customer form sheet opens
+    And the "Display name" field shows "Acme Printing"
+
+  Scenario: Editing a field updates the customer
+    Given I am editing customer "Acme Printing"
+    When I change "Phone" to "555-9876"
+    And I submit the form
+    Then I see a "Customer updated" toast notification
+    And the detail page shows "555-9876" as the phone number
+
+  Scenario: Clearing an optional field removes the value
+    Given customer "Acme Printing" has email "acme@example.com"
+    And I am editing customer "Acme Printing"
+    When I clear the "Email" field
+    And I submit the form
+    Then the detail page no longer shows an email address
+
+  Scenario: Edit form reflects the latest customer data
+    Given customer "Acme Printing" has company "Acme Corp", email "info@acme.com", and phone "555-1234"
+    And I am on the detail page for customer "Acme Printing"
+    When I click "Edit"
+    Then the form shows the following values:
+      | field        | value          |
+      | Display name | Acme Printing  |
+      | Company name | Acme Corp      |
+      | Email        | info@acme.com  |
+      | Phone        | 555-1234       |

--- a/apps/web/tests/features/customers/customer-list.feature
+++ b/apps/web/tests/features/customers/customer-list.feature
@@ -1,0 +1,113 @@
+Feature: Customer list page
+
+  The customer list is the primary entry point for managing customers.
+  It displays all active customers in a table with search, filtering,
+  pagination, and a toggle to reveal archived customers. All filter
+  state lives in the URL so it survives refresh and back-button navigation.
+
+  # --- Empty State ---
+
+  Scenario: Empty customer list shows a call to action
+    Given no customers exist in the system
+    When I navigate to the Customers page
+    Then I see an empty state with an "Add Customer" prompt
+
+  # --- Error State ---
+
+  Scenario: Error state shows when the API is unreachable
+    Given the API is unavailable
+    When I navigate to the Customers page
+    Then I see an error message indicating the data could not be loaded
+
+  # --- Data Display (V1) ---
+
+  Scenario: Customer list loads with a data table
+    Given customers exist in the system
+    When I navigate to the Customers page
+    Then I see a table of customers
+    And each row shows the customer's name, company, email, and phone
+
+  Scenario: Loading skeleton appears while data is fetching
+    When I navigate to the Customers page
+    Then I see a loading skeleton before the table appears
+
+  Scenario: Total customer count is displayed above the table
+    Given 15 customers exist in the system
+    When I navigate to the Customers page
+    Then the KPI strip shows "15" as the total customer count
+
+  Scenario: Clicking a customer row opens the detail page
+    Given a customer "Acme Printing" exists
+    When I click the "Acme Printing" row in the table
+    Then I am on the Acme Printing detail page
+
+  Scenario: Add Customer button opens the create form
+    Given I am on the Customers page
+    When I click "Add Customer"
+    Then the customer form sheet opens
+    And the form fields are empty
+
+  # --- Search (V2 — requires P0 backend search param) ---
+
+  Scenario: Searching filters the customer list
+    Given customers "Acme Printing" and "Beta Apparel" exist
+    When I type "acme" in the search bar
+    Then only "Acme Printing" appears in the table
+
+  Scenario: Clearing the search shows all customers
+    Given I am searching for "acme" on the Customers page
+    When I clear the search bar
+    Then all customers appear in the table
+
+  # --- Soft Delete Toggle (V2) ---
+
+  Scenario: Archived customers are hidden by default
+    Given an archived customer "Old Corp" exists
+    When I navigate to the Customers page
+    Then "Old Corp" does not appear in the table
+
+  Scenario: Show-deleted toggle reveals archived customers
+    Given an archived customer "Old Corp" exists
+    And I am on the Customers page
+    When I toggle "Show deleted"
+    Then "Old Corp" appears in the table
+
+  # --- Pagination (V2) ---
+
+  Scenario: Pagination controls appear when results span multiple pages
+    Given more customers exist than fit on one page
+    When I navigate to the Customers page
+    Then I see pagination controls
+
+  Scenario: Clicking next page shows the next set of customers
+    Given I am on page 1 of the customer list
+    When I click the next page button
+    Then I see a different set of customers
+    And the URL reflects page 2
+
+  # --- URL State Persistence (V2) ---
+
+  Scenario: Search state survives page refresh
+    Given I am searching for "acme" on the Customers page
+    When I refresh the page
+    Then the search bar still shows "acme"
+    And the table is filtered to match "acme"
+
+  Scenario: Filter state works with browser back button
+    Given I am on the Customers page with no filters
+    And I search for "acme"
+    When I press the browser back button
+    Then the search bar is empty
+    And all customers appear in the table
+
+  Scenario: Pagination state survives page refresh
+    Given I am on page 2 of the customer list
+    When I refresh the page
+    Then I am still on page 2
+
+  # --- Responsive (R5) ---
+
+  Scenario: Customer list adapts to narrow viewports
+    Given customers exist in the system
+    When I view the Customers page on a mobile viewport
+    Then customer information is still readable and accessible

--- a/crates/core/src/customer/service.rs
+++ b/crates/core/src/customer/service.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::customer::traits::CustomerRepository;
 use crate::customer::{CreateCustomer, Customer, CustomerId, UpdateCustomer};
 use crate::error::DomainError;
@@ -31,7 +33,17 @@ impl<R: CustomerRepository> CustomerService<R> {
     }
 
     pub async fn create(&self, req: &CreateCustomer) -> Result<Customer, DomainError> {
-        self.repo.create(req).await
+        if req.display_name.trim().is_empty() {
+            return Err(DomainError::Validation {
+                details: HashMap::from([(
+                    "display_name".into(),
+                    vec!["Display name is required".into()],
+                )]),
+            });
+        }
+        let mut normalized = req.clone();
+        normalized.display_name = req.display_name.trim().to_string();
+        self.repo.create(&normalized).await
     }
 
     pub async fn update(
@@ -39,7 +51,23 @@ impl<R: CustomerRepository> CustomerService<R> {
         id: &CustomerId,
         req: &UpdateCustomer,
     ) -> Result<Customer, DomainError> {
-        self.repo.update(id, req).await
+        if req
+            .display_name
+            .as_ref()
+            .is_some_and(|n| n.trim().is_empty())
+        {
+            return Err(DomainError::Validation {
+                details: HashMap::from([(
+                    "display_name".into(),
+                    vec!["Display name is required".into()],
+                )]),
+            });
+        }
+        let mut normalized = req.clone();
+        if let Some(ref name) = normalized.display_name {
+            normalized.display_name = Some(name.trim().to_string());
+        }
+        self.repo.update(id, &normalized).await
     }
 
     pub async fn soft_delete(&self, id: &CustomerId) -> Result<Customer, DomainError> {

--- a/crates/core/src/customer/service.rs
+++ b/crates/core/src/customer/service.rs
@@ -25,8 +25,9 @@ impl<R: CustomerRepository> CustomerService<R> {
         &self,
         params: PageParams,
         filter: IncludeDeleted,
+        search: Option<&str>,
     ) -> Result<(Vec<Customer>, i64), DomainError> {
-        self.repo.list(params, filter).await
+        self.repo.list(params, filter, search).await
     }
 
     pub async fn create(&self, req: &CreateCustomer) -> Result<Customer, DomainError> {

--- a/crates/core/src/customer/traits.rs
+++ b/crates/core/src/customer/traits.rs
@@ -15,6 +15,7 @@ pub trait CustomerRepository: Send + Sync {
         &self,
         params: PageParams,
         filter: IncludeDeleted,
+        search: Option<&str>,
     ) -> impl Future<Output = Result<(Vec<Customer>, i64), DomainError>> + Send;
 
     fn create(

--- a/crates/db/src/customer/repo.rs
+++ b/crates/db/src/customer/repo.rs
@@ -107,14 +107,19 @@ impl CustomerRepository for SeaOrmCustomerRepo {
 
         // Search across display_name, company_name, and email with wildcard escaping
         if let Some(term) = search.filter(|s| !s.is_empty()) {
-            let escaped = term.replace('%', "\\%").replace('_', "\\_");
+            let escaped = term
+                .replace('\\', "\\\\")
+                .replace('%', "\\%")
+                .replace('_', "\\_");
             let pattern = format!("%{escaped}%");
             use sea_orm::Condition;
+            use sea_orm::sea_query::LikeExpr;
+            let like_expr = LikeExpr::new(&pattern).escape('\\');
             base = base.filter(
                 Condition::any()
-                    .add(entity::Column::DisplayName.like(&pattern))
-                    .add(entity::Column::CompanyName.like(&pattern))
-                    .add(entity::Column::Email.like(&pattern)),
+                    .add(entity::Column::DisplayName.like(like_expr.clone()))
+                    .add(entity::Column::CompanyName.like(like_expr.clone()))
+                    .add(entity::Column::Email.like(like_expr)),
             );
         }
 

--- a/crates/db/src/customer/repo.rs
+++ b/crates/db/src/customer/repo.rs
@@ -97,11 +97,25 @@ impl CustomerRepository for SeaOrmCustomerRepo {
         &self,
         params: PageParams,
         filter: IncludeDeleted,
+        search: Option<&str>,
     ) -> Result<(Vec<Customer>, i64), DomainError> {
         let include = matches!(filter, IncludeDeleted::IncludeDeleted);
         let mut base = CustomerEntity::find();
         if !include {
             base = base.filter(entity::Column::DeletedAt.is_null());
+        }
+
+        // Search across display_name, company_name, and email with wildcard escaping
+        if let Some(term) = search.filter(|s| !s.is_empty()) {
+            let escaped = term.replace('%', "\\%").replace('_', "\\_");
+            let pattern = format!("%{escaped}%");
+            use sea_orm::Condition;
+            base = base.filter(
+                Condition::any()
+                    .add(entity::Column::DisplayName.like(&pattern))
+                    .add(entity::Column::CompanyName.like(&pattern))
+                    .add(entity::Column::Email.like(&pattern)),
+            );
         }
 
         let count = base.clone().count(&self.db).await.map_err(sea_err)? as i64;
@@ -323,6 +337,109 @@ mod tests {
             count.0, 0,
             "Customer should NOT exist after transaction rollback"
         );
+    }
+
+    async fn create_test_customer(
+        repo: &SeaOrmCustomerRepo,
+        display_name: &str,
+        company_name: Option<&str>,
+        email: Option<&str>,
+    ) -> Customer {
+        repo.create(&CreateCustomer {
+            display_name: display_name.to_string(),
+            company_name: company_name.map(String::from),
+            email: email.map(String::from),
+            phone: None,
+            address_line1: None,
+            address_line2: None,
+            city: None,
+            state: None,
+            postal_code: None,
+            country: None,
+            notes: None,
+            portal_enabled: None,
+            tax_exempt: None,
+            payment_terms: None,
+            credit_limit_cents: None,
+            lead_source: None,
+            tags: None,
+        })
+        .await
+        .expect("create test customer")
+    }
+
+    #[tokio::test]
+    async fn list_search_filters_by_display_name() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let db_path = tmp.path().join("test.db");
+        let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
+        let pool = crate::initialize_database(&database_url)
+            .await
+            .expect("init db");
+        let repo = SeaOrmCustomerRepo::new(pool);
+
+        create_test_customer(
+            &repo,
+            "Acme Printing",
+            Some("Acme Corp"),
+            Some("info@acme.com"),
+        )
+        .await;
+        create_test_customer(
+            &repo,
+            "Beta Apparel",
+            Some("Beta LLC"),
+            Some("hello@beta.com"),
+        )
+        .await;
+        create_test_customer(&repo, "Gamma Designs", None, None).await;
+
+        let params = PageParams::new(Some(1), Some(25));
+        let filter = IncludeDeleted::ExcludeDeleted;
+
+        // Search by display_name
+        let (results, count) = repo
+            .list(params, filter, Some("acme"))
+            .await
+            .expect("search");
+        assert_eq!(count, 1);
+        assert_eq!(results[0].display_name, "Acme Printing");
+
+        // Search by company_name
+        let (results, count) = repo
+            .list(params, filter, Some("beta"))
+            .await
+            .expect("search");
+        assert_eq!(count, 1);
+        assert_eq!(results[0].display_name, "Beta Apparel");
+
+        // Search by email
+        let (results, count) = repo
+            .list(params, filter, Some("@acme"))
+            .await
+            .expect("search");
+        assert_eq!(count, 1);
+        assert_eq!(results[0].display_name, "Acme Printing");
+
+        // No search returns all
+        let (results, count) = repo.list(params, filter, None).await.expect("no search");
+        assert_eq!(count, 3);
+        assert_eq!(results.len(), 3);
+
+        // Empty search returns all
+        let (results, count) = repo
+            .list(params, filter, Some(""))
+            .await
+            .expect("empty search");
+        assert_eq!(count, 3);
+        assert_eq!(results.len(), 3);
+
+        // No match
+        let (_, count) = repo
+            .list(params, filter, Some("zzzzz"))
+            .await
+            .expect("no match");
+        assert_eq!(count, 0);
     }
 
     /// Fault-injection test: dropping the `activity_log` table simulates

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,18 @@ importers:
       mode-watcher:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.54.1)
+      runed:
+        specifier: 0.37.1
+        version: 0.37.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.54.1)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.54.1)(zod@4.3.6)
       svelte-sonner:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.54.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^4.1.0
+        version: 4.3.6
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.1
@@ -2500,6 +2506,18 @@ packages:
       svelte: ^5.7.0
     peerDependenciesMeta:
       '@sveltejs/kit':
+        optional: true
+
+  runed@0.37.1:
+    resolution: {integrity: sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.21.0
+      svelte: ^5.7.0
+      zod: ^4.1.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      zod:
         optional: true
 
   rxjs@7.8.2:
@@ -5197,6 +5215,16 @@ snapshots:
       svelte: 5.54.1
     optionalDependencies:
       '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.54.1)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))
+
+  runed@0.37.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.54.1)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.54.1)(zod@4.3.6):
+    dependencies:
+      dequal: 2.0.3
+      esm-env: 1.2.2
+      lz-string: 1.5.0
+      svelte: 5.54.1
+    optionalDependencies:
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.54.1)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.54.1)(typescript@5.9.3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))
+      zod: 4.3.6
 
   rxjs@7.8.2:
     dependencies:

--- a/services/api/src/customer/mod.rs
+++ b/services/api/src/customer/mod.rs
@@ -88,6 +88,7 @@ struct ListCustomersQuery {
     include_deleted: Option<bool>,
     page: Option<u32>,
     per_page: Option<u32>,
+    search: Option<String>,
 }
 
 async fn create_customer(
@@ -132,7 +133,7 @@ async fn list_customers(
     .into_page_params();
 
     let svc = customer_service(&state);
-    let (customers, total) = svc.list(params, filter).await?;
+    let (customers, total) = svc.list(params, filter, query.search.as_deref()).await?;
 
     let items: Vec<CustomerResponse> = customers.into_iter().map(to_response).collect();
     Ok(Json(PaginatedList::new(


### PR DESCRIPTION
## Summary

- Customer management UI: list page with search/filter/pagination, detail page with tab navigation (overview, activity, contacts, artwork, pricing, communication), create/edit form sheet, and archive flow
- Server-side customer search across display name, company name, and email with SQL wildcard escaping (SeaORM LIKE)
- Per-vertical frontend module pattern established: API wrapper, Zod schemas, Symbol-keyed context class, tab navigation, 3-state update payload builder
- Theme selector with 6 color swatches (Niji, Tangerine, Midnight, Solar, Soft Pop, Sunset) and horizontal Sun/Moon mode toggle
- Breadcrumb shows customer display name instead of UUID on detail pages
- Fixed tab nav highlighting only the active tab (was highlighting Overview on all sub-tabs)
- Fixed Sidebar and AlertDialog Storybook stories rendering empty content

### Review highlights
- 7 review agents dispatched, 11 code fixes applied, all quality gates pass
- Removed unused `sveltekit-superforms` and `formsnap` deps (native Zod 4 `safeParse` used instead)
- 2 ADRs written: form validation strategy, frontend vertical module convention

Closes #17
Closes #86

### Follow-ups
- #89 restore/unarchive (M1)
- #90 column sorting
- #91 bulk actions (M1)
- #92 real contacts (M1)
- #93 seed data
- #94 BDD step defs
- #95 pattern catalog

## Test plan

- [x] `moon run web:check` — 0 errors, 0 warnings
- [x] `moon run web:test` — 59 tests pass (6 test files)
- [x] `moon run web:build` — succeeds
- [x] `cargo test -p mokumo-db --lib` — 5 tests pass (including search)
- [x] `cargo check --workspace` — clean compile
- [x] Tab nav: only active tab highlighted when switching between tabs
- [x] Breadcrumb: shows customer name on detail pages, not UUID
- [x] Theme: swatches apply theme, mode toggle switches light/dark, persists to localStorage
- [ ] Manual: list page renders with search, pagination, show-deleted
- [ ] Manual: detail page with 6 tabs, all render content
- [ ] Manual: create/edit form with validation
- [ ] Manual: archive from list and detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive customer management UI with search, filtering, pagination, and create/edit capabilities
  * Implemented customer detail page with multiple tabs (Overview, Activity, Contacts, Artwork, Pricing, Communication)
  * Added server-side customer search across display name, company, and email
  * Introduced customer activity log with pagination
  * Added theme selector with multiple theme variants
  * Added tab navigation component for organized content presentation

* **Documentation**
  * Updated changelog with customer management features

* **Tests**
  * Added BDD feature tests for customer list, detail, form, activity, archive, and tab navigation

* **Chores**
  * Added `runed` and `zod` dependencies
  * Updated test configuration for nested test directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->