### PR TITLE
Error handling cleanup: ErrorCode, DbInitError, sqlx categorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,6 +3786,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,9 +1,4 @@
 import type { ErrorBody } from "./types/ErrorBody";
-import type { ErrorCode } from "./types/ErrorCode";
-
-type ClientErrorCode = "parse_error" | "network_error";
-export type AnyErrorCode = ErrorCode | ClientErrorCode;
-export type ClientErrorBody = Omit<ErrorBody, "code"> & { code: AnyErrorCode };
 
 /** Builds a URL query string, filtering out undefined, empty, and false values. */
 export function buildQuery(params: Record<string, string | number | boolean | undefined>): string {
@@ -17,7 +12,7 @@ export function buildQuery(params: Record<string, string | number | boolean | un
 export type ApiResult<T> =
   | { ok: true; status: 204 }
   | { ok: true; status: number; data: T }
-  | { ok: false; status: number; error: ClientErrorBody };
+  | { ok: false; status: number; error: ErrorBody };
 
 export async function apiFetch<T>(url: string, options?: RequestInit): Promise<ApiResult<T>> {
   try {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,9 @@
 import type { ErrorBody } from "./types/ErrorBody";
+import type { ErrorCode } from "./types/ErrorCode";
+
+type ClientErrorCode = "parse_error" | "network_error";
+export type AnyErrorCode = ErrorCode | ClientErrorCode;
+export type ClientErrorBody = Omit<ErrorBody, "code"> & { code: AnyErrorCode };
 
 /** Builds a URL query string, filtering out undefined, empty, and false values. */
 export function buildQuery(params: Record<string, string | number | boolean | undefined>): string {
@@ -12,7 +17,7 @@ export function buildQuery(params: Record<string, string | number | boolean | un
 export type ApiResult<T> =
   | { ok: true; status: 204 }
   | { ok: true; status: number; data: T }
-  | { ok: false; status: number; error: ErrorBody };
+  | { ok: false; status: number; error: ClientErrorBody };
 
 export async function apiFetch<T>(url: string, options?: RequestInit): Promise<ApiResult<T>> {
   try {

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -16,6 +16,9 @@ pub enum DatabaseSetupError {
 
     #[error("migration failed: {0}")]
     Migration(#[from] sea_orm::DbErr),
+
+    #[error("database query failed: {0}")]
+    Query(sqlx::Error),
 }
 
 /// Convert a sqlx error into a DomainError::Internal.
@@ -201,12 +204,13 @@ pub async fn pre_migration_backup(
 ///
 /// Queries the `settings` table for a row with `key = 'setup_complete'` and
 /// returns `true` only when `value = "true"`.
-pub async fn is_setup_complete(db: &DatabaseConnection) -> Result<bool, sqlx::Error> {
+pub async fn is_setup_complete(db: &DatabaseConnection) -> Result<bool, DatabaseSetupError> {
     let pool = db.get_sqlite_connection_pool();
     let row: Option<(Option<String>,)> =
         sqlx::query_as("SELECT value FROM settings WHERE key = 'setup_complete'")
             .fetch_optional(pool)
-            .await?;
+            .await
+            .map_err(DatabaseSetupError::Query)?;
 
     Ok(matches!(row, Some((Some(ref v),)) if v == "true"))
 }

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -137,6 +137,11 @@ tasks:
       trap 'rm -rf "$TEMP_BINDINGS"' EXIT
 
       TS_RS_EXPORT_DIR="$TEMP_BINDINGS" cargo test --workspace --exclude mokumo-desktop
+
+      # Format generated files so diff ignores stylistic differences (oxfmt vs ts-rs)
+      npx oxfmt "$TEMP_BINDINGS"/*.ts 2>/dev/null || true
+      npx oxfmt apps/web/src/lib/types/*.ts 2>/dev/null || true
+
       diff -ru apps/web/src/lib/types/ "$TEMP_BINDINGS/"
     inputs:
     - '@group(allRust)'

--- a/services/api/src/error.rs
+++ b/services/api/src/error.rs
@@ -66,10 +66,20 @@ impl IntoResponse for AppError {
                     (StatusCode::INTERNAL_SERVER_ERROR, redacted_internal())
                 }
             },
-            Self::Database(err) => {
-                tracing::error!("Database error: {err}");
-                (StatusCode::INTERNAL_SERVER_ERROR, redacted_internal())
-            }
+            Self::Database(err) => match &err {
+                sqlx::Error::RowNotFound => (
+                    StatusCode::NOT_FOUND,
+                    ErrorBody {
+                        code: ErrorCode::NotFound,
+                        message: "The requested record was not found".into(),
+                        details: None,
+                    },
+                ),
+                other => {
+                    tracing::error!("Database error: {other}");
+                    (StatusCode::INTERNAL_SERVER_ERROR, redacted_internal())
+                }
+            },
         };
 
         let mut response = (status, Json(body)).into_response();
@@ -275,6 +285,47 @@ mod tests {
             content_type.to_str().unwrap().contains("application/json"),
             "Expected JSON content type, got: {:?}",
             content_type
+        );
+    }
+
+    // --- sqlx::Error categorization (#38) ---
+
+    #[test]
+    fn sqlx_row_not_found_maps_to_404() {
+        let err = AppError::Database(sqlx::Error::RowNotFound);
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn sqlx_row_not_found_response_body() {
+        let err = AppError::Database(sqlx::Error::RowNotFound);
+        let response = err.into_response();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let error_body: ErrorBody = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error_body.code, ErrorCode::NotFound);
+        assert!(
+            !error_body.message.is_empty(),
+            "RowNotFound should have a user-facing message"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlx_other_errors_still_map_to_500_and_redact() {
+        let err = AppError::Database(sqlx::Error::PoolTimedOut);
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let error_body: ErrorBody = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error_body.code, ErrorCode::InternalError);
+        assert!(
+            !error_body.message.contains("PoolTimedOut"),
+            "sqlx error variant should not leak: {}",
+            error_body.message
         );
     }
 }

--- a/services/api/src/error.rs
+++ b/services/api/src/error.rs
@@ -66,6 +66,9 @@ impl IntoResponse for AppError {
                     (StatusCode::INTERNAL_SERVER_ERROR, redacted_internal())
                 }
             },
+            // Boundary safeguard: repo impls currently normalise DB errors into
+            // DomainError before they reach here, so this arm fires only for raw
+            // SQLx queries (e.g. future reporting endpoints) that bypass the repo layer.
             Self::Database(err) => match &err {
                 sqlx::Error::RowNotFound => (
                     StatusCode::NOT_FOUND,

--- a/services/api/tests/server_startup.rs
+++ b/services/api/tests/server_startup.rs
@@ -121,8 +121,11 @@ async fn health_endpoint_returns_500_error_body_on_db_failure() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(json["code"], "internal_error");
-    assert_eq!(json["message"], "An internal error occurred");
+    assert_eq!(json["code"].as_str().unwrap(), "internal_error");
+    assert_eq!(
+        json["message"].as_str().unwrap(),
+        "An internal error occurred"
+    );
 }
 
 #[tokio::test]
@@ -153,6 +156,6 @@ async fn spa_fallback_returns_json_404_for_unknown_api_paths() {
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["code"], "not_found");
+    assert_eq!(json["code"].as_str().unwrap(), "not_found");
     assert!(json["message"].as_str().is_some(), "Expected message field");
 }


### PR DESCRIPTION
## Summary
- **ErrorCode enum** (`crates/types`): Replaces stringly-typed error codes with a typed enum (NotFound, Conflict, ValidationError, InternalError). Serializes as snake_case strings for wire compatibility. TypeScript bindings generate a string literal union type.
- **sqlx::Error categorization** (`services/api`): Teaches the HTTP boundary to map `sqlx::Error::RowNotFound` to 404 instead of 500. This is a boundary safeguard for future raw-SQLx handlers (e.g. reporting queries) — current repo impls normalise DB errors into `DomainError` before reaching `AppError::Database`, so existing endpoints already return 404 through `DomainError::NotFound`.
- **Frontend type safety**: Updated TS bindings, added `ClientErrorBody` type for client-only error codes (`parse_error`, `network_error`).

Closes #38, #39

## Test plan
- [x] 102 Rust tests pass (29 API unit, 12 API integration, 33 types, 28 db)
- [x] 45 frontend tests pass (Vitest)
- [x] `svelte-check` — 0 errors across 1261 files
- [x] `cargo clippy` clean (enforced by pre-push hook)
- [x] `cargo fmt` clean
- [x] TS bindings regenerated — ErrorCode is `"not_found" | "conflict" | "validation_error" | "internal_error"`
- [x] New tests: `sqlx_row_not_found_maps_to_404`, `sqlx_row_not_found_response_body`, `sqlx_other_errors_still_map_to_500_and_redact`
- [x] ErrorCode serialization/deserialization round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)