### PR TITLE
feat(activity): replace hardcoded 'system' actor with authenticated user (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+
+- Activity log entries now record the authenticated user's ID and type instead of hardcoded "system" for customer mutations
+
 ### Added
 
 - Customer management UI: list page with search/filter/pagination, detail page with tab navigation (overview, activity, contacts, artwork, pricing, communication), create/edit form sheet, and archive flow

--- a/crates/core/src/actor.rs
+++ b/crates/core/src/actor.rs
@@ -1,0 +1,79 @@
+use std::fmt;
+
+/// Who is performing a mutation. Threaded from the handler layer
+/// through services and into repository adapters for activity logging.
+#[derive(Debug, Clone)]
+pub struct Actor {
+    id: String,
+    actor_type: ActorType,
+}
+
+/// The kind of actor performing an action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActorType {
+    User,
+    System,
+    ApiKey,
+}
+
+impl fmt::Display for ActorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::User => write!(f, "user"),
+            Self::System => write!(f, "system"),
+            Self::ApiKey => write!(f, "api_key"),
+        }
+    }
+}
+
+impl Actor {
+    /// Build an actor from an authenticated user's ID.
+    pub fn user(id: impl ToString) -> Self {
+        Self {
+            id: id.to_string(),
+            actor_type: ActorType::User,
+        }
+    }
+
+    /// System actor for migrations, CLI operations, and tests.
+    pub fn system() -> Self {
+        Self {
+            id: "system".to_string(),
+            actor_type: ActorType::System,
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn actor_type(&self) -> ActorType {
+        self.actor_type
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_actor_stores_id_and_type() {
+        let actor = Actor::user(42);
+        assert_eq!(actor.id(), "42");
+        assert_eq!(actor.actor_type(), ActorType::User);
+    }
+
+    #[test]
+    fn system_actor_has_system_id() {
+        let actor = Actor::system();
+        assert_eq!(actor.id(), "system");
+        assert_eq!(actor.actor_type(), ActorType::System);
+    }
+
+    #[test]
+    fn actor_type_display() {
+        assert_eq!(ActorType::User.to_string(), "user");
+        assert_eq!(ActorType::System.to_string(), "system");
+        assert_eq!(ActorType::ApiKey.to_string(), "api_key");
+    }
+}

--- a/crates/core/src/customer/service.rs
+++ b/crates/core/src/customer/service.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::actor::Actor;
 use crate::customer::traits::CustomerRepository;
 use crate::customer::{CreateCustomer, Customer, CustomerId, UpdateCustomer};
 use crate::error::DomainError;
@@ -32,7 +33,11 @@ impl<R: CustomerRepository> CustomerService<R> {
         self.repo.list(params, filter, search).await
     }
 
-    pub async fn create(&self, req: &CreateCustomer) -> Result<Customer, DomainError> {
+    pub async fn create(
+        &self,
+        req: &CreateCustomer,
+        actor: &Actor,
+    ) -> Result<Customer, DomainError> {
         if req.display_name.trim().is_empty() {
             return Err(DomainError::Validation {
                 details: HashMap::from([(
@@ -43,13 +48,14 @@ impl<R: CustomerRepository> CustomerService<R> {
         }
         let mut normalized = req.clone();
         normalized.display_name = req.display_name.trim().to_string();
-        self.repo.create(&normalized).await
+        self.repo.create(&normalized, actor).await
     }
 
     pub async fn update(
         &self,
         id: &CustomerId,
         req: &UpdateCustomer,
+        actor: &Actor,
     ) -> Result<Customer, DomainError> {
         if req
             .display_name
@@ -67,10 +73,14 @@ impl<R: CustomerRepository> CustomerService<R> {
         if let Some(ref name) = normalized.display_name {
             normalized.display_name = Some(name.trim().to_string());
         }
-        self.repo.update(id, &normalized).await
+        self.repo.update(id, &normalized, actor).await
     }
 
-    pub async fn soft_delete(&self, id: &CustomerId) -> Result<Customer, DomainError> {
-        self.repo.soft_delete(id).await
+    pub async fn soft_delete(
+        &self,
+        id: &CustomerId,
+        actor: &Actor,
+    ) -> Result<Customer, DomainError> {
+        self.repo.soft_delete(id, actor).await
     }
 }

--- a/crates/core/src/customer/traits.rs
+++ b/crates/core/src/customer/traits.rs
@@ -1,3 +1,4 @@
+use crate::actor::Actor;
 use crate::customer::{CreateCustomer, Customer, CustomerId, UpdateCustomer};
 use crate::error::DomainError;
 use crate::filter::IncludeDeleted;
@@ -21,16 +22,19 @@ pub trait CustomerRepository: Send + Sync {
     fn create(
         &self,
         req: &CreateCustomer,
+        actor: &Actor,
     ) -> impl Future<Output = Result<Customer, DomainError>> + Send;
 
     fn update(
         &self,
         id: &CustomerId,
         req: &UpdateCustomer,
+        actor: &Actor,
     ) -> impl Future<Output = Result<Customer, DomainError>> + Send;
 
     fn soft_delete(
         &self,
         id: &CustomerId,
+        actor: &Actor,
     ) -> impl Future<Output = Result<Customer, DomainError>> + Send;
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod actor;
 pub mod customer;
 pub mod error;
 pub mod filter;

--- a/crates/db/src/customer/repo.rs
+++ b/crates/db/src/customer/repo.rs
@@ -1,4 +1,5 @@
 use mokumo_core::activity::ActivityAction;
+use mokumo_core::actor::Actor;
 use mokumo_core::customer::traits::CustomerRepository;
 use mokumo_core::customer::{CreateCustomer, Customer, CustomerId, UpdateCustomer};
 use mokumo_core::error::DomainError;
@@ -46,11 +47,12 @@ impl From<entity::Model> for Customer {
 }
 
 /// Serialize the customer snapshot and insert an activity log entry within
-/// the caller's transaction. Hardcodes actor to "system" until auth lands.
+/// the caller's transaction.
 async fn log_customer_activity(
     conn: &impl ConnectionTrait,
     customer: &Customer,
     action: ActivityAction,
+    actor: &Actor,
 ) -> Result<(), DomainError> {
     let payload = serde_json::to_value(customer).map_err(|e| DomainError::Internal {
         message: format!("failed to serialize customer for activity log: {e}"),
@@ -60,8 +62,8 @@ async fn log_customer_activity(
         "customer",
         &customer.id.to_string(),
         action,
-        "system",
-        "system",
+        actor.id(),
+        &actor.actor_type().to_string(),
         &payload,
     )
     .await
@@ -138,7 +140,7 @@ impl CustomerRepository for SeaOrmCustomerRepo {
         Ok((customers, count))
     }
 
-    async fn create(&self, req: &CreateCustomer) -> Result<Customer, DomainError> {
+    async fn create(&self, req: &CreateCustomer, actor: &Actor) -> Result<Customer, DomainError> {
         let id = CustomerId::generate();
         let txn = self.db.begin().await.map_err(sea_err)?;
 
@@ -180,13 +182,18 @@ impl CustomerRepository for SeaOrmCustomerRepo {
         let model = active.insert(&txn).await.map_err(sea_err)?;
         let customer = Customer::from(model);
 
-        log_customer_activity(&txn, &customer, ActivityAction::Created).await?;
+        log_customer_activity(&txn, &customer, ActivityAction::Created, actor).await?;
 
         txn.commit().await.map_err(sea_err)?;
         Ok(customer)
     }
 
-    async fn update(&self, id: &CustomerId, req: &UpdateCustomer) -> Result<Customer, DomainError> {
+    async fn update(
+        &self,
+        id: &CustomerId,
+        req: &UpdateCustomer,
+        actor: &Actor,
+    ) -> Result<Customer, DomainError> {
         let txn = self.db.begin().await.map_err(sea_err)?;
 
         // Verify customer exists and is not soft-deleted
@@ -249,12 +256,12 @@ impl CustomerRepository for SeaOrmCustomerRepo {
             })?;
 
         let customer = Customer::from(model);
-        log_customer_activity(&txn, &customer, ActivityAction::Updated).await?;
+        log_customer_activity(&txn, &customer, ActivityAction::Updated, actor).await?;
         txn.commit().await.map_err(sea_err)?;
         Ok(customer)
     }
 
-    async fn soft_delete(&self, id: &CustomerId) -> Result<Customer, DomainError> {
+    async fn soft_delete(&self, id: &CustomerId, actor: &Actor) -> Result<Customer, DomainError> {
         let txn = self.db.begin().await.map_err(sea_err)?;
 
         let result = CustomerEntity::update_many()
@@ -285,7 +292,7 @@ impl CustomerRepository for SeaOrmCustomerRepo {
             })?;
 
         let customer = Customer::from(model);
-        log_customer_activity(&txn, &customer, ActivityAction::SoftDeleted).await?;
+        log_customer_activity(&txn, &customer, ActivityAction::SoftDeleted, actor).await?;
         txn.commit().await.map_err(sea_err)?;
         Ok(customer)
     }
@@ -294,6 +301,7 @@ impl CustomerRepository for SeaOrmCustomerRepo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mokumo_core::actor::Actor;
     use mokumo_core::customer::traits::CustomerRepository;
 
     async fn test_db() -> (
@@ -350,25 +358,28 @@ mod tests {
         company_name: Option<&str>,
         email: Option<&str>,
     ) -> Customer {
-        repo.create(&CreateCustomer {
-            display_name: display_name.to_string(),
-            company_name: company_name.map(String::from),
-            email: email.map(String::from),
-            phone: None,
-            address_line1: None,
-            address_line2: None,
-            city: None,
-            state: None,
-            postal_code: None,
-            country: None,
-            notes: None,
-            portal_enabled: None,
-            tax_exempt: None,
-            payment_terms: None,
-            credit_limit_cents: None,
-            lead_source: None,
-            tags: None,
-        })
+        repo.create(
+            &CreateCustomer {
+                display_name: display_name.to_string(),
+                company_name: company_name.map(String::from),
+                email: email.map(String::from),
+                phone: None,
+                address_line1: None,
+                address_line2: None,
+                city: None,
+                state: None,
+                postal_code: None,
+                country: None,
+                notes: None,
+                portal_enabled: None,
+                tax_exempt: None,
+                payment_terms: None,
+                credit_limit_cents: None,
+                lead_source: None,
+                tags: None,
+            },
+            &Actor::system(),
+        )
         .await
         .expect("create test customer")
     }
@@ -460,7 +471,7 @@ mod tests {
             .unwrap();
 
         let repo = SeaOrmCustomerRepo::new(db);
-        let result = repo.create(&sample_create()).await;
+        let result = repo.create(&sample_create(), &Actor::system()).await;
         assert!(
             result.is_err(),
             "create should fail when activity_log table is missing"
@@ -507,13 +518,14 @@ mod tests {
         let (db, _pool, _tmp) = test_db().await;
         let repo = SeaOrmCustomerRepo::new(db);
 
-        let customer = repo.create(&sample_create()).await.unwrap();
+        let actor = Actor::system();
+        let customer = repo.create(&sample_create(), &actor).await.unwrap();
 
         // First soft-delete succeeds
-        repo.soft_delete(&customer.id).await.unwrap();
+        repo.soft_delete(&customer.id, &actor).await.unwrap();
 
         // Second soft-delete should return NotFound
-        let result = repo.soft_delete(&customer.id).await;
+        let result = repo.soft_delete(&customer.id, &actor).await;
         assert!(
             matches!(result, Err(DomainError::NotFound { .. })),
             "double soft-delete should return NotFound, got: {result:?}"
@@ -524,8 +536,9 @@ mod tests {
     async fn test_empty_update_is_noop() {
         let (db, _pool, _tmp) = test_db().await;
         let repo = SeaOrmCustomerRepo::new(db);
+        let actor = Actor::system();
 
-        let customer = repo.create(&sample_create()).await.unwrap();
+        let customer = repo.create(&sample_create(), &actor).await.unwrap();
         let before = repo
             .find_by_id(&customer.id, IncludeDeleted::ExcludeDeleted)
             .await
@@ -533,7 +546,10 @@ mod tests {
             .unwrap();
 
         // Update with all None fields — should be a no-op
-        let after = repo.update(&customer.id, &empty_update()).await.unwrap();
+        let after = repo
+            .update(&customer.id, &empty_update(), &actor)
+            .await
+            .unwrap();
 
         assert_eq!(before.display_name, after.display_name);
         assert_eq!(before.company_name, after.company_name);

--- a/crates/db/tests/bdd_world/customer_steps.rs
+++ b/crates/db/tests/bdd_world/customer_steps.rs
@@ -1,5 +1,6 @@
 use cucumber::{given, then, when};
 use mokumo_core::activity::traits::ActivityLogRepository;
+use mokumo_core::actor::Actor;
 use mokumo_core::customer::traits::CustomerRepository;
 use mokumo_core::customer::{CreateCustomer, CustomerId, UpdateCustomer};
 use mokumo_core::pagination::PageParams;
@@ -75,7 +76,10 @@ async fn empty_database(_w: &mut DbWorld) {
 async fn customer_exists(w: &mut DbWorld, name: String) {
     let repo = customer_repo(w);
     let req = make_create_request(&name);
-    let customer = repo.create(&req).await.expect("failed to create customer");
+    let customer = repo
+        .create(&req, &Actor::system())
+        .await
+        .expect("failed to create customer");
     w.last_customer = Some(customer);
 }
 
@@ -107,7 +111,7 @@ async fn customer_exists_with_entries(w: &mut DbWorld, name: String, count: i32)
 async fn create_customer(w: &mut DbWorld, name: String) {
     let repo = customer_repo(w);
     let req = make_create_request(&name);
-    match repo.create(&req).await {
+    match repo.create(&req, &Actor::system()).await {
         Ok(customer) => w.last_customer = Some(customer),
         Err(e) => w.last_error = Some(e),
     }
@@ -119,7 +123,7 @@ async fn update_customer_name(w: &mut DbWorld, new_name: String) {
     let id = customer.id;
     let repo = customer_repo(w);
     let req = make_update_request(Some(&new_name));
-    match repo.update(&id, &req).await {
+    match repo.update(&id, &req, &Actor::system()).await {
         Ok(customer) => w.last_customer = Some(customer),
         Err(e) => w.last_error = Some(e),
     }
@@ -133,7 +137,7 @@ async fn soft_delete_customer(w: &mut DbWorld) {
         .expect("no customer to soft-delete");
     let id = customer.id;
     let repo = customer_repo(w);
-    match repo.soft_delete(&id).await {
+    match repo.soft_delete(&id, &Actor::system()).await {
         Ok(customer) => w.last_customer = Some(customer),
         Err(e) => w.last_error = Some(e),
     }
@@ -144,7 +148,7 @@ async fn update_nonexistent(w: &mut DbWorld) {
     let repo = customer_repo(w);
     let fake_id = CustomerId::generate();
     let req = make_update_request(Some("Should Not Exist"));
-    match repo.update(&fake_id, &req).await {
+    match repo.update(&fake_id, &req, &Actor::system()).await {
         Ok(customer) => w.last_customer = Some(customer),
         Err(e) => w.last_error = Some(e),
     }
@@ -153,23 +157,27 @@ async fn update_nonexistent(w: &mut DbWorld) {
 #[when("a customer is created, then updated, then soft-deleted")]
 async fn create_update_delete(w: &mut DbWorld) {
     let repo = customer_repo(w);
+    let actor = Actor::system();
 
     // Create
     let req = make_create_request("Lifecycle Corp");
-    let customer = repo.create(&req).await.expect("failed to create");
+    let customer = repo.create(&req, &actor).await.expect("failed to create");
     let id = customer.id;
     w.last_customer = Some(customer);
 
     // Update
     let update_req = make_update_request(Some("Lifecycle Corp Updated"));
     let customer = repo
-        .update(&id, &update_req)
+        .update(&id, &update_req, &actor)
         .await
         .expect("failed to update");
     w.last_customer = Some(customer);
 
     // Soft-delete
-    let customer = repo.soft_delete(&id).await.expect("failed to soft-delete");
+    let customer = repo
+        .soft_delete(&id, &actor)
+        .await
+        .expect("failed to soft-delete");
     w.last_customer = Some(customer);
 }
 

--- a/services/api/src/customer/mod.rs
+++ b/services/api/src/customer/mod.rs
@@ -2,6 +2,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::get;
 use axum::{Json, Router};
+use mokumo_core::actor::Actor;
 use mokumo_core::customer::service::CustomerService;
 use mokumo_core::customer::{CreateCustomer, Customer, CustomerId, UpdateCustomer};
 use mokumo_core::error::DomainError;
@@ -12,6 +13,7 @@ use mokumo_types::pagination::PaginatedList;
 use serde::Deserialize;
 
 use crate::SharedState;
+use crate::auth::AuthSessionType;
 use crate::error::AppError;
 use crate::pagination::PaginationParams;
 
@@ -70,6 +72,13 @@ fn customer_service(state: &SharedState) -> CustomerService<SeaOrmCustomerRepo> 
     CustomerService::new(SeaOrmCustomerRepo::new(state.db.clone()))
 }
 
+fn actor_from_session(auth_session: &AuthSessionType) -> Actor {
+    match &auth_session.user {
+        Some(user) => Actor::user(user.user.id.get()),
+        None => Actor::system(),
+    }
+}
+
 fn include_deleted_filter(flag: Option<bool>) -> IncludeDeleted {
     if flag.unwrap_or(false) {
         IncludeDeleted::IncludeDeleted
@@ -93,10 +102,12 @@ struct ListCustomersQuery {
 
 async fn create_customer(
     State(state): State<SharedState>,
+    auth_session: AuthSessionType,
     Json(req): Json<CreateCustomer>,
 ) -> Result<(StatusCode, Json<CustomerResponse>), AppError> {
+    let actor = actor_from_session(&auth_session);
     let svc = customer_service(&state);
-    let customer = svc.create(&req).await?;
+    let customer = svc.create(&req, &actor).await?;
     Ok((StatusCode::CREATED, Json(to_response(customer))))
 }
 
@@ -146,21 +157,25 @@ async fn list_customers(
 
 async fn update_customer(
     State(state): State<SharedState>,
+    auth_session: AuthSessionType,
     Path(id): Path<String>,
     Json(req): Json<UpdateCustomer>,
 ) -> Result<Json<CustomerResponse>, AppError> {
+    let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
     let svc = customer_service(&state);
-    let customer = svc.update(&customer_id, &req).await?;
+    let customer = svc.update(&customer_id, &req, &actor).await?;
     Ok(Json(to_response(customer)))
 }
 
 async fn delete_customer(
     State(state): State<SharedState>,
+    auth_session: AuthSessionType,
     Path(id): Path<String>,
 ) -> Result<Json<CustomerResponse>, AppError> {
+    let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
     let svc = customer_service(&state);
-    let customer = svc.soft_delete(&customer_id).await?;
+    let customer = svc.soft_delete(&customer_id, &actor).await?;
     Ok(Json(to_response(customer)))
 }

--- a/services/api/tests/bdd_world/activity_steps.rs
+++ b/services/api/tests/bdd_world/activity_steps.rs
@@ -55,18 +55,29 @@ async fn latest_action_should_be(w: &mut ApiWorld, expected: String) {
 
 #[then("the activity actor should be the authenticated user")]
 async fn activity_actor_should_be_authenticated_user(w: &mut ApiWorld) {
-    let resp = w.response.as_ref().expect("no response");
+    // Get the actual authenticated user's ID from /api/auth/me
+    let me_resp = w.server.get("/api/auth/me").await;
+    me_resp.assert_status(axum::http::StatusCode::OK);
+    let me_json: serde_json::Value = me_resp.json();
+    let expected_user_id = me_json["user"]["id"]
+        .as_i64()
+        .expect("user.id should be numeric");
+
+    let resp = w
+        .response
+        .as_ref()
+        .expect("no response — query activity first");
     let json: serde_json::Value = resp.json();
     let items = json["items"].as_array().expect("items should be an array");
     let latest = items.first().expect("no activity entries");
     let actor_id = latest["actor_id"].as_str().unwrap();
     let actor_type = latest["actor_type"].as_str().unwrap();
-    assert_ne!(actor_id, "system", "actor_id should not be 'system'");
-    assert_eq!(actor_type, "user", "actor_type should be 'user'");
-    assert!(
-        actor_id.parse::<i64>().is_ok(),
-        "actor_id should be a numeric user ID, got: {actor_id}"
+    assert_eq!(
+        actor_id,
+        expected_user_id.to_string(),
+        "actor_id should match the authenticated user's ID"
     );
+    assert_eq!(actor_type, "user", "actor_type should be 'user'");
 }
 
 #[then("the activity payload should contain the customer snapshot")]

--- a/services/api/tests/bdd_world/activity_steps.rs
+++ b/services/api/tests/bdd_world/activity_steps.rs
@@ -53,13 +53,20 @@ async fn latest_action_should_be(w: &mut ApiWorld, expected: String) {
     assert_eq!(latest["action"].as_str().unwrap(), expected);
 }
 
-#[then(expr = "the activity actor should be {string}")]
-async fn activity_actor_should_be(w: &mut ApiWorld, expected: String) {
+#[then("the activity actor should be the authenticated user")]
+async fn activity_actor_should_be_authenticated_user(w: &mut ApiWorld) {
     let resp = w.response.as_ref().expect("no response");
     let json: serde_json::Value = resp.json();
     let items = json["items"].as_array().expect("items should be an array");
     let latest = items.first().expect("no activity entries");
-    assert_eq!(latest["actor_id"].as_str().unwrap(), expected);
+    let actor_id = latest["actor_id"].as_str().unwrap();
+    let actor_type = latest["actor_type"].as_str().unwrap();
+    assert_ne!(actor_id, "system", "actor_id should not be 'system'");
+    assert_eq!(actor_type, "user", "actor_type should be 'user'");
+    assert!(
+        actor_id.parse::<i64>().is_ok(),
+        "actor_id should be a numeric user ID, got: {actor_id}"
+    );
 }
 
 #[then("the activity payload should contain the customer snapshot")]

--- a/services/api/tests/features/activity_log.feature
+++ b/services/api/tests/features/activity_log.feature
@@ -13,7 +13,7 @@ Feature: Activity log
     When I create a customer "Acme Corp"
     Then the activity log for that customer should have 1 entry
     And the latest activity action should be "created"
-    And the activity actor should be "system"
+    And the activity actor should be the authenticated user
     And the activity payload should contain the customer snapshot
 
   Scenario: Updating a customer logs an "updated" activity

--- a/services/api/tests/features/activity_log.feature
+++ b/services/api/tests/features/activity_log.feature
@@ -20,12 +20,14 @@ Feature: Activity log
     Given a customer "Acme Corp" exists
     When I update that customer's display name to "Acme Industries"
     Then the latest activity action for that customer should be "updated"
+    And the activity actor should be the authenticated user
     And the activity payload should reflect the updated name
 
   Scenario: Deleting a customer logs a "soft_deleted" activity
     Given a customer exists
     When I delete that customer
     Then the latest activity action for that customer should be "soft_deleted"
+    And the activity actor should be the authenticated user
 
   # --- Query endpoint ---
 


### PR DESCRIPTION
## Summary

- Adds `Actor` domain type in `crates/core/src/actor.rs` with `User`, `System`, and `ApiKey` variants
- Threads `Actor` through `CustomerRepository` trait → `CustomerService` → `SeaOrmCustomerRepo` so activity log entries record the authenticated user's ID and type
- Extracts `AuthSession` in customer mutation handlers to build `Actor::user(user_id)`
- Updates BDD assertion from hardcoded "system" to verify authenticated user ID

Closes #66

## Test plan

- [x] `moon run api:test` — 170/170 tests pass
- [x] `moon run api:lint` — clippy clean
- [x] `moon run api:fmt` — formatting clean
- [x] BDD: "Creating a customer logs a 'created' activity" now asserts `actor_type = "user"` and `actor_id` is a numeric user ID
- [x] Existing db-level tests use `Actor::system()` — backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)