### PR TITLE
fix(web): flaky E2E tests — LAN port assertion race + axe-core contention (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Customer mutations (create, update, soft-delete) now execute within atomic transactions — the mutation and its activity log entry either both persist or neither does, preventing orphaned records
 - `ErrorBody.details` now always serializes as `null` when absent (not omitted from JSON)
+- Settings LAN port E2E test no longer flaky in CI — replaced manual element iteration with auto-retrying Playwright assertion

--- a/apps/web/tests/steps/a11y.steps.ts
+++ b/apps/web/tests/steps/a11y.steps.ts
@@ -7,6 +7,9 @@ let axeResults: Awaited<ReturnType<AxeBuilder["analyze"]>>;
 When("I open the accessibility panel", async ({ page }) => {
   // Reset to prevent stale results from a previous scenario in the same worker
   axeResults = undefined!;
+  // Wait for any in-flight axe run (e.g. from @storybook/addon-a11y) to finish
+  // before starting our own analysis — prevents "Axe is already running" race.
+  await page.waitForFunction(() => !(window as any).axe?._running, null, { timeout: 10_000 });
   axeResults = await new AxeBuilder({ page }).include("body").analyze();
 });
 

--- a/apps/web/tests/steps/a11y.steps.ts
+++ b/apps/web/tests/steps/a11y.steps.ts
@@ -9,7 +9,11 @@ When("I open the accessibility panel", async ({ page }) => {
   axeResults = undefined!;
   // Wait for any in-flight axe run (e.g. from @storybook/addon-a11y) to finish
   // before starting our own analysis — prevents "Axe is already running" race.
-  await page.waitForFunction(() => !(window as any).axe?._running, null, { timeout: 10_000 });
+  await page.waitForFunction(
+    () => !(window as unknown as { axe?: { _running?: boolean } }).axe?._running,
+    null,
+    { timeout: 10_000 },
+  );
   axeResults = await new AxeBuilder({ page }).include("body").analyze();
 });
 

--- a/apps/web/tests/steps/confirm-dialog.steps.ts
+++ b/apps/web/tests/steps/confirm-dialog.steps.ts
@@ -132,6 +132,9 @@ Then("the dialog is still open", async ({ page }) => {
 });
 
 Then("no critical accessibility violations are found", async ({ page }) => {
+  // Wait for any in-flight axe run (e.g. from @storybook/addon-a11y) to finish
+  // before starting our own analysis — prevents "Axe is already running" race.
+  await page.waitForFunction(() => !(window as any).axe?._running, null, { timeout: 10_000 });
   const dialog = page.getByRole("alertdialog").first();
   const dialogId = await dialog.getAttribute("id");
   const results = await new AxeBuilder({ page }).include(`#${dialogId}`).analyze();

--- a/apps/web/tests/steps/confirm-dialog.steps.ts
+++ b/apps/web/tests/steps/confirm-dialog.steps.ts
@@ -134,7 +134,11 @@ Then("the dialog is still open", async ({ page }) => {
 Then("no critical accessibility violations are found", async ({ page }) => {
   // Wait for any in-flight axe run (e.g. from @storybook/addon-a11y) to finish
   // before starting our own analysis — prevents "Axe is already running" race.
-  await page.waitForFunction(() => !(window as any).axe?._running, null, { timeout: 10_000 });
+  await page.waitForFunction(
+    () => !(window as unknown as { axe?: { _running?: boolean } }).axe?._running,
+    null,
+    { timeout: 10_000 },
+  );
   const dialog = page.getByRole("alertdialog").first();
   const dialogId = await dialog.getAttribute("id");
   const results = await new AxeBuilder({ page }).include(`#${dialogId}`).analyze();

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -185,19 +185,12 @@ Then("the IP fallback URL is not shown", async ({ page }) => {
 });
 
 Then("the displayed URLs include port {string}", async ({ page }, port: string) => {
-  const codeBlocks = page.locator("code");
-  const count = await codeBlocks.count();
-  let foundPort = false;
-
-  for (let i = 0; i < count; i += 1) {
-    const text = await codeBlocks.nth(i).textContent();
-    if (text?.includes(`:${port}`)) {
-      foundPort = true;
-      break;
-    }
-  }
-
-  expect(foundPort, `Expected at least one URL containing port ${port}`).toBe(true);
+  await expect(
+    page
+      .locator("code")
+      .filter({ hasText: `:${port}` })
+      .first(),
+  ).toBeVisible();
 });
 
 Then("the LAN URL contains the mDNS hostname {string}", async ({ page }, hostname: string) => {


### PR DESCRIPTION
## Summary
Two flaky E2E test fixes that only manifest in CI due to timing differences:

- **LAN port test (#135)**: Replace manual `count()`/`textContent()` iteration loop with Playwright's idiomatic `locator.filter({ hasText }).first().toBeVisible()` — the old pattern used snapshot-based DOM reads with no retry, failing when the mocked `/api/server-info` response hadn't rendered `<code>` elements yet
- **axe-core race condition**: Add `waitForFunction` guard before `AxeBuilder.analyze()` in both `confirm-dialog.steps.ts` and `a11y.steps.ts` — `@storybook/addon-a11y` with `test: "warn"` runs its own axe scan automatically, which races against our manual `AxeBuilder` call, producing "Axe is already running" errors in CI
- **Research captured**: Playwright wait pattern reference added to `ops/research/engineering/testing-strategy/playwright-wait-patterns.md` covering auto-retrying assertions, `filter({ hasText })`, `expect.poll`, and the axe-core contention fix

## Changed files
- `apps/web/tests/steps/settings-lan.steps.ts` — replace 14-line manual loop with 3-line auto-retrying assertion
- `apps/web/tests/steps/confirm-dialog.steps.ts` — wait for in-flight axe run before analyzing
- `apps/web/tests/steps/a11y.steps.ts` — same axe guard applied preventatively
- `CHANGELOG.md` — document the LAN port test fix

## Test plan
- [x] "Port number is part of the displayed URLs" scenario passes
- [x] All 9 LAN status scenarios pass (no regressions)
- [x] "Dialog passes accessibility scan" scenario passes
- [x] Full Playwright suite: 51 passed, 4 skipped (existing @skip)
- [ ] CI green on this PR

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)