### PR TITLE
refactor(stack): extract init_server return tuple into ServerInit struct

### DIFF
--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -19,6 +19,16 @@ struct MdnsState {
     status: discovery::SharedMdnsStatus,
 }
 
+/// Resources produced by `init_server`, consumed by Tauri setup.
+struct ServerInit {
+    listener: tokio::net::TcpListener,
+    router: axum::Router,
+    port: u16,
+    setup_token: Option<String>,
+    mdns_handle: Option<MdnsHandle>,
+    mdns_status: discovery::SharedMdnsStatus,
+}
+
 /// Map the bind host to a routable address for the webview.
 ///
 /// `0.0.0.0` means "all interfaces" — valid for `bind()` but not routable.
@@ -48,17 +58,7 @@ async fn init_server(
     port: u16,
     host: &str,
     shutdown: CancellationToken,
-) -> Result<
-    (
-        tokio::net::TcpListener,
-        axum::Router,
-        u16,
-        Option<String>,
-        Option<MdnsHandle>,
-        discovery::SharedMdnsStatus,
-    ),
-    Box<dyn std::error::Error>,
-> {
+) -> Result<ServerInit, Box<dyn std::error::Error>> {
     let config = ServerConfig {
         port,
         host: host.to_owned(),
@@ -84,7 +84,7 @@ async fn init_server(
     // Pre-allocate mDNS status (will be populated after mDNS registration)
     let mdns_status = discovery::MdnsStatus::shared();
 
-    let (app, setup_token) =
+    let (router, setup_token) =
         build_app_with_shutdown(&config, pool, shutdown, mdns_status.clone()).await;
 
     // Bind to port (with fallback)
@@ -113,14 +113,14 @@ async fn init_server(
         &discovery::RealDiscovery,
     );
 
-    Ok((
+    Ok(ServerInit {
         listener,
-        app,
-        actual_port,
+        router,
+        port: actual_port,
         setup_token,
         mdns_handle,
         mdns_status,
-    ))
+    })
 }
 
 pub fn run() {
@@ -158,17 +158,23 @@ pub fn run() {
 
             let server_token = shutdown_token.clone();
 
-            let (listener, router, actual_port, setup_token, mdns_handle, mdns_status) =
-                tauri::async_runtime::block_on(init_server(
-                    data_dir,
-                    DEFAULT_PORT,
-                    DEFAULT_HOST,
-                    shutdown_token.clone(),
-                ))
-                .map_err(|e| {
-                    tracing::error!("Server initialization failed: {e}");
-                    e
-                })?;
+            let ServerInit {
+                listener,
+                router,
+                port: actual_port,
+                setup_token,
+                mdns_handle,
+                mdns_status,
+            } = tauri::async_runtime::block_on(init_server(
+                data_dir,
+                DEFAULT_PORT,
+                DEFAULT_HOST,
+                shutdown_token.clone(),
+            ))
+            .map_err(|e| {
+                tracing::error!("Server initialization failed: {e}");
+                e
+            })?;
 
             // Spawn the Axum server on Tauri's async runtime (NOT tokio::spawn)
             let server_handle = tauri::async_runtime::spawn(async move {


### PR DESCRIPTION
## Summary

- Replace the 6-element tuple returned by `init_server()` in `apps/desktop/src/lib.rs` with a named `ServerInit` struct for readability and extensibility
- Rename local `app` binding to `router` to match struct field and actual Axum type
- No behavior change — all existing tests pass

## Context

Flagged during pipeline `mokumo/20260327-multi-client-lan-validation` closeout by CEng and CAO. The tuple was becoming unwieldy and would be untenable as M1 adds more startup resources.

Closes #145

## Test plan

- [x] `cargo check -p mokumo-desktop` — clean compile
- [x] `cargo test -p mokumo-desktop` — 5/5 tests pass
- [x] `cargo fmt` — formatting clean (verified by pre-commit hook)
- [x] Clippy clean (verified by pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)