### PR TITLE
fix(web): sidebar story visible in Storybook iframe regardless of width

### DIFF
--- a/apps/web/src/lib/components/ui/sidebar/Sidebar.stories.svelte
+++ b/apps/web/src/lib/components/ui/sidebar/Sidebar.stories.svelte
@@ -22,7 +22,7 @@
 <Story name="Default">
   <div style="height: 400px; display: flex;">
     <SidebarProvider open={true}>
-      <Sidebar>
+      <Sidebar collapsible="none">
         <SidebarContent>
           <SidebarGroup>
             <SidebarGroupLabel>Navigation</SidebarGroupLabel>

--- a/apps/web/tests/features/component-stories.feature
+++ b/apps/web/tests/features/component-stories.feature
@@ -23,11 +23,6 @@ Feature: Every installed component has a story
       | AppSidebar    |
       | EmptyState    |
 
-  # Sidebar uses `hidden md:block` responsive CSS and a MediaQuery-based
-  # isMobile check. The Storybook iframe may be narrower than 768px even
-  # when the outer viewport is wide, causing the sidebar to render hidden.
-  # Fix: add a viewport decorator to the Sidebar story or set iframe width.
-  @wip
   Scenario: Sidebar component has a story
     Given Storybook is running
     Then each of the following components has at least one story:


### PR DESCRIPTION
## Summary
- Use `collapsible="none"` in the Sidebar story to bypass responsive `hidden md:block` CSS and `MediaQuery`-based `isMobile` check that caused the sidebar to render hidden when the Storybook iframe was narrower than 768px
- Remove `@wip` tag from "Sidebar component has a story" BDD scenario in `component-stories.feature`

Closes #131

## Test plan
- [x] `moon run web:test-storybook` — 51 passed, 0 failed
- [x] Sidebar scenario no longer tagged `@wip`, runs and passes
- [x] No `@wip` scenarios remain in `component-stories.feature`
- [ ] CI passes (storybook BDD, Chromatic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)