### PR TITLE
docs: tighten Codex repo guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,15 @@
 # Mokumo Agent Notes
 
-- For GitHub PR reviews and disposable review worktrees, use the global Codex skill `$pr-review-hygiene`.
-- The cross-repo reference note lives at `~/.codex/AGENTS.md`.
-- The executable global workflow lives at `~/.codex/skills/pr-review-hygiene`.
-- Invoke it explicitly when needed, for example: `Use $pr-review-hygiene to review PR #58.`
+- Use `$ops-conventions` whenever work here needs pipeline notes, board state, decision records, closeout logs, or other private ops artifacts in `/Users/cmbays/github/ops`.
+- Use `$pr-review-hygiene` for GitHub PR reviews and disposable review worktrees.
+- Cross-repo reference note: `~/.codex/AGENTS.md`.
+- Global skills: `~/.codex/skills/ops-conventions`, `~/.codex/skills/pr-review-hygiene`.
 - This repo uses a shared Cargo target directory via `.cargo/config.toml`; let worktrees inherit it normally.
 - Preserve any worktree the user identifies as active.
+
+## Repo Context
+
+- Architecture: Moon monorepo with `apps/web` (SvelteKit), `services/api` (Axum), `apps/desktop` (Tauri), `crates/core`, `crates/types`, and `crates/db`.
+- Testing: prefer repo tasks over ad hoc commands. `moon check --all` is the broadest validation path; `moon run web:test` covers frontend tests; `moon run api:test` covers backend tests. BDD suites live under `crates/core`, `crates/db`, and `services/api`; Playwright BDD coverage lives under `apps/web/tests`.
+- Quality context: `COVERAGE.md` documents `cargo-llvm-cov`; `tools/bdd-lint` enforces BDD spec and step-definition hygiene.
+- Safety: do not push directly to `main`, do not modify `.github/workflows/*` unless the task clearly requires CI changes, and keep private operational state in `ops`, not this repo.


### PR DESCRIPTION
## Summary
- add the Phase 3 `-conventions` trigger for private ops artifacts
- keep global skill references for Codex review and ops workflows
- add concise repo context for architecture, tests, and safety boundaries

## Testing
- not run (docs-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational guidance and expanded repository context documentation, including monorepo architecture overview, recommended testing commands, quality tooling references, and development safety guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->