### PR TITLE
fix(ci): use --ignore-workspace for demo guide pnpm install

### DIFF
--- a/.github/workflows/demo-guide.yml
+++ b/.github/workflows/demo-guide.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/demo-guide.yml
+++ b/.github/workflows/demo-guide.yml
@@ -31,7 +31,7 @@ jobs:
           cache-dependency-path: docs/demo-guide/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
         working-directory: docs/demo-guide
 
       - name: Build slides


### PR DESCRIPTION
## Summary

- Adds `--ignore-workspace` to `pnpm install` in the demo guide workflow
- Without it, pnpm walks up to the root workspace and installs there (`Scope: all 3 workspace projects`), leaving `docs/demo-guide/node_modules` empty
- This was the same flag used during local development (`pnpm install --ignore-workspace`)

## Test plan

- [ ] Demo guide workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)