### PR TITLE
test(web): Playwright E2E for settings page LAN status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - TypeScript bindings for `ErrorBody` and `PaginatedList<T>` via ts-rs
 - JSON 404 responses for unmatched API routes (instead of serving the SPA shell)
 - BDD feature files specifying error, pagination, and response convention behaviors
-- Playwright BDD coverage for shop settings LAN status states (Active, Unavailable, Disabled) and copy-to-clipboard behavior
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - TypeScript bindings for `ErrorBody` and `PaginatedList<T>` via ts-rs
 - JSON 404 responses for unmatched API routes (instead of serving the SPA shell)
 - BDD feature files specifying error, pagination, and response convention behaviors
+- Playwright BDD coverage for shop settings LAN status states (Active, Unavailable, Disabled) and copy-to-clipboard behavior
 
 ### Changed
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -81,3 +81,7 @@ The `coverage-rust` job in `.github/workflows/quality.yml` runs `moon run api:co
 - **Branches**: LLVM branch coverage (currently 0/0 — requires `--branch` flag which is not enabled in the current configuration)
 - The `--lib` flag means only `#[cfg(test)]` unit tests contribute. Integration tests (`tests/`) and BDD tests are excluded.
 - Files appearing twice in raw JSON is expected when using shared `target-dir` across worktrees — the deduplicated per-crate numbers above are authoritative.
+
+## Web E2E Coverage Notes
+
+- Playwright BDD coverage includes shop settings LAN status states (`Active`, `Unavailable`, `Disabled`) and copy-to-clipboard behavior.

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -116,6 +116,7 @@ tasks:
     command: pnpm test-storybook
     deps:
     - build-storybook
+    - build
     inputs:
     - '@group(sources)'
     - '@group(tests)'

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -117,7 +117,6 @@ tasks:
     deps:
     - build
     - build-storybook
-    - build
     inputs:
     - '@group(sources)'
     - '@group(tests)'

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -115,6 +115,7 @@ tasks:
   test-storybook:
     command: pnpm test-storybook
     deps:
+    - build
     - build-storybook
     - build
     inputs:

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,21 +1,39 @@
 import { defineConfig } from '@playwright/test';
 import { defineBddConfig } from 'playwright-bdd';
 
-const testDir = defineBddConfig({
-	features: 'tests/features/**/*.feature',
-	steps: ['tests/steps/*.ts', 'tests/support/*.ts'],
-	tags: 'not @wip'
+const storybookTestDir = defineBddConfig({
+	outputDir: '.features-gen/storybook',
+	features: [
+		'tests/features/**/*.feature',
+		'!tests/features/settings/**/*.feature',
+	],
+	steps: ['tests/steps/*.ts', '!tests/steps/settings-lan.steps.ts', 'tests/support/storybook.fixture.ts', 'tests/support/storybook.helpers.ts'],
+	tags: 'not @wip',
+});
+
+const appTestDir = defineBddConfig({
+	outputDir: '.features-gen/app',
+	features: 'tests/features/settings/**/*.feature',
+	steps: ['tests/steps/settings-lan.steps.ts'],
+	importTestFrom: 'tests/support/app.fixture.ts',
+	tags: 'not @wip',
+	disableWarnings: { importTestFrom: true },
 });
 
 export default defineConfig({
-	testDir,
 	workers: 2,
 	projects: [
 		{
 			name: 'storybook',
-			use: { browserName: 'chromium' }
-		}
+			testDir: storybookTestDir,
+			use: { browserName: 'chromium' },
+		},
+		{
+			name: 'app',
+			testDir: appTestDir,
+			use: { browserName: 'chromium' },
+		},
 	],
 	reporter: 'html',
-	timeout: 30_000
+	timeout: 30_000,
 });

--- a/apps/web/src/routes/(app)/settings/shop/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/shop/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import type { ServerInfoResponse } from "$lib/types/ServerInfoResponse";
   import * as Card from "$lib/components/ui/card";
-  import { Badge } from "$lib/components/ui/badge";
+  import { Badge, type BadgeVariant } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
   import { toast } from "$lib/components/toast";
   import Wifi from "@lucide/svelte/icons/wifi";
@@ -12,6 +12,49 @@
   let serverInfo = $state<ServerInfoResponse | null>(null);
   let loading = $state(true);
   let error = $state<string | null>(null);
+
+  type LanStatus = {
+    label: "Active" | "Unavailable" | "Disabled";
+    variant: BadgeVariant;
+    badgeClass: string;
+    iconClass: string;
+    message: string;
+  };
+
+  const lanStatus = $derived.by<LanStatus | null>(() => {
+    if (!serverInfo) return null;
+
+    if (serverInfo.mdns_active) {
+      return {
+        label: "Active",
+        variant: "outline",
+        badgeClass: "border-success/40 bg-success/10 text-foreground",
+        iconClass: "text-success",
+        message:
+          "Devices can discover this server by hostname on your local network.",
+      };
+    }
+
+    if (serverInfo.ip_url) {
+      return {
+        label: "Unavailable",
+        variant: "outline",
+        badgeClass: "border-warning/40 bg-warning/10 text-foreground",
+        iconClass: "text-warning",
+        message:
+          "mDNS discovery is unavailable. Use the IP address below to reach this server.",
+      };
+    }
+
+    return {
+      label: "Disabled",
+      variant: "secondary",
+      badgeClass: "",
+      iconClass: "text-muted-foreground",
+      message:
+        "LAN discovery is disabled because this server is not available on the local network.",
+    };
+  });
 
   onMount(async () => {
     try {
@@ -42,10 +85,12 @@
   <Card.Card>
     <Card.CardHeader>
       <Card.CardTitle class="flex items-center gap-2">
-        {#if serverInfo?.mdns_active}
-          <Wifi class="size-5 text-status-success" />
+        {#if lanStatus?.label === "Active"}
+          <Wifi class={`size-5 ${lanStatus.iconClass}`} />
         {:else}
-          <WifiOff class="size-5 text-muted-foreground" />
+          <WifiOff
+            class={`size-5 ${lanStatus?.iconClass ?? "text-muted-foreground"}`}
+          />
         {/if}
         LAN Access
       </Card.CardTitle>
@@ -61,14 +106,18 @@
         </div>
       {:else if error}
         <p class="text-sm text-destructive">{error}</p>
-      {:else if serverInfo}
+      {:else if serverInfo && lanStatus}
         <div class="flex items-center gap-2">
-          {#if serverInfo.mdns_active}
-            <Badge variant="default">Active</Badge>
-          {:else}
-            <Badge variant="secondary">Disabled</Badge>
-          {/if}
+          <Badge
+            data-testid="lan-status-badge"
+            variant={lanStatus.variant}
+            class={lanStatus.badgeClass}
+          >
+            {lanStatus.label}
+          </Badge>
         </div>
+
+        <p class="text-sm text-muted-foreground">{lanStatus.message}</p>
 
         {#if serverInfo.lan_url}
           <div class="space-y-1">
@@ -80,6 +129,8 @@
               <Button
                 variant="ghost"
                 size="icon"
+                aria-label="Copy LAN URL to clipboard"
+                data-testid="copy-lan-url"
                 onclick={() => copyUrl(serverInfo!.lan_url!)}
               >
                 <Copy class="size-4" />
@@ -98,6 +149,8 @@
               <Button
                 variant="ghost"
                 size="icon"
+                aria-label="Copy IP address URL to clipboard"
+                data-testid="copy-ip-url"
                 onclick={() => copyUrl(serverInfo!.ip_url!)}
               >
                 <Copy class="size-4" />

--- a/apps/web/tests/features/settings/settings-lan-status.feature
+++ b/apps/web/tests/features/settings/settings-lan-status.feature
@@ -33,7 +33,7 @@ Feature: Settings page displays LAN status information
   Scenario: LAN status shows unavailable when mDNS is inactive
     Given the server-info API returns mDNS inactive
     When I navigate to the Shop settings page
-    Then I see a "Unavailable" status badge
+    Then I see an "Unavailable" status badge
     And I see the IP address "http://192.168.1.42:3000"
     And the LAN status helper text is "mDNS discovery is unavailable. Use the IP address below to reach this server."
 

--- a/apps/web/tests/features/settings/settings-lan-status.feature
+++ b/apps/web/tests/features/settings/settings-lan-status.feature
@@ -1,0 +1,36 @@
+Feature: Settings page displays LAN status information
+
+  The Shop settings tab shows LAN access details so the shop owner
+  can share the local URL with devices on the same network.
+
+  Background:
+    Given the server-info API returns LAN status
+
+  Scenario: LAN Access card is visible on the Shop settings page
+    When I navigate to the Shop settings page
+    Then I see the "LAN Access" card
+
+  Scenario: LAN status badge shows active when mDNS is running
+    When I navigate to the Shop settings page
+    Then I see an "Active" status badge
+
+  Scenario: LAN URL is displayed
+    When I navigate to the Shop settings page
+    Then I see the LAN URL "http://mokumo.local:3000"
+
+  Scenario: IP address URL is displayed
+    When I navigate to the Shop settings page
+    Then I see the IP address "http://192.168.1.42:3000"
+
+  Scenario: Port number is part of the displayed URLs
+    When I navigate to the Shop settings page
+    Then the displayed URLs include port "3000"
+
+  Scenario: mDNS hostname is part of the LAN URL
+    When I navigate to the Shop settings page
+    Then the LAN URL contains the mDNS hostname "mokumo.local"
+
+  Scenario: LAN status shows disabled when mDNS is inactive
+    Given the server-info API returns mDNS inactive
+    When I navigate to the Shop settings page
+    Then I see a "Disabled" status badge

--- a/apps/web/tests/features/settings/settings-lan-status.feature
+++ b/apps/web/tests/features/settings/settings-lan-status.feature
@@ -30,7 +30,22 @@ Feature: Settings page displays LAN status information
     When I navigate to the Shop settings page
     Then the LAN URL contains the mDNS hostname "mokumo.local"
 
-  Scenario: LAN status shows disabled when mDNS is inactive
+  Scenario: LAN status shows unavailable when mDNS is inactive
     Given the server-info API returns mDNS inactive
     When I navigate to the Shop settings page
-    Then I see a "Disabled" status badge
+    Then I see a "Unavailable" status badge
+    And I see the IP address "http://192.168.1.42:3000"
+    And the LAN status helper text is "mDNS discovery is unavailable. Use the IP address below to reach this server."
+
+  Scenario: LAN status shows disabled when LAN access is disabled
+    Given the shop settings page loads with disabled LAN access
+    Then the LAN status badge shows "Disabled"
+    And the LAN URL is not shown
+    And the IP fallback URL is not shown
+    And the LAN status helper text is "LAN discovery is disabled because this server is not available on the local network."
+
+  Scenario: LAN URL can be copied to clipboard
+    Given the shop settings page loads with active LAN access
+    When I copy the LAN URL
+    Then the clipboard contains the LAN URL
+    And I see a "URL copied to clipboard" toast message

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -1,0 +1,100 @@
+import { expect } from "@playwright/test";
+import { Given, When, Then } from "../support/app.fixture";
+
+const MOCK_SERVER_INFO = {
+  lan_url: "http://mokumo.local:3000",
+  ip_url: "http://192.168.1.42:3000",
+  mdns_active: true,
+  host: "0.0.0.0",
+  port: 3000,
+};
+
+const MOCK_SERVER_INFO_MDNS_INACTIVE = {
+  ...MOCK_SERVER_INFO,
+  mdns_active: false,
+  lan_url: null,
+};
+
+Given("the server-info API returns LAN status", async ({ page }) => {
+  await page.route("**/api/server-info", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_SERVER_INFO),
+    }),
+  );
+});
+
+Given("the server-info API returns mDNS inactive", async ({ page }) => {
+  await page.route("**/api/server-info", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(MOCK_SERVER_INFO_MDNS_INACTIVE),
+    }),
+  );
+});
+
+When("I navigate to the Shop settings page", async ({ page, appUrl }) => {
+  await page.goto(`${appUrl}/settings/shop`);
+  // Wait for the LAN Access card to appear (loading state resolves)
+  await page.waitForSelector("text=LAN Access", { timeout: 10_000 });
+});
+
+Then("I see the {string} card", async ({ page }, cardTitle: string) => {
+  const card = page.locator(`text=${cardTitle}`);
+  await expect(card).toBeVisible();
+});
+
+Then("I see an {string} status badge", async ({ page }, status: string) => {
+  const badge = page
+    .getByRole("status")
+    .filter({ hasText: status })
+    .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
+  await expect(badge).toBeVisible();
+});
+
+Then("a {string} status badge", async ({ page }, status: string) => {
+  const badge = page
+    .getByRole("status")
+    .filter({ hasText: status })
+    .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
+  await expect(badge).toBeVisible();
+});
+
+Then("I see the LAN URL {string}", async ({ page }, url: string) => {
+  const codeBlock = page.locator("code").filter({ hasText: url });
+  await expect(codeBlock).toBeVisible();
+});
+
+Then("I see the IP address {string}", async ({ page }, ip: string) => {
+  const codeBlock = page.locator("code").filter({ hasText: ip });
+  await expect(codeBlock).toBeVisible();
+});
+
+Then("the displayed URLs include port {string}", async ({ page }, port: string) => {
+  const codeBlocks = page.locator("code");
+  const count = await codeBlocks.count();
+  let foundPort = false;
+  for (let i = 0; i < count; i++) {
+    const text = await codeBlocks.nth(i).textContent();
+    if (text?.includes(`:${port}`)) {
+      foundPort = true;
+      break;
+    }
+  }
+  expect(foundPort, `Expected at least one URL containing port ${port}`).toBe(true);
+});
+
+Then("the LAN URL contains the mDNS hostname {string}", async ({ page }, hostname: string) => {
+  const codeBlock = page.locator("code").filter({ hasText: hostname });
+  await expect(codeBlock).toBeVisible();
+});
+
+Then("I see a {string} status badge", async ({ page }, status: string) => {
+  const badge = page
+    .getByRole("status")
+    .filter({ hasText: status })
+    .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
+  await expect(badge).toBeVisible();
+});

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -62,6 +62,29 @@ function statusBadge(page: Page, status: string) {
     .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
 }
 
+function requireServerInfoUrl(
+  stepName: string,
+  serverInfo: ServerInfoResponse | null,
+  field: "ip_url" | "lan_url",
+): string {
+  expect(
+    serverInfo,
+    `Step "${stepName}" requires lanTestState.serverInfo before page.getByText/page.getByRole assertions.`,
+  ).not.toBeNull();
+
+  const url = serverInfo?.[field];
+  expect(
+    url,
+    `Step "${stepName}" requires lanTestState.serverInfo.${field} before page.getByText/page.getByRole assertions.`,
+  ).toBeTruthy();
+
+  if (!url) {
+    throw new Error(`Step "${stepName}" requires lanTestState.serverInfo.${field}.`);
+  }
+
+  return url;
+}
+
 Given("the server-info API returns LAN status", async ({ lanTestState, page }) => {
   lanTestState.serverInfo = ACTIVE_SERVER_INFO;
   await mockServerInfo(page, ACTIVE_SERVER_INFO);
@@ -126,7 +149,9 @@ Then("I see the LAN URL {string}", async ({ page }, url: string) => {
 });
 
 Then("the LAN URL is shown", async ({ lanTestState, page }) => {
-  await expect(page.getByText(lanTestState.serverInfo?.lan_url ?? "")).toBeVisible();
+  const lanUrl = requireServerInfoUrl("the LAN URL is shown", lanTestState.serverInfo, "lan_url");
+
+  await expect(page.getByText(lanUrl)).toBeVisible();
   await expect(page.getByRole("button", { name: "Copy LAN URL to clipboard" })).toBeVisible();
 });
 
@@ -140,7 +165,13 @@ Then("I see the IP address {string}", async ({ page }, ip: string) => {
 });
 
 Then("the IP fallback URL is shown", async ({ lanTestState, page }) => {
-  await expect(page.getByText(lanTestState.serverInfo?.ip_url ?? "")).toBeVisible();
+  const ipUrl = requireServerInfoUrl(
+    "the IP fallback URL is shown",
+    lanTestState.serverInfo,
+    "ip_url",
+  );
+
+  await expect(page.getByText(ipUrl)).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Copy IP address URL to clipboard" }),
   ).toBeVisible();

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -46,20 +46,19 @@ Then("I see the {string} card", async ({ page }, cardTitle: string) => {
   await expect(card).toBeVisible();
 });
 
-Then("I see an {string} status badge", async ({ page }, status: string) => {
-  const badge = page
+function statusBadge(page: import("@playwright/test").Page, status: string) {
+  return page
     .getByRole("status")
     .filter({ hasText: status })
     .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
-  await expect(badge).toBeVisible();
+}
+
+Then("I see an {string} status badge", async ({ page }, status: string) => {
+  await expect(statusBadge(page, status)).toBeVisible();
 });
 
 Then("a {string} status badge", async ({ page }, status: string) => {
-  const badge = page
-    .getByRole("status")
-    .filter({ hasText: status })
-    .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
-  await expect(badge).toBeVisible();
+  await expect(statusBadge(page, status)).toBeVisible();
 });
 
 Then("I see the LAN URL {string}", async ({ page }, url: string) => {
@@ -92,9 +91,5 @@ Then("the LAN URL contains the mDNS hostname {string}", async ({ page }, hostnam
 });
 
 Then("I see a {string} status badge", async ({ page }, status: string) => {
-  const badge = page
-    .getByRole("status")
-    .filter({ hasText: status })
-    .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
-  await expect(badge).toBeVisible();
+  await expect(statusBadge(page, status)).toBeVisible();
 });

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -1,95 +1,188 @@
-import { expect } from "@playwright/test";
-import { Given, When, Then } from "../support/app.fixture";
+import { expect, type Page } from "@playwright/test";
+import type { ServerInfoResponse } from "../../src/lib/types/ServerInfoResponse";
+import { Given, Then, When } from "../support/app.fixture";
+import { buildHttpUrl, TEST_SERVER_HOST } from "../support/local-server";
 
-const MOCK_SERVER_INFO = {
-  lan_url: "http://mokumo.local:3000",
-  ip_url: "http://192.168.1.42:3000",
+const SHOP_SETTINGS_PATH = "/settings/shop";
+const SERVER_INFO_ROUTE = "**/api/server-info";
+const TOAST_SELECTOR = "[data-sonner-toast]";
+const TEST_DEVICE_PORT = Number(process.env.PLAYWRIGHT_TEST_DEVICE_PORT ?? "3000");
+const TEST_MDNS_HOST = process.env.PLAYWRIGHT_TEST_MDNS_HOST ?? "mokumo.local";
+const TEST_IP_HOST = process.env.PLAYWRIGHT_TEST_IP_HOST ?? "192.168.1.42";
+
+const ACTIVE_SERVER_INFO: ServerInfoResponse = {
+  host: TEST_MDNS_HOST,
+  ip_url: buildHttpUrl(TEST_IP_HOST, TEST_DEVICE_PORT),
+  lan_url: buildHttpUrl(TEST_MDNS_HOST, TEST_DEVICE_PORT),
   mdns_active: true,
-  host: "0.0.0.0",
-  port: 3000,
+  port: TEST_DEVICE_PORT,
 };
 
-const MOCK_SERVER_INFO_MDNS_INACTIVE = {
-  ...MOCK_SERVER_INFO,
-  mdns_active: false,
+const UNAVAILABLE_SERVER_INFO: ServerInfoResponse = {
+  host: TEST_IP_HOST,
+  ip_url: buildHttpUrl(TEST_IP_HOST, TEST_DEVICE_PORT),
   lan_url: null,
+  mdns_active: false,
+  port: TEST_DEVICE_PORT,
 };
 
-Given("the server-info API returns LAN status", async ({ page }) => {
-  await page.route("**/api/server-info", (route) =>
-    route.fulfill({
+const DISABLED_SERVER_INFO: ServerInfoResponse = {
+  host: TEST_SERVER_HOST,
+  ip_url: null,
+  lan_url: null,
+  mdns_active: false,
+  port: TEST_DEVICE_PORT,
+};
+
+async function mockServerInfo(page: Page, serverInfo: ServerInfoResponse): Promise<void> {
+  await page.route(SERVER_INFO_ROUTE, async (route) => {
+    await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify(MOCK_SERVER_INFO),
-    }),
-  );
-});
+      body: JSON.stringify(serverInfo),
+    });
+  });
+}
 
-Given("the server-info API returns mDNS inactive", async ({ page }) => {
-  await page.route("**/api/server-info", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(MOCK_SERVER_INFO_MDNS_INACTIVE),
-    }),
-  );
-});
+async function loadShopSettingsPage(
+  page: Page,
+  appUrl: string,
+  serverInfo: ServerInfoResponse,
+): Promise<void> {
+  await mockServerInfo(page, serverInfo);
+  await page.goto(new URL(SHOP_SETTINGS_PATH, appUrl).toString());
+  await expect(page.getByRole("heading", { name: "Shop Settings" })).toBeVisible();
+  await expect(page.getByTestId("lan-status-badge")).toBeVisible();
+}
 
-When("I navigate to the Shop settings page", async ({ page, appUrl }) => {
-  await page.goto(`${appUrl}/settings/shop`);
-  // Wait for the LAN Access card to appear (loading state resolves)
-  await page.waitForSelector("text=LAN Access", { timeout: 10_000 });
-});
-
-Then("I see the {string} card", async ({ page }, cardTitle: string) => {
-  const card = page.locator(`text=${cardTitle}`);
-  await expect(card).toBeVisible();
-});
-
-function statusBadge(page: import("@playwright/test").Page, status: string) {
+function statusBadge(page: Page, status: string) {
   return page
-    .getByRole("status")
+    .getByTestId("lan-status-badge")
     .filter({ hasText: status })
     .or(page.locator("[data-slot='badge']").filter({ hasText: status }));
 }
+
+Given("the server-info API returns LAN status", async ({ lanTestState, page }) => {
+  lanTestState.serverInfo = ACTIVE_SERVER_INFO;
+  await mockServerInfo(page, ACTIVE_SERVER_INFO);
+});
+
+Given("the server-info API returns mDNS inactive", async ({ lanTestState, page }) => {
+  lanTestState.serverInfo = UNAVAILABLE_SERVER_INFO;
+  await mockServerInfo(page, UNAVAILABLE_SERVER_INFO);
+});
+
+Given(
+  "the shop settings page loads with active LAN access",
+  async ({ appUrl, lanTestState, page }) => {
+    lanTestState.serverInfo = ACTIVE_SERVER_INFO;
+    await loadShopSettingsPage(page, appUrl, ACTIVE_SERVER_INFO);
+  },
+);
+
+Given(
+  "the shop settings page loads with unavailable LAN access",
+  async ({ appUrl, lanTestState, page }) => {
+    lanTestState.serverInfo = UNAVAILABLE_SERVER_INFO;
+    await loadShopSettingsPage(page, appUrl, UNAVAILABLE_SERVER_INFO);
+  },
+);
+
+Given(
+  "the shop settings page loads with disabled LAN access",
+  async ({ appUrl, lanTestState, page }) => {
+    lanTestState.serverInfo = DISABLED_SERVER_INFO;
+    await loadShopSettingsPage(page, appUrl, DISABLED_SERVER_INFO);
+  },
+);
+
+When("I navigate to the Shop settings page", async ({ page, appUrl }) => {
+  await page.goto(new URL(SHOP_SETTINGS_PATH, appUrl).toString());
+  await expect(page.getByText("LAN Access")).toBeVisible();
+});
+
+When("I copy the LAN URL", async ({ page }) => {
+  await page.getByRole("button", { name: "Copy LAN URL to clipboard" }).click();
+});
+
+Then("I see the {string} card", async ({ page }, cardTitle: string) => {
+  await expect(page.getByText(cardTitle)).toBeVisible();
+});
 
 Then("I see an {string} status badge", async ({ page }, status: string) => {
   await expect(statusBadge(page, status)).toBeVisible();
 });
 
-Then("a {string} status badge", async ({ page }, status: string) => {
+Then("I see a {string} status badge", async ({ page }, status: string) => {
   await expect(statusBadge(page, status)).toBeVisible();
 });
 
+Then("the LAN status badge shows {string}", async ({ page }, label: string) => {
+  await expect(page.getByTestId("lan-status-badge")).toHaveText(label);
+});
+
 Then("I see the LAN URL {string}", async ({ page }, url: string) => {
-  const codeBlock = page.locator("code").filter({ hasText: url });
-  await expect(codeBlock).toBeVisible();
+  await expect(page.getByText(url)).toBeVisible();
+});
+
+Then("the LAN URL is shown", async ({ lanTestState, page }) => {
+  await expect(page.getByText(lanTestState.serverInfo?.lan_url ?? "")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Copy LAN URL to clipboard" })).toBeVisible();
+});
+
+Then("the LAN URL is not shown", async ({ page }) => {
+  await expect(page.getByText("LAN URL")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Copy LAN URL to clipboard" })).toHaveCount(0);
 });
 
 Then("I see the IP address {string}", async ({ page }, ip: string) => {
-  const codeBlock = page.locator("code").filter({ hasText: ip });
-  await expect(codeBlock).toBeVisible();
+  await expect(page.getByText(ip)).toBeVisible();
+});
+
+Then("the IP fallback URL is shown", async ({ lanTestState, page }) => {
+  await expect(page.getByText(lanTestState.serverInfo?.ip_url ?? "")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Copy IP address URL to clipboard" }),
+  ).toBeVisible();
+});
+
+Then("the IP fallback URL is not shown", async ({ page }) => {
+  await expect(page.getByText("IP Address")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Copy IP address URL to clipboard" })).toHaveCount(
+    0,
+  );
 });
 
 Then("the displayed URLs include port {string}", async ({ page }, port: string) => {
   const codeBlocks = page.locator("code");
   const count = await codeBlocks.count();
   let foundPort = false;
-  for (let i = 0; i < count; i++) {
+
+  for (let i = 0; i < count; i += 1) {
     const text = await codeBlocks.nth(i).textContent();
     if (text?.includes(`:${port}`)) {
       foundPort = true;
       break;
     }
   }
+
   expect(foundPort, `Expected at least one URL containing port ${port}`).toBe(true);
 });
 
 Then("the LAN URL contains the mDNS hostname {string}", async ({ page }, hostname: string) => {
-  const codeBlock = page.locator("code").filter({ hasText: hostname });
-  await expect(codeBlock).toBeVisible();
+  await expect(page.getByText(hostname)).toBeVisible();
 });
 
-Then("I see a {string} status badge", async ({ page }, status: string) => {
-  await expect(statusBadge(page, status)).toBeVisible();
+Then("the LAN status helper text is {string}", async ({ page }, text: string) => {
+  await expect(page.getByText(text)).toBeVisible();
+});
+
+Then("the clipboard contains the LAN URL", async ({ lanTestState, page }) => {
+  await expect
+    .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(lanTestState.serverInfo?.lan_url);
+});
+
+Then("I see a {string} toast message", async ({ page }, message: string) => {
+  await expect(page.locator(TOAST_SELECTOR).filter({ hasText: message }).first()).toBeVisible();
 });

--- a/apps/web/tests/support/app.fixture.ts
+++ b/apps/web/tests/support/app.fixture.ts
@@ -24,7 +24,7 @@ export const test = base.extend<object, WorkerFixtures>({
         );
       }
 
-      const port = await getPort({ portRange: [4200, 4299] });
+      const port = await getPort({ random: true });
       const url = `http://localhost:${port}`;
 
       const httpServerBin = resolve(webRoot, "node_modules/.bin/http-server");

--- a/apps/web/tests/support/app.fixture.ts
+++ b/apps/web/tests/support/app.fixture.ts
@@ -1,44 +1,26 @@
-import { test as base, createBdd } from "playwright-bdd";
-import type { ChildProcess } from "node:child_process";
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { getPort } from "get-port-please";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { createBdd } from "playwright-bdd";
+import type { ServerInfoResponse } from "../../src/lib/types/ServerInfoResponse";
+import { test as base } from "./storybook.fixture";
+import { resolveWebRoot, startPreviewServer } from "./local-server";
 
 type WorkerFixtures = {
   appUrl: string;
 };
 
-export const test = base.extend<object, WorkerFixtures>({
+type TestFixtures = {
+  lanTestState: {
+    serverInfo: ServerInfoResponse | null;
+  };
+};
+
+const webRoot = resolveWebRoot(import.meta.url);
+
+export const test = base.extend<TestFixtures, WorkerFixtures>({
   appUrl: [
-    // oxlint-disable-next-line eslint/no-empty-pattern -- playwright-bdd requires object destructuring
-    async ({}, use) => {
-      const webRoot = resolve(__dirname, "../..");
-      const buildDir = resolve(webRoot, "build");
-      if (!existsSync(buildDir)) {
-        throw new Error(
-          `SvelteKit build not found at ${buildDir}. Run 'moon run web:build' first.`,
-        );
-      }
-
-      const port = await getPort({ random: true });
-      const url = `http://localhost:${port}`;
-
-      const httpServerBin = resolve(webRoot, "node_modules/.bin/http-server");
-      const server = spawn(
-        httpServerBin,
-        [buildDir, "-p", String(port), "-s", "--proxy", `http://localhost:${port}?`],
-        {
-          stdio: "ignore",
-          cwd: webRoot,
-        },
-      );
+    async (_fixtures, use) => {
+      const { server, url } = await startPreviewServer(webRoot);
 
       try {
-        await waitForServer(url, server);
         await use(url);
       } finally {
         server.kill("SIGTERM");
@@ -46,29 +28,18 @@ export const test = base.extend<object, WorkerFixtures>({
     },
     { auto: true, scope: "worker" },
   ],
+
+  lanTestState: async (_fixtures, use) => {
+    await use({ serverInfo: null });
+  },
+
+  page: async ({ appUrl, page }, use) => {
+    await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: appUrl,
+    });
+
+    await use(page);
+  },
 });
 
 export const { Given, When, Then } = createBdd(test);
-
-async function waitForServer(
-  url: string,
-  process: ChildProcess,
-  timeoutMs = 15_000,
-): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
-      if (response.ok) return;
-    } catch {
-      // server not ready yet
-    }
-
-    if (process.exitCode !== null) {
-      throw new Error(`http-server exited with code ${process.exitCode}`);
-    }
-
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`App server did not start within ${timeoutMs}ms`);
-}

--- a/apps/web/tests/support/app.fixture.ts
+++ b/apps/web/tests/support/app.fixture.ts
@@ -1,0 +1,74 @@
+import { test as base, createBdd } from "playwright-bdd";
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getPort } from "get-port-please";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+type WorkerFixtures = {
+  appUrl: string;
+};
+
+export const test = base.extend<object, WorkerFixtures>({
+  appUrl: [
+    // oxlint-disable-next-line eslint/no-empty-pattern -- playwright-bdd requires object destructuring
+    async ({}, use) => {
+      const webRoot = resolve(__dirname, "../..");
+      const buildDir = resolve(webRoot, "build");
+      if (!existsSync(buildDir)) {
+        throw new Error(
+          `SvelteKit build not found at ${buildDir}. Run 'moon run web:build' first.`,
+        );
+      }
+
+      const port = await getPort({ portRange: [4200, 4299] });
+      const url = `http://localhost:${port}`;
+
+      const httpServerBin = resolve(webRoot, "node_modules/.bin/http-server");
+      const server = spawn(
+        httpServerBin,
+        [buildDir, "-p", String(port), "-s", "--proxy", `http://localhost:${port}?`],
+        {
+          stdio: "ignore",
+          cwd: webRoot,
+        },
+      );
+
+      try {
+        await waitForServer(url, server);
+        await use(url);
+      } finally {
+        server.kill("SIGTERM");
+      }
+    },
+    { auto: true, scope: "worker" },
+  ],
+});
+
+export const { Given, When, Then } = createBdd(test);
+
+async function waitForServer(
+  url: string,
+  process: ChildProcess,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      if (response.ok) return;
+    } catch {
+      // server not ready yet
+    }
+
+    if (process.exitCode !== null) {
+      throw new Error(`http-server exited with code ${process.exitCode}`);
+    }
+
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`App server did not start within ${timeoutMs}ms`);
+}

--- a/apps/web/tests/support/app.fixture.ts
+++ b/apps/web/tests/support/app.fixture.ts
@@ -17,7 +17,7 @@ const webRoot = resolveWebRoot(import.meta.url);
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
   appUrl: [
-    async (_fixtures, use) => {
+    async ({ browserName: _browserName }, use) => {
       const { server, url } = await startPreviewServer(webRoot);
 
       try {
@@ -29,7 +29,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     { auto: true, scope: "worker" },
   ],
 
-  lanTestState: async (_fixtures, use) => {
+  lanTestState: async ({ browserName: _browserName }, use) => {
     await use({ serverInfo: null });
   },
 

--- a/apps/web/tests/support/local-server.ts
+++ b/apps/web/tests/support/local-server.ts
@@ -1,0 +1,109 @@
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getPort } from "get-port-please";
+
+export const TEST_SERVER_HOST = process.env.PLAYWRIGHT_TEST_HOST ?? "127.0.0.1";
+
+type StaticServerOptions = {
+  outputDir: string;
+  outputName: string;
+  prepareCommand: string;
+  webRoot: string;
+};
+
+export function buildHttpUrl(host: string, port: number): string {
+  return `http://${host}:${port}`;
+}
+
+export function resolveWebRoot(importMetaUrl: string): string {
+  return resolve(dirname(fileURLToPath(importMetaUrl)), "../..");
+}
+
+function resolveLocalBinary(webRoot: string, binaryName: string): string {
+  const binaryPath = resolve(webRoot, "node_modules/.bin", binaryName);
+  if (!existsSync(binaryPath)) {
+    throw new Error(`${binaryName} not found at ${binaryPath}. Run 'pnpm install' first.`);
+  }
+
+  return binaryPath;
+}
+
+async function getAvailablePort(): Promise<number> {
+  return getPort({ host: TEST_SERVER_HOST, port: 0 });
+}
+
+export async function startStaticServer({
+  outputDir,
+  outputName,
+  prepareCommand,
+  webRoot,
+}: StaticServerOptions): Promise<{ server: ChildProcess; url: string }> {
+  if (!existsSync(outputDir)) {
+    throw new Error(`${outputName} not found at ${outputDir}. Run '${prepareCommand}' first.`);
+  }
+
+  const httpServerBin = resolveLocalBinary(webRoot, "http-server");
+  const port = await getAvailablePort();
+  const url = buildHttpUrl(TEST_SERVER_HOST, port);
+
+  const server = spawn(
+    httpServerBin,
+    [outputDir, "-a", TEST_SERVER_HOST, "-p", String(port), "-s"],
+    {
+      stdio: "ignore",
+      cwd: webRoot,
+    },
+  );
+
+  await waitForServer(url, server);
+
+  return { server, url };
+}
+
+export async function startPreviewServer(
+  webRoot: string,
+): Promise<{ server: ChildProcess; url: string }> {
+  const viteBin = resolveLocalBinary(webRoot, "vite");
+  const port = await getAvailablePort();
+  const url = buildHttpUrl(TEST_SERVER_HOST, port);
+
+  const server = spawn(
+    viteBin,
+    ["preview", "--host", TEST_SERVER_HOST, "--port", String(port), "--strictPort"],
+    {
+      stdio: "ignore",
+      cwd: webRoot,
+    },
+  );
+
+  await waitForServer(url, server);
+
+  return { server, url };
+}
+
+async function waitForServer(
+  url: string,
+  process: ChildProcess,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      if (response.ok) return;
+    } catch {
+      // server not ready yet
+    }
+
+    if (process.exitCode !== null) {
+      throw new Error(`http-server exited with code ${process.exitCode}`);
+    }
+
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  throw new Error(`Static server did not start within ${timeoutMs}ms`);
+}

--- a/apps/web/tests/support/local-server.ts
+++ b/apps/web/tests/support/local-server.ts
@@ -58,7 +58,7 @@ export async function startStaticServer({
     },
   );
 
-  await waitForServer(url, server);
+  await waitForServer(url, server, "http-server");
 
   return { server, url };
 }
@@ -79,7 +79,7 @@ export async function startPreviewServer(
     },
   );
 
-  await waitForServer(url, server);
+  await waitForServer(url, server, "vite preview");
 
   return { server, url };
 }
@@ -87,6 +87,7 @@ export async function startPreviewServer(
 async function waitForServer(
   url: string,
   process: ChildProcess,
+  processName = "http-server",
   timeoutMs = 15_000,
 ): Promise<void> {
   const start = Date.now();
@@ -99,11 +100,11 @@ async function waitForServer(
     }
 
     if (process.exitCode !== null) {
-      throw new Error(`http-server exited with code ${process.exitCode}`);
+      throw new Error(`${processName} exited with code ${process.exitCode}`);
     }
 
     await new Promise((r) => setTimeout(r, 250));
   }
 
-  throw new Error(`Static server did not start within ${timeoutMs}ms`);
+  throw new Error(`${processName} did not start within ${timeoutMs}ms at ${url}`);
 }

--- a/apps/web/tests/support/storybook.fixture.ts
+++ b/apps/web/tests/support/storybook.fixture.ts
@@ -1,40 +1,25 @@
 import { test as base, createBdd } from "playwright-bdd";
-import type { ChildProcess } from "node:child_process";
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { getPort } from "get-port-please";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { resolve } from "node:path";
+import { resolveWebRoot, startStaticServer } from "./local-server";
 
 type WorkerFixtures = {
   storybookUrl: string;
 };
 
+const webRoot = resolveWebRoot(import.meta.url);
+
 export const test = base.extend<object, WorkerFixtures>({
   storybookUrl: [
     // oxlint-disable-next-line eslint/no-empty-pattern -- playwright-bdd requires object destructuring
     async ({}, use) => {
-      const webRoot = resolve(__dirname, "../..");
-      const staticDir = resolve(webRoot, "storybook-static");
-      if (!existsSync(staticDir)) {
-        throw new Error(
-          `storybook-static not found at ${staticDir}. Run 'moon run web:build-storybook' first.`,
-        );
-      }
-
-      const port = await getPort({ random: true });
-      const url = `http://localhost:${port}`;
-
-      const httpServerBin = resolve(webRoot, "node_modules/.bin/http-server");
-      const server = spawn(httpServerBin, [staticDir, "-p", String(port), "-s"], {
-        stdio: "ignore",
-        cwd: webRoot,
+      const { server, url } = await startStaticServer({
+        outputDir: resolve(webRoot, "storybook-static"),
+        outputName: "storybook-static",
+        prepareCommand: "moon run web:build-storybook",
+        webRoot,
       });
 
       try {
-        await waitForServer(url, server);
         await use(url);
       } finally {
         server.kill("SIGTERM");
@@ -45,26 +30,3 @@ export const test = base.extend<object, WorkerFixtures>({
 });
 
 export const { Given, When, Then } = createBdd(test);
-
-async function waitForServer(
-  url: string,
-  process: ChildProcess,
-  timeoutMs = 15_000,
-): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
-      if (response.ok) return;
-    } catch {
-      // server not ready yet
-    }
-
-    if (process.exitCode !== null) {
-      throw new Error(`http-server exited with code ${process.exitCode}`);
-    }
-
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`Storybook server did not start within ${timeoutMs}ms`);
-}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	test: {
 		passWithNoTests: true,
-		exclude: [...configDefaults.exclude, '**/.claude/**'],
+		exclude: [...configDefaults.exclude, '**/.claude/**', '.features-gen/**'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['json', 'text'],


### PR DESCRIPTION
## Summary
- Adds Playwright E2E test (BDD feature + steps) for the Shop settings page LAN status display
- Verifies local IP, mDNS hostname, port, and active/disabled status badge are shown
- Introduces an `app` Playwright project with its own fixture for serving the SvelteKit static build (separate from Storybook)
- Fixes Vitest incorrectly picking up generated `.features-gen/` spec files

## Test plan
- [x] All 7 Playwright E2E scenarios pass locally (`pnpm exec playwright test --project=app`)
- [x] Existing 116 Vitest unit tests still pass (`moon run web:test`)
- [ ] CI passes

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI: Improved LAN status display with computed status, descriptive message, and copy-to-clipboard buttons (aria labels/data-testid added).

* **Tests**
  * Added BDD end-to-end coverage for Shop settings LAN access (Active, Unavailable, Disabled), URL/IP rendering, port checks, clipboard copy, and toast verification.
  * Added local server/fixture support to run these tests.

* **Chores**
  * Test discovery/exclude and test-run config refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->