### PR TITLE
feat(stack): bind to 0.0.0.0 by default for LAN access (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Default standalone server bind address from `0.0.0.0` to `127.0.0.1` (use `--host 0.0.0.0` for LAN access)
+- Default bind address to `0.0.0.0` (all interfaces) for both desktop and CLI — enables LAN access and mDNS registration by default (use `--host 127.0.0.1` for local-only)
 
 ### Fixed
 

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -17,7 +17,7 @@ struct ServerHandle(std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>
 /// `0.0.0.0` means "all interfaces" — valid for `bind()` but not routable.
 /// The webview always runs on the same machine, so rewrite to loopback.
 fn webview_host(bind_host: &str) -> &str {
-    if bind_host == "0.0.0.0" {
+    if bind_host == "0.0.0.0" || bind_host == "::" {
         "127.0.0.1"
     } else {
         bind_host
@@ -227,6 +227,7 @@ mod tests {
     #[test]
     fn wildcard_bind_rewrites_to_loopback_for_webview() {
         assert_eq!(webview_host("0.0.0.0"), "127.0.0.1");
+        assert_eq!(webview_host("::"), "127.0.0.1");
     }
 
     #[test]

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -4,6 +4,7 @@ use tauri::Manager;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;
 
+use mokumo_api::discovery::MdnsHandle;
 use mokumo_api::{ServerConfig, build_app_with_shutdown, discovery, ensure_data_dirs, try_bind};
 
 const DEFAULT_PORT: u16 = 6565;
@@ -11,6 +12,12 @@ const DEFAULT_HOST: &str = "0.0.0.0";
 
 /// Holds the server task handle so `ExitRequested` can await a clean drain.
 struct ServerHandle(std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>>>);
+
+/// Holds the mDNS handle + status so `ExitRequested` can deregister gracefully.
+struct MdnsState {
+    handle: std::sync::Mutex<Option<MdnsHandle>>,
+    status: discovery::SharedMdnsStatus,
+}
 
 /// Map the bind host to a routable address for the webview.
 ///
@@ -41,8 +48,17 @@ async fn init_server(
     port: u16,
     host: &str,
     shutdown: CancellationToken,
-) -> Result<(tokio::net::TcpListener, axum::Router, u16, Option<String>), Box<dyn std::error::Error>>
-{
+) -> Result<
+    (
+        tokio::net::TcpListener,
+        axum::Router,
+        u16,
+        Option<String>,
+        Option<MdnsHandle>,
+        discovery::SharedMdnsStatus,
+    ),
+    Box<dyn std::error::Error>,
+> {
     let config = ServerConfig {
         port,
         host: host.to_owned(),
@@ -90,14 +106,21 @@ async fn init_server(
     }
 
     // Register mDNS (skipped if bound to loopback, active on 0.0.0.0)
-    let _mdns_handle = discovery::register_mdns(
+    let mdns_handle = discovery::register_mdns(
         &config.host,
         actual_port,
         &mdns_status,
         &discovery::RealDiscovery,
     );
 
-    Ok((listener, app, actual_port, setup_token))
+    Ok((
+        listener,
+        app,
+        actual_port,
+        setup_token,
+        mdns_handle,
+        mdns_status,
+    ))
 }
 
 pub fn run() {
@@ -135,13 +158,17 @@ pub fn run() {
 
             let server_token = shutdown_token.clone();
 
-            let (listener, router, actual_port, setup_token) = tauri::async_runtime::block_on(
-                init_server(data_dir, DEFAULT_PORT, DEFAULT_HOST, shutdown_token.clone()),
-            )
-            .map_err(|e| {
-                tracing::error!("Server initialization failed: {e}");
-                e
-            })?;
+            let (listener, router, actual_port, setup_token, mdns_handle, mdns_status) =
+                tauri::async_runtime::block_on(init_server(
+                    data_dir,
+                    DEFAULT_PORT,
+                    DEFAULT_HOST,
+                    shutdown_token.clone(),
+                ))
+                .map_err(|e| {
+                    tracing::error!("Server initialization failed: {e}");
+                    e
+                })?;
 
             // Spawn the Axum server on Tauri's async runtime (NOT tokio::spawn)
             let server_handle = tauri::async_runtime::spawn(async move {
@@ -156,8 +183,12 @@ pub fn run() {
                 tracing::info!("Server shut down cleanly");
             });
 
-            // Store the handle so ExitRequested can await server drain
+            // Store handles so ExitRequested can deregister mDNS and await server drain
             app.manage(ServerHandle(std::sync::Mutex::new(Some(server_handle))));
+            app.manage(MdnsState {
+                handle: std::sync::Mutex::new(mdns_handle),
+                status: mdns_status,
+            });
 
             let url = initial_webview_url(DEFAULT_HOST, actual_port, setup_token.as_deref());
             let log_url = initial_webview_url(
@@ -183,6 +214,14 @@ pub fn run() {
         .run(move |app, event| {
             if let tauri::RunEvent::ExitRequested { api, .. } = &event {
                 tracing::info!("Exit requested, draining server...");
+
+                // Deregister mDNS BEFORE cancelling the token (matches CLI behavior)
+                if let Some(mdns) = app.try_state::<MdnsState>() {
+                    if let Some(handle) = mdns.handle.lock().ok().and_then(|mut h| h.take()) {
+                        discovery::deregister_mdns(handle, &mdns.status);
+                    }
+                }
+
                 exit_token.cancel();
 
                 // Take the server handle and await drain before allowing exit

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -7,12 +7,25 @@ use tracing_subscriber::EnvFilter;
 use mokumo_api::{ServerConfig, build_app_with_shutdown, discovery, ensure_data_dirs, try_bind};
 
 const DEFAULT_PORT: u16 = 6565;
-const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_HOST: &str = "0.0.0.0";
 
 /// Holds the server task handle so `ExitRequested` can await a clean drain.
 struct ServerHandle(std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>>>);
 
+/// Map the bind host to a routable address for the webview.
+///
+/// `0.0.0.0` means "all interfaces" — valid for `bind()` but not routable.
+/// The webview always runs on the same machine, so rewrite to loopback.
+fn webview_host(bind_host: &str) -> &str {
+    if bind_host == "0.0.0.0" {
+        "127.0.0.1"
+    } else {
+        bind_host
+    }
+}
+
 fn initial_webview_url(host: &str, port: u16, setup_token: Option<&str>) -> String {
+    let host = webview_host(host);
     let path = match setup_token {
         Some(token) => format!("/setup?setup_token={token}"),
         None => "/".to_string(),
@@ -52,7 +65,7 @@ async fn init_server(
     let pool = mokumo_db::initialize_database(&database_url).await?;
     tracing::info!("Database ready at {}", db_path.display());
 
-    // Pre-allocate mDNS status (desktop always uses loopback, so mDNS is always skipped)
+    // Pre-allocate mDNS status (will be populated after mDNS registration)
     let mdns_status = discovery::MdnsStatus::shared();
 
     let (app, setup_token) =
@@ -76,7 +89,7 @@ async fn init_server(
         s.bind_host = config.host.to_owned();
     }
 
-    // Register mDNS (will be skipped since DEFAULT_HOST is 127.0.0.1)
+    // Register mDNS (skipped if bound to loopback, active on 0.0.0.0)
     let _mdns_handle = discovery::register_mdns(
         &config.host,
         actual_port,
@@ -193,7 +206,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::initial_webview_url;
+    use super::{initial_webview_url, webview_host};
 
     #[test]
     fn setup_url_prefills_setup_token() {
@@ -208,6 +221,29 @@ mod tests {
         assert_eq!(
             initial_webview_url("127.0.0.1", 6565, None),
             "http://127.0.0.1:6565/"
+        );
+    }
+
+    #[test]
+    fn wildcard_bind_rewrites_to_loopback_for_webview() {
+        assert_eq!(webview_host("0.0.0.0"), "127.0.0.1");
+    }
+
+    #[test]
+    fn explicit_host_passes_through() {
+        assert_eq!(webview_host("127.0.0.1"), "127.0.0.1");
+        assert_eq!(webview_host("192.168.1.50"), "192.168.1.50");
+    }
+
+    #[test]
+    fn wildcard_bind_webview_url_uses_loopback() {
+        assert_eq!(
+            initial_webview_url("0.0.0.0", 6565, None),
+            "http://127.0.0.1:6565/"
+        );
+        assert_eq!(
+            initial_webview_url("0.0.0.0", 6565, Some("tok")),
+            "http://127.0.0.1:6565/setup?setup_token=tok"
         );
     }
 }

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -16,8 +16,8 @@ struct Cli {
     #[arg(short, long, default_value = "6565")]
     port: u16,
 
-    /// Address to bind to (defaults to localhost; use 0.0.0.0 for LAN access)
-    #[arg(long, default_value = "127.0.0.1")]
+    /// Address to bind to (defaults to all interfaces for LAN access; use 127.0.0.1 for local-only)
+    #[arg(long, default_value = "0.0.0.0")]
     host: String,
 
     /// Directory for application data (database, uploads)

--- a/services/api/tests/bdd_world/discovery_steps.rs
+++ b/services/api/tests/bdd_world/discovery_steps.rs
@@ -11,12 +11,16 @@ async fn server_started_with(w: &mut ApiWorld, flag: String) {
         w.mdns_host = "0.0.0.0".into();
         let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
         s.bind_host = "0.0.0.0".into();
+    } else if flag == "--host 127.0.0.1" {
+        w.mdns_host = "127.0.0.1".into();
+        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+        s.bind_host = "127.0.0.1".into();
     }
 }
 
 #[given("no CLI flags are provided")]
 async fn no_cli_flags(_w: &mut ApiWorld) {
-    // Default host is 127.0.0.1, already set in ApiWorld::new
+    // Default host is 0.0.0.0, already set in ApiWorld::new
 }
 
 #[given("mDNS registration will fail")]
@@ -151,7 +155,7 @@ async fn mdns_registered_as_hostname(w: &mut ApiWorld, hostname: String) {
 
 #[given("the server is started with default host")]
 async fn server_started_with_default_host(_w: &mut ApiWorld) {
-    // Default host is 127.0.0.1, already set in ApiWorld::new
+    // Default host is 0.0.0.0, already set in ApiWorld::new
 }
 
 #[given("mDNS registration has failed")]

--- a/services/api/tests/bdd_world/mod.rs
+++ b/services/api/tests/bdd_world/mod.rs
@@ -65,7 +65,7 @@ impl ApiWorld {
 
         let config = ServerConfig {
             port: 0,
-            host: "127.0.0.1".into(),
+            host: "0.0.0.0".into(),
             data_dir,
             recovery_dir: recovery_dir.clone(),
         };
@@ -111,7 +111,7 @@ impl ApiWorld {
             db,
             db_pool: pool,
             mdns_status,
-            mdns_host: "127.0.0.1".into(),
+            mdns_host: "0.0.0.0".into(),
             mdns_should_fail: false,
             setup_token,
             recovery_codes: Vec::new(),

--- a/services/api/tests/features/lan_discovery.feature
+++ b/services/api/tests/features/lan_discovery.feature
@@ -13,7 +13,7 @@ Feature: LAN Discovery
     And the service type is "_http._tcp"
 
   Scenario: Server skips LAN discovery when bound to localhost
-    Given no CLI flags are provided
+    Given the server is started with "--host 127.0.0.1"
     When the server starts
     Then mDNS is not registered
     And the log contains "mDNS registration skipped"
@@ -52,7 +52,7 @@ Feature: LAN Discovery
     And an IP-based URL is included as fallback
 
   Scenario: Server info reports LAN access disabled on localhost
-    Given the server is started with default host
+    Given the server is started with "--host 127.0.0.1"
     When a client requests the server info endpoint
     Then the response shows LAN access is disabled
     And the LAN URL is absent


### PR DESCRIPTION
## Summary

- Change default bind address from `127.0.0.1` to `0.0.0.0` in both Tauri desktop and CLI server, enabling LAN access and mDNS registration out of the box
- Add `webview_host()` to rewrite wildcard addresses (`0.0.0.0`, `::`) to `127.0.0.1` for the Tauri webview URL (wildcard is valid for `bind()` but not routable)
- Update comments and CHANGELOG to reflect new defaults

Closes #19

## Test plan

- [x] 5 desktop crate unit tests pass (3 new: wildcard rewrite, passthrough, integration)
- [x] 171/172 backend tests pass (1 pre-existing flaky unrelated to this change)
- [x] Clippy clean, svelte-check 0 errors
- [x] ATDD gates: CRAP PASS, Mutation PASS, Architecture PASS, Clean Arch Review PASS
- [x] Review: Code Reviewer PASS, Code Simplifier PASS, CEng APPROVE, CQO SHIP
- [ ] Manual: Two-device LAN test (Tauri + browser on second device)
- [ ] Manual: mDNS resolution from second device (`http://mokumo.local:6565`)
- [ ] Manual: WebSocket broadcast cross-device
- [ ] Manual: Session isolation (independent sessions on both devices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Default server bind address is now `0.0.0.0` (previously `127.0.0.1`), enabling LAN access and mDNS registration by default for both desktop and CLI
  * Desktop application webview automatically handles the new binding behavior
  * Use `--host 127.0.0.1` flag to restrict server access to local connections only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->