### PR TITLE
test(api): add sync guard for SPA fallback JSON constant (#118)

### DIFF
--- a/services/api/src/error.rs
+++ b/services/api/src/error.rs
@@ -94,7 +94,7 @@ impl IntoResponse for AppError {
     }
 }
 
-fn redacted_internal() -> ErrorBody {
+pub(crate) fn redacted_internal() -> ErrorBody {
     ErrorBody {
         code: ErrorCode::InternalError,
         message: "An internal error occurred".into(),

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -234,6 +234,12 @@ fn spa_response(status: StatusCode, content_type: &str, cache: &str, body: Vec<u
     )
 }
 
+/// Last-resort JSON returned when serializing an `ErrorBody` to JSON fails
+/// in `serve_spa`. Kept as a byte-string constant so the sync-guard test can
+/// verify it stays in sync with the canonical serde output.
+pub(crate) const INTERNAL_ERROR_FALLBACK_JSON: &[u8] =
+    br#"{"code":"internal_error","message":"An internal error occurred","details":null}"#;
+
 async fn serve_spa(uri: axum::http::Uri) -> impl IntoResponse {
     let path = uri.path().trim_start_matches('/');
 
@@ -246,8 +252,7 @@ async fn serve_spa(uri: axum::http::Uri) -> impl IntoResponse {
         };
         let json = serde_json::to_vec(&body).unwrap_or_else(|e| {
             tracing::error!("Failed to serialize ErrorBody: {e}");
-            br#"{"code":"internal_error","message":"An internal error occurred","details":null}"#
-                .to_vec()
+            INTERNAL_ERROR_FALLBACK_JSON.to_vec()
         });
         return spa_response(StatusCode::NOT_FOUND, "application/json", "no-store", json);
     }
@@ -279,5 +284,25 @@ async fn serve_spa(uri: axum::http::Uri) -> impl IntoResponse {
             "no-store",
             b"SPA not built. Run: moon run web:build".to_vec(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The content of `INTERNAL_ERROR_FALLBACK_JSON` must match what serde
+    /// produces for `redacted_internal()`. If an `ErrorCode` variant is renamed
+    /// or serde attributes change, this test catches the divergence.
+    #[test]
+    fn fallback_json_matches_serde_output() {
+        let expected =
+            serde_json::to_vec(&crate::error::redacted_internal()).expect("must serialize");
+
+        assert_eq!(
+            expected.as_slice(),
+            super::INTERNAL_ERROR_FALLBACK_JSON,
+            "INTERNAL_ERROR_FALLBACK_JSON diverged from serde output. \
+             Update the constant to: {}",
+            String::from_utf8_lossy(&expected),
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Extract hardcoded fallback byte string in `serve_spa` into `INTERNAL_ERROR_FALLBACK_JSON` constant
- Add sync guard test asserting the constant matches `serde_json::to_vec(&redacted_internal())`
- Widen `redacted_internal()` to `pub(crate)` so the test can reference it

Prevents silent divergence if `ErrorCode` variants are renamed or serde attributes change.

Closes #118

## Follow-up
- #123 — unify ErrorBody serialization fallback strategy (pre-existing design concerns surfaced during review)

## Test plan
- [x] `fallback_json_matches_serde_output` passes (new sync guard)
- [x] All 124 API tests pass (`moon run api:test`)
- [x] Clippy clean, formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling reliability by introducing a fallback mechanism for error response serialization.

* **Tests**
  * Added validation tests to ensure error response consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->