### PR TITLE
refactor(db): migrate string timestamps to chrono types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ sqlx = { version = "0.8", default-features = false, features = [
 ] }
 
 # ORM
-sea-orm = { version = "=2.0.0-rc.37", features = ["runtime-tokio", "sqlx-sqlite"] }
+sea-orm = { version = "=2.0.0-rc.37", features = ["runtime-tokio", "sqlx-sqlite", "with-chrono"] }
 sea-orm-migration = { version = "=2.0.0-rc.37", features = ["runtime-tokio", "sqlx-sqlite"] }
 
 # Serialization

--- a/crates/core/src/activity/mod.rs
+++ b/crates/core/src/activity/mod.rs
@@ -1,5 +1,6 @@
 pub mod traits;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Actions that can be recorded in the activity log.
@@ -33,7 +34,7 @@ pub struct ActivityEntry {
     pub actor_id: String,
     pub actor_type: String,
     pub payload: serde_json::Value,
-    pub created_at: String,
+    pub created_at: DateTime<Utc>,
 }
 
 #[cfg(test)]

--- a/crates/core/src/customer/mod.rs
+++ b/crates/core/src/customer/mod.rs
@@ -1,6 +1,7 @@
 pub mod service;
 pub mod traits;
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -57,16 +58,16 @@ pub struct Customer {
     pub portal_user_id: Option<String>,
     pub tax_exempt: bool,
     pub tax_exemption_certificate_path: Option<String>,
-    pub tax_exemption_expires_at: Option<String>,
+    pub tax_exemption_expires_at: Option<DateTime<Utc>>,
     pub payment_terms: Option<String>,
     pub credit_limit_cents: Option<i64>,
     pub stripe_customer_id: Option<String>,
     pub quickbooks_customer_id: Option<String>,
     pub lead_source: Option<String>,
     pub tags: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
-    pub deleted_at: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 /// Request to create a new customer. Only `display_name` is required.

--- a/crates/db/src/activity/repo.rs
+++ b/crates/db/src/activity/repo.rs
@@ -1,4 +1,5 @@
 use crate::db_err;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use mokumo_core::activity::traits::ActivityLogRepository;
 use mokumo_core::activity::{ActivityAction, ActivityEntry};
 use mokumo_core::error::DomainError;
@@ -17,11 +18,27 @@ struct ActivityRow {
     created_at: String,
 }
 
+/// Parse a SQLite timestamp string (e.g. `2026-03-27T12:00:00Z`) into `DateTime<Utc>`.
+fn parse_sqlite_timestamp(s: &str) -> Result<DateTime<Utc>, DomainError> {
+    // Try ISO 8601 with timezone suffix first
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+    // Fallback: parse as naive datetime (no timezone) and assume UTC
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S"))
+        .map(|naive| naive.and_utc())
+        .map_err(|e| DomainError::Internal {
+            message: format!("invalid timestamp in activity log: {e}"),
+        })
+}
+
 fn row_to_entry(row: ActivityRow) -> Result<ActivityEntry, DomainError> {
     let payload: serde_json::Value =
         serde_json::from_str(&row.payload).map_err(|e| DomainError::Internal {
             message: format!("invalid JSON in activity payload: {e}"),
         })?;
+    let created_at = parse_sqlite_timestamp(&row.created_at)?;
     Ok(ActivityEntry {
         id: row.id,
         entity_type: row.entity_type,
@@ -30,7 +47,7 @@ fn row_to_entry(row: ActivityRow) -> Result<ActivityEntry, DomainError> {
         actor_id: row.actor_id,
         actor_type: row.actor_type,
         payload,
-        created_at: row.created_at,
+        created_at,
     })
 }
 

--- a/crates/db/src/customer/entity.rs
+++ b/crates/db/src/customer/entity.rs
@@ -20,16 +20,16 @@ pub struct Model {
     pub portal_user_id: Option<String>,
     pub tax_exempt: bool,
     pub tax_exemption_certificate_path: Option<String>,
-    pub tax_exemption_expires_at: Option<String>,
+    pub tax_exemption_expires_at: Option<DateTimeUtc>,
     pub payment_terms: Option<String>,
     pub credit_limit_cents: Option<i64>,
     pub stripe_customer_id: Option<String>,
     pub quickbooks_customer_id: Option<String>,
     pub lead_source: Option<String>,
     pub tags: Option<String>,
-    pub created_at: String,
-    pub updated_at: String,
-    pub deleted_at: Option<String>,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+    pub deleted_at: Option<DateTimeUtc>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/services/api/src/activity/mod.rs
+++ b/services/api/src/activity/mod.rs
@@ -25,7 +25,7 @@ pub fn to_response(e: ActivityEntry) -> ActivityEntryResponse {
         actor_id: e.actor_id,
         actor_type: e.actor_type,
         payload: Some(e.payload),
-        created_at: e.created_at,
+        created_at: e.created_at.to_rfc3339(),
     }
 }
 

--- a/services/api/src/customer/mod.rs
+++ b/services/api/src/customer/mod.rs
@@ -44,16 +44,16 @@ pub fn to_response(c: Customer) -> CustomerResponse {
         portal_user_id: c.portal_user_id,
         tax_exempt: c.tax_exempt,
         tax_exemption_certificate_path: c.tax_exemption_certificate_path,
-        tax_exemption_expires_at: c.tax_exemption_expires_at,
+        tax_exemption_expires_at: c.tax_exemption_expires_at.map(|dt| dt.to_rfc3339()),
         payment_terms: c.payment_terms,
         credit_limit_cents: c.credit_limit_cents,
         stripe_customer_id: c.stripe_customer_id,
         quickbooks_customer_id: c.quickbooks_customer_id,
         lead_source: c.lead_source,
         tags: c.tags,
-        created_at: c.created_at,
-        updated_at: c.updated_at,
-        deleted_at: c.deleted_at,
+        created_at: c.created_at.to_rfc3339(),
+        updated_at: c.updated_at.to_rfc3339(),
+        deleted_at: c.deleted_at.map(|dt| dt.to_rfc3339()),
     }
 }
 


### PR DESCRIPTION
## Summary
- Enables `with-chrono` feature on SeaORM to support `DateTimeUtc` column types
- Migrates `created_at`, `updated_at`, `deleted_at`, and `tax_exemption_expires_at` from `String` to `DateTimeUtc` in the SeaORM entity (`crates/db/src/customer/entity.rs`)
- Updates corresponding domain types in `crates/core/` to use `chrono::DateTime<Utc>`
- Updates `ActivityEntry.created_at` in `crates/core/src/activity/` to `DateTime<Utc>` with parsing in the db adapter
- API DTOs in `crates/types/` remain `String` for wire-format stability; conversion happens via `to_rfc3339()` at the handler boundary
- No schema migration needed -- SQLite TEXT columns with ISO 8601 format are parsed by SeaORM/chrono automatically

## Test plan
- [x] `moon run api:build` passes
- [x] `moon run api:test` passes (124/124)
- [x] `moon run api:lint` passes (clippy clean)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled chrono-based datetime support in the workspace database dependency.
  * Converted domain and storage timestamp fields to typed UTC datetimes.
  * Added robust parsing for legacy and multiple timestamp formats when reading activity logs.
  * Normalized all API-facing timestamps to RFC 3339 strings for consistent client consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->