### PR TITLE
fix(ci): remove explicit pnpm version from demo guide workflow

### DIFF
--- a/.github/workflows/demo-guide.yml
+++ b/.github/workflows/demo-guide.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- Removes `version: 10` from `pnpm/action-setup` in the demo guide workflow
- `pnpm/action-setup@v4` reads the version from root `package.json`'s `packageManager` field (`pnpm@10.6.5`), so specifying it explicitly causes a conflict error

Fixes the failing demo guide deployment from #150.

## Test plan

- [ ] Re-run demo guide workflow after merge — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)