### PR TITLE
feat: add M0 demo walkthrough content and help icon (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Slidev demo guide infrastructure (`docs/demo-guide/`) for interactive milestone walkthroughs
 - GitHub Pages deployment workflow for demo guide
+- Help icon with demo guide link in sidebar footer (popover with external link)
+- M0 demo walkthrough slides: 10 sections + 2 appendixes covering installation through LAN multi-client
+- `Checklist.vue` Slidev component for step-by-step checklists in slides
+- Getting Started section in README with download link and platform notes
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ moon run web:test             # Frontend tests
 moon check --all              # Full CI suite
 ```
 
+## Getting Started
+
+Mokumo is a self-hosted desktop application — download it, run it, and own your data.
+
+### What you'll need
+
+- A computer running **Windows 10+** or **macOS 12+**
+- A second device on the same WiFi network (for the LAN demo)
+
+### Download
+
+Grab the latest installer from [GitHub Releases](https://github.com/breezy-bays-labs/mokumo/releases).
+
+### Platform notes
+
+- **Windows**: SmartScreen may warn about an unrecognized publisher. Click **More info → Run anyway** to proceed.
+- **macOS**: Gatekeeper may block the app. Right-click the app and select **Open**, then confirm in the dialog.
+
+### Demo Guide
+
+Follow the interactive walkthrough to set up your shop and explore every feature:
+
+**[Open the Demo Guide →](https://breezy-bays-labs.github.io/mokumo/)**
+
 ## License
 
 [Business Source License 1.1](LICENSE) (BUSL-1.1). Free to use for your own shop. Cannot be offered as a competing hosted product. Converts to Apache 2.0 three years after each version's release.

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -7,8 +7,9 @@ const storybookTestDir = defineBddConfig({
 		'tests/features/**/*.feature',
 		'!tests/features/settings/**/*.feature',
 		'!tests/features/customers/**/*.feature',
+		'!tests/features/help-popover/**/*.feature',
 	],
-	steps: ['tests/steps/*.ts', '!tests/steps/settings-lan.steps.ts', 'tests/support/storybook.fixture.ts', 'tests/support/storybook.helpers.ts'],
+	steps: ['tests/steps/*.ts', '!tests/steps/settings-lan.steps.ts', '!tests/steps/help-popover.steps.ts', '!tests/steps/customer-*.steps.ts', 'tests/support/storybook.fixture.ts', 'tests/support/storybook.helpers.ts'],
 	tags: 'not @wip',
 });
 
@@ -17,10 +18,12 @@ const appTestDir = defineBddConfig({
 	features: [
 		'tests/features/settings/**/*.feature',
 		'tests/features/customers/**/*.feature',
+		'tests/features/help-popover/**/*.feature',
 	],
 	steps: [
 		'tests/steps/settings-lan.steps.ts',
 		'tests/steps/customer-*.steps.ts',
+		'tests/steps/help-popover.steps.ts',
 		'tests/support/app.fixture.ts',
 	],
 	importTestFrom: 'tests/support/app.fixture.ts',

--- a/apps/web/src/lib/components/app-sidebar.svelte
+++ b/apps/web/src/lib/components/app-sidebar.svelte
@@ -9,6 +9,8 @@
   import * as Sidebar from "$lib/components/ui/sidebar";
   import { useSidebar } from "$lib/components/ui/sidebar";
   import { mode, setMode } from "mode-watcher";
+  import { DEMO_GUIDE_URL } from "$lib/config/constants";
+  import CircleHelp from "@lucide/svelte/icons/circle-help";
   import LogOut from "@lucide/svelte/icons/log-out";
   import Moon from "@lucide/svelte/icons/moon";
   import Sun from "@lucide/svelte/icons/sun";
@@ -120,6 +122,45 @@
   </Sidebar.SidebarContent>
   <Sidebar.SidebarFooter>
     <Sidebar.SidebarMenu>
+      <Sidebar.SidebarMenuItem>
+        <Popover.Root>
+          <Popover.Trigger>
+            <Sidebar.SidebarMenuButton
+              tooltipContent="Help"
+              data-testid="help-trigger"
+            >
+              <CircleHelp class="size-4" />
+              <span class="group-data-[collapsible=icon]:hidden">Help</span>
+            </Sidebar.SidebarMenuButton>
+          </Popover.Trigger>
+          <Popover.Content
+            side="top"
+            align="start"
+            class="w-64 p-4"
+            data-testid="help-popover"
+          >
+            <h3 class="text-sm font-semibold">Demo Guide</h3>
+            <p class="mt-1 text-xs text-muted-foreground">
+              Step-by-step walkthrough for setting up and exploring your shop.
+            </p>
+            <a
+              href={DEMO_GUIDE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="mt-3 inline-flex w-full items-center justify-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              data-testid="open-demo-guide"
+            >
+              Open Demo Guide
+            </a>
+            <p
+              class="mt-2 text-xs text-muted-foreground"
+              data-testid="internet-note"
+            >
+              Requires internet connection
+            </p>
+          </Popover.Content>
+        </Popover.Root>
+      </Sidebar.SidebarMenuItem>
       <Sidebar.SidebarMenuItem>
         <Popover.Root>
           <Popover.Trigger

--- a/apps/web/src/lib/config/constants.ts
+++ b/apps/web/src/lib/config/constants.ts
@@ -1,0 +1,1 @@
+export const DEMO_GUIDE_URL = "https://breezy-bays-labs.github.io/mokumo/";

--- a/apps/web/tests/features/help-popover/help-popover.feature
+++ b/apps/web/tests/features/help-popover/help-popover.feature
@@ -1,0 +1,47 @@
+Feature: Help popover in sidebar footer
+
+  The sidebar footer contains a help icon that opens a popover with a link
+  to the external demo guide. The help icon is separate from the nav-items
+  contract — it triggers an external browser navigation, not SPA routing.
+
+  # --- Visibility ---
+
+  Scenario: Help icon is visible in the sidebar footer
+    Given the app shell is loaded
+    Then the sidebar footer displays a help icon before the user avatar
+
+  Scenario: Help icon shows tooltip on hover when collapsed
+    Given the sidebar is collapsed to icon rail
+    When I hover over the help icon
+    Then a tooltip shows "Help"
+
+  Scenario: Help icon is visible when sidebar is collapsed
+    Given the sidebar is collapsed to icon rail
+    Then the help icon is still visible in the footer
+
+  # --- Popover ---
+
+  Scenario: Clicking the help icon opens a popover
+    Given the app shell is loaded
+    When I click the help icon
+    Then a help popover appears
+    And the popover heading is "Demo Guide"
+    And the popover contains an "Open Demo Guide" button
+    And the popover shows a "Requires internet" note
+
+  Scenario: Popover closes when clicking outside
+    Given the help popover is open
+    When I click outside the popover
+    Then the help popover closes
+
+  Scenario: Popover closes on Escape key
+    Given the help popover is open
+    When I press Escape on the help popover
+    Then the help popover closes
+
+  # --- External Navigation ---
+
+  Scenario: Open Demo Guide button opens the guide in a new tab
+    Given the help popover is open
+    When I click the Open Demo Guide link
+    Then a new browser tab opens with the demo guide URL

--- a/apps/web/tests/steps/help-popover.steps.ts
+++ b/apps/web/tests/steps/help-popover.steps.ts
@@ -1,0 +1,103 @@
+import { expect, type Page } from "@playwright/test";
+import { Given, Then, When } from "../support/app.fixture";
+import { DEMO_GUIDE_URL } from "../../src/lib/config/constants";
+
+const HELP_TRIGGER = "[data-testid='help-trigger']";
+const HELP_POPOVER = "[data-testid='help-popover']";
+
+// --- Shared setup ---
+
+async function loadAppShell(page: Page, appUrl: string) {
+  await page.goto(appUrl);
+  await expect(page.locator("[data-sidebar='sidebar']")).toBeVisible({ timeout: 10_000 });
+}
+
+async function openHelpPopover(page: Page, appUrl: string) {
+  await loadAppShell(page, appUrl);
+  await page.locator(HELP_TRIGGER).click();
+  await expect(page.locator(HELP_POPOVER)).toBeVisible();
+}
+
+// --- Visibility ---
+
+Given("the app shell is loaded", async ({ appUrl, page }) => {
+  await loadAppShell(page, appUrl);
+});
+
+Then("the sidebar footer displays a help icon before the user avatar", async ({ page }) => {
+  const footer = page.locator("[data-sidebar='footer']");
+  const menuItems = footer.locator("[data-sidebar='menu-item']");
+  const helpItem = menuItems.nth(0);
+  await expect(helpItem.locator(HELP_TRIGGER)).toBeVisible();
+});
+
+When("I hover over the help icon", async ({ page }) => {
+  await page.locator(HELP_TRIGGER).hover();
+});
+
+Then("a tooltip shows {string}", async ({ page }, text: string) => {
+  await expect(page.locator("[data-slot='tooltip-content']").getByText(text)).toBeVisible({
+    timeout: 5_000,
+  });
+});
+
+Given("the sidebar is collapsed to icon rail", async ({ appUrl, page }) => {
+  await loadAppShell(page, appUrl);
+  const rail = page.locator("[data-sidebar='rail']");
+  await rail.click();
+  await expect(page.locator("[data-slot='sidebar']")).toHaveAttribute("data-state", "collapsed");
+});
+
+Then("the help icon is still visible in the footer", async ({ page }) => {
+  await expect(page.locator(HELP_TRIGGER)).toBeVisible();
+});
+
+// --- Popover ---
+
+When("I click the help icon", async ({ page }) => {
+  await page.locator(HELP_TRIGGER).click();
+});
+
+Then("a help popover appears", async ({ page }) => {
+  await expect(page.locator(HELP_POPOVER)).toBeVisible();
+});
+
+Then("the popover heading is {string}", async ({ page }, heading: string) => {
+  await expect(page.locator(HELP_POPOVER).getByText(heading).first()).toBeVisible();
+});
+
+Then("the popover contains an {string} button", async ({ page }, buttonText: string) => {
+  await expect(page.locator(HELP_POPOVER).getByRole("link", { name: buttonText })).toBeVisible();
+});
+
+Then("the popover shows a {string} note", async ({ page }, noteText: string) => {
+  await expect(page.locator("[data-testid='internet-note']")).toContainText(noteText);
+});
+
+Given("the help popover is open", async ({ appUrl, page }) => {
+  await openHelpPopover(page, appUrl);
+});
+
+When("I click outside the popover", async ({ page }) => {
+  await page.locator("body").click({ position: { x: 0, y: 0 } });
+});
+
+Then("the help popover closes", async ({ page }) => {
+  await expect(page.locator(HELP_POPOVER)).not.toBeVisible();
+});
+
+When("I press Escape on the help popover", async ({ page }) => {
+  await page.keyboard.press("Escape");
+});
+
+// --- External Navigation ---
+
+When("I click the Open Demo Guide link", async ({ page }) => {
+  await page.locator(HELP_POPOVER).getByRole("link", { name: "Open Demo Guide" }).click();
+});
+
+Then("a new browser tab opens with the demo guide URL", async ({ page }) => {
+  const link = page.locator("[data-testid='open-demo-guide']");
+  await expect(link).toHaveAttribute("href", DEMO_GUIDE_URL);
+  await expect(link).toHaveAttribute("target", "_blank");
+});

--- a/docs/demo-guide/components/Checklist.vue
+++ b/docs/demo-guide/components/Checklist.vue
@@ -1,0 +1,11 @@
+<script setup>
+defineProps<{ items: string[] }>()
+</script>
+<template>
+  <ul class="my-4 space-y-2 text-sm">
+    <li v-for="item in items" :key="item" class="flex items-center gap-2">
+      <span class="text-green-500 text-lg">✓</span>
+      <span>{{ item }}</span>
+    </li>
+  </ul>
+</template>

--- a/docs/demo-guide/slides/m0.md
+++ b/docs/demo-guide/slides/m0.md
@@ -4,23 +4,778 @@ layout: intro
 
 # M0: Foundation
 
-Self-Hosted Stack Walkthrough
+## Self-Hosted Stack Walkthrough
+
+Set up Mokumo on your machine and take the full tour:
+
+- Install the desktop application
+- Run the setup wizard and create your admin account
+- Navigate the app shell and key features
+- Create, edit, and manage customer records
+- Connect a second device over LAN
+- See real-time sync in action
+
+---
+layout: section
+---
+
+# Installation
+
+Platform-specific setup for Windows and macOS
 
 ---
 
-## What You'll Set Up
+## Installation — Windows
 
-- Mokumo desktop application (Tauri)
-- Initial admin account via setup wizard
-- LAN access from a second device
-- Your first customer record
+Download the latest `.exe` installer from GitHub Releases.
 
-> Full walkthrough content coming in #143
+<!-- SCREENSHOT: screenshots/m0/01-github-releases-windows.png -->
+
+<v-click>
+
+**Step 1:** Locate the downloaded `.exe` and double-click to run.
+
+</v-click>
+<v-click>
+
+**Step 2:** Windows SmartScreen may block the installer.
+
+Click **"More info"** on the SmartScreen dialog, then click **"Run anyway"**.
+
+<!-- SCREENSHOT: screenshots/m0/02-smartscreen-more-info.png -->
+
+</v-click>
+<v-click>
+
+**Step 3:** Follow the NSIS installer prompts — accept defaults.
+
+<!-- SCREENSHOT: screenshots/m0/03-nsis-installer.png -->
+
+</v-click>
+<v-click>
+
+**Step 4:** Launch Mokumo from the Start Menu or desktop shortcut.
+
+Verify the setup wizard appears.
+
+<!-- SCREENSHOT: screenshots/m0/04-windows-setup-wizard.png -->
+
+</v-click>
+
+<!--
+Presenter notes:
+- SmartScreen appears because the binary is not yet code-signed. This is expected for early releases.
+- If SmartScreen does not show "More info", the user may need to right-click the .exe → Properties → Unblock.
+- NSIS installer places the binary in Program Files by default. No admin rights required for per-user install.
+- Appendix B has deeper troubleshooting for edge cases.
+-->
 
 ---
 
-## Ready?
+## Installation — macOS
 
-Launch the Mokumo app and follow along.
+Download the latest `.dmg` from GitHub Releases.
 
-→ Next milestone slides will be added as `slides/m1.md`, `slides/m2.md`, etc.
+<!-- SCREENSHOT: screenshots/m0/05-github-releases-macos.png -->
+
+<v-click>
+
+**Step 1:** Open the `.dmg` and drag Mokumo to your Applications folder.
+
+<!-- SCREENSHOT: screenshots/m0/06-dmg-drag-to-applications.png -->
+
+</v-click>
+<v-click>
+
+**Step 2:** Double-click to launch. macOS Gatekeeper will block it.
+
+Instead, **right-click** the app icon and choose **"Open"** from the context menu.
+
+<!-- SCREENSHOT: screenshots/m0/07-gatekeeper-right-click-open.png -->
+
+</v-click>
+<v-click>
+
+**Step 3:** Click **"Open"** on the confirmation dialog.
+
+macOS remembers this choice — future launches work normally.
+
+<!-- SCREENSHOT: screenshots/m0/08-gatekeeper-confirm-open.png -->
+
+</v-click>
+<v-click>
+
+**Step 4:** Verify the setup wizard appears.
+
+<!-- SCREENSHOT: screenshots/m0/09-macos-setup-wizard.png -->
+
+</v-click>
+
+<!--
+Presenter notes:
+- Gatekeeper blocks because the app is not notarized yet. Right-click → Open is the standard bypass.
+- If the user gets "damaged" errors, they may need to run: xattr -cr /Applications/Mokumo.app
+- On Apple Silicon Macs, Rosetta is NOT required — the binary is universal.
+- Appendix B covers the quarantine attribute removal in detail.
+-->
+
+---
+layout: section
+---
+
+# Setup Wizard + Login
+
+Create your shop identity and admin account
+
+---
+
+## Setup Wizard — Shop Name
+
+When Mokumo launches for the first time, the setup wizard appears.
+
+<!-- SCREENSHOT: screenshots/m0/10-setup-wizard-shop-name.png -->
+
+<v-click>
+
+**Enter your shop name.** This becomes the display name throughout the app and the mDNS hostname for LAN discovery.
+
+</v-click>
+<v-click>
+
+Click **"Next"** to proceed to password creation.
+
+</v-click>
+
+---
+
+## Setup Wizard — Admin Password
+
+Choose a strong password for your admin account.
+
+<!-- SCREENSHOT: screenshots/m0/11-setup-wizard-password.png -->
+
+<v-click>
+
+This is the only account created during setup. Additional users come in a later milestone.
+
+</v-click>
+<v-click>
+
+Click **"Next"** to generate your recovery code.
+
+</v-click>
+
+---
+
+## Setup Wizard — Recovery Code
+
+A one-time recovery code is generated and displayed in a two-column layout.
+
+<!-- SCREENSHOT: screenshots/m0/12-setup-wizard-recovery-code.png -->
+
+<v-click>
+
+The left column displays the code. The right column provides two actions:
+
+- **Download** — saves the code as a `.txt` file
+- **Print** — opens the system print dialog
+
+</v-click>
+<v-click>
+
+**Save this code now.** It is the only way to recover your account if you forget your password.
+
+Once you leave this screen, the code cannot be displayed again.
+
+</v-click>
+<v-click>
+
+Click **"Complete Setup"** to finalize.
+
+</v-click>
+
+<!--
+Presenter notes:
+- The recovery code screen uses a 2-column grid: code display on the left, download/print buttons on the right.
+- The code is generated server-side and stored as a bcrypt hash — the plaintext is shown only once.
+- Emphasize that users MUST save the code before proceeding. There is no "show again" option.
+- The three-tier password reset strategy (recovery code → admin reset → factory reset) is an M0 design decision.
+-->
+
+---
+
+## First Login
+
+After setup completes, you are redirected to the login screen.
+
+<!-- SCREENSHOT: screenshots/m0/13-login-screen.png -->
+
+<v-click>
+
+Enter the password you just created and click **"Sign In"**.
+
+</v-click>
+<v-click>
+
+You are now logged in as the shop admin. The main dashboard loads.
+
+<!-- SCREENSHOT: screenshots/m0/14-dashboard-after-login.png -->
+
+</v-click>
+
+---
+layout: section
+---
+
+# App Shell Tour
+
+Navigation, layout, and empty states
+
+---
+
+## App Shell — Sidebar Navigation
+
+The sidebar is the primary navigation element.
+
+<!-- SCREENSHOT: screenshots/m0/15-sidebar-navigation.png -->
+
+<v-click>
+
+Navigation items visible in M0:
+
+- **Dashboard** — landing page with summary cards
+- **Customers** — customer management
+- **Activity** — system-wide activity log
+- **Settings** — application configuration
+
+</v-click>
+<v-click>
+
+The sidebar collapses on smaller viewports for responsive use.
+
+<!-- SCREENSHOT: screenshots/m0/16-sidebar-collapsed.png -->
+
+</v-click>
+
+---
+
+## App Shell — Empty States
+
+Before any data exists, each section shows a purposeful empty state.
+
+<!-- SCREENSHOT: screenshots/m0/17-empty-state-customers.png -->
+
+<v-click>
+
+Empty states include:
+
+- A clear description of what the section does
+- A prominent call-to-action to create the first record
+
+</v-click>
+<v-click>
+
+The theme switcher (light/dark) is accessible from the settings or the sidebar footer.
+
+<!-- SCREENSHOT: screenshots/m0/18-theme-switcher.png -->
+
+</v-click>
+
+---
+layout: section
+---
+
+# Customer Management
+
+Create, view, edit, search, and filter customer records
+
+---
+
+## Create a Customer
+
+Navigate to **Customers** and click the **"New Customer"** button.
+
+<!-- SCREENSHOT: screenshots/m0/19-new-customer-button.png -->
+
+<v-click>
+
+Fill in the customer form:
+
+- **Name** (required)
+- **Email** (optional)
+- **Phone** (optional)
+- **Notes** (optional)
+
+</v-click>
+<v-click>
+
+Click **"Save"** to create the record.
+
+<!-- SCREENSHOT: screenshots/m0/20-customer-form-filled.png -->
+
+</v-click>
+
+---
+
+## Customer Detail View
+
+After creation, you land on the customer detail page.
+
+<!-- SCREENSHOT: screenshots/m0/21-customer-detail.png -->
+
+<v-click>
+
+The detail view shows:
+
+- All customer fields
+- Creation and last-updated timestamps
+- Activity log entries for this customer
+- Edit and delete actions
+
+</v-click>
+
+---
+
+## Edit a Customer
+
+Click **"Edit"** on the customer detail page.
+
+<!-- SCREENSHOT: screenshots/m0/22-customer-edit.png -->
+
+<v-click>
+
+Modify any field and click **"Save"**.
+
+The activity log automatically records the change with the authenticated user as the actor.
+
+</v-click>
+
+---
+
+## Search and Filter
+
+Return to the customer list. Use the search bar to filter by name.
+
+<!-- SCREENSHOT: screenshots/m0/23-customer-search.png -->
+
+<v-click>
+
+Filters update the URL query parameters — bookmarkable and shareable across devices.
+
+</v-click>
+<v-click>
+
+The KPI cards above the list show summary metrics:
+
+- **Total Customers**
+- **Active Customers**
+- **Recently Added** (last 30 days)
+
+<!-- SCREENSHOT: screenshots/m0/24-customer-kpi-cards.png -->
+
+</v-click>
+
+---
+
+## Customer Management — Checklist
+
+Verify you have completed these steps:
+
+<Checklist :items="[
+  'Created a new customer record',
+  'Viewed the customer detail page',
+  'Edited a customer field',
+  'Used search to filter the customer list',
+  'Reviewed KPI summary cards'
+]" />
+
+---
+layout: section
+---
+
+# Soft Delete & Restore
+
+Archive and recover customer records safely
+
+---
+
+## Soft Delete a Customer
+
+From the customer detail page, click **"Delete"**.
+
+<!-- SCREENSHOT: screenshots/m0/25-soft-delete-confirm.png -->
+
+<v-click>
+
+A confirmation dialog appears. Click **"Delete"** to confirm.
+
+The customer is soft-deleted — it is hidden from the default list but not permanently removed.
+
+</v-click>
+<v-click>
+
+The activity log records the deletion with your user as the actor.
+
+</v-click>
+
+---
+
+## Show Deleted Customers
+
+On the customer list, toggle **"Show deleted"**.
+
+<!-- SCREENSHOT: screenshots/m0/26-show-deleted-toggle.png -->
+
+<v-click>
+
+Deleted customers appear with a visual indicator (muted styling, "Deleted" badge).
+
+</v-click>
+
+---
+
+## Restore a Customer
+
+Click into a deleted customer and click **"Restore"**.
+
+<!-- SCREENSHOT: screenshots/m0/27-restore-customer.png -->
+
+<v-click>
+
+The customer returns to the active list. The activity log records the restoration.
+
+</v-click>
+
+---
+
+## Soft Delete & Restore — Checklist
+
+<Checklist :items="[
+  'Soft-deleted a customer record',
+  'Toggled Show deleted to see archived records',
+  'Restored a deleted customer',
+  'Verified activity log entries for delete and restore'
+]" />
+
+---
+layout: section
+---
+
+# Activity Log
+
+Track every change across the system
+
+---
+
+## View Activity Entries
+
+Navigate to **Activity** in the sidebar.
+
+<!-- SCREENSHOT: screenshots/m0/28-activity-log-list.png -->
+
+<v-click>
+
+Each entry shows:
+
+- **Action** — created, updated, deleted, restored
+- **Entity type** — customer (more types in future milestones)
+- **Actor** — the authenticated user who made the change
+- **Timestamp** — when the action occurred
+
+</v-click>
+
+---
+
+## Filter by Entity Type
+
+Use the entity type filter to narrow results.
+
+<!-- SCREENSHOT: screenshots/m0/29-activity-filter-entity.png -->
+
+<v-click>
+
+In M0, only "Customer" entries exist. As more verticals ship (garments, quotes, invoices), this filter becomes essential.
+
+</v-click>
+
+---
+
+## Activity Log — Checklist
+
+<Checklist :items="[
+  'Viewed the global activity log',
+  'Identified entries for create, update, delete, and restore actions',
+  'Filtered activity entries by entity type'
+]" />
+
+---
+layout: section
+---
+
+# LAN Access
+
+Connect a second device on the same network
+
+---
+
+## Connect a Second Device
+
+Open a browser on a phone, tablet, or second computer connected to the same WiFi network.
+
+<!-- SCREENSHOT: screenshots/m0/30-lan-second-device.png -->
+
+<v-click>
+
+Navigate to:
+
+```
+http://{your-shop-name}.local:{port}
+```
+
+Replace `{your-shop-name}` with the shop name you entered during setup (lowercased, spaces replaced with hyphens). The port is displayed in the Mokumo app's status bar.
+
+</v-click>
+<v-click>
+
+The login screen appears. Sign in with your admin credentials.
+
+</v-click>
+<v-click>
+
+You now have the full Mokumo interface on a second device — no internet required.
+
+</v-click>
+
+<!--
+Presenter notes:
+- mDNS discovery uses the mdns-sd crate. The shop name becomes the hostname: "Cool Prints" → cool-prints.local
+- The port is shown in the app status bar and defaults to 3000. If 3000 is in use, it auto-increments.
+- mDNS works on most home and office networks. Corporate networks with client isolation may block it.
+- If mDNS fails, use the IP address directly (shown in the app status bar). See Appendix A.
+- iOS Safari and Android Chrome both work. Firefox on Android may have mDNS issues.
+-->
+
+---
+layout: section
+---
+
+# WebSocket Live Updates
+
+Real-time sync between devices
+
+---
+
+## Live Sync Demo
+
+With two devices connected:
+
+<!-- SCREENSHOT: screenshots/m0/31-two-devices-side-by-side.png -->
+
+<v-click>
+
+**On Device A:** Create a new customer record.
+
+</v-click>
+<v-click>
+
+**On Device B:** Watch the customer list — the new record appears automatically without refreshing.
+
+<!-- SCREENSHOT: screenshots/m0/32-websocket-new-customer-appears.png -->
+
+</v-click>
+<v-click>
+
+This works for all mutations: create, edit, delete, and restore. Changes propagate in real time via WebSocket.
+
+</v-click>
+
+<!--
+Presenter notes:
+- The WebSocket connection is established on page load and maintained as long as the tab is open.
+- If the connection drops (device sleeps, network change), it auto-reconnects and fetches missed updates.
+- In M0, the update payload triggers a full list refetch. Granular patching comes in a later milestone.
+- Latency on a local network is typically under 50ms — changes feel instant.
+-->
+
+---
+layout: section
+---
+
+# Settings + Next Steps
+
+Configuration and your call to action
+
+---
+
+## Settings Page
+
+Navigate to **Settings** in the sidebar.
+
+<!-- SCREENSHOT: screenshots/m0/33-settings-page.png -->
+
+<v-click>
+
+Available settings in M0:
+
+- **Shop name** — update your display name
+- **Theme** — switch between light and dark mode
+- **About** — version info and license details
+
+</v-click>
+<v-click>
+
+More settings (user management, backup/restore, Cloudflare Tunnel) arrive in future milestones.
+
+</v-click>
+
+---
+
+## What's Next
+
+You have completed the M0 Foundation walkthrough.
+
+<v-click>
+
+**Your call to action:** Create your first real customer records. Enter the customers you work with today — names, emails, phone numbers.
+
+</v-click>
+<v-click>
+
+Building real data now means you are ready when M1 ships garment tracking, multi-user support, and Cloudflare Tunnel for remote access.
+
+</v-click>
+<v-click>
+
+<Checklist :items="[
+  'Installed Mokumo on your platform',
+  'Completed the setup wizard',
+  'Created and managed customer records',
+  'Tested soft delete and restore',
+  'Reviewed the activity log',
+  'Connected a second device over LAN',
+  'Verified real-time sync via WebSocket'
+]" />
+
+</v-click>
+
+---
+layout: section
+---
+
+# Appendices
+
+Reference material and troubleshooting
+
+---
+
+## Appendix A: LAN Troubleshooting
+
+If you cannot reach Mokumo from a second device:
+
+<v-click>
+
+**1. Same WiFi Network**
+
+Both devices must be on the same network. Guest networks and hotspots often isolate clients.
+
+</v-click>
+<v-click>
+
+**2. Firewall Rules**
+
+The Mokumo port (default 3000) must be allowed through your OS firewall.
+
+- **Windows:** Check Windows Defender Firewall → Allow an app → Mokumo
+- **macOS:** System Settings → Network → Firewall → allow incoming connections for Mokumo
+
+</v-click>
+<v-click>
+
+**3. mDNS Not Resolving**
+
+If `{shop}.local` does not resolve, use the IP address directly:
+
+```
+http://192.168.x.x:{port}
+```
+
+Find the IP in the Mokumo status bar or run `ipconfig` (Windows) / `ifconfig` (macOS) in a terminal.
+
+</v-click>
+<v-click>
+
+**4. Browser Compatibility**
+
+- iOS Safari and Android Chrome work reliably
+- Firefox on Android may not resolve `.local` addresses — use the IP fallback
+- Desktop browsers all work
+
+</v-click>
+
+---
+
+## Appendix B: Platform Install Details — Windows
+
+**Installer type:** NSIS (Nullsoft Scriptable Install System)
+
+<v-click>
+
+**SmartScreen behavior:**
+
+- Appears on first run because the binary is unsigned
+- Click "More info" → "Run anyway"
+- If "More info" does not appear: right-click the `.exe` → Properties → check "Unblock" → Apply
+
+</v-click>
+<v-click>
+
+**Install location:** `C:\Program Files\Mokumo\` (default) or per-user install if no admin rights
+
+**Uninstall:** Control Panel → Programs → Uninstall → Mokumo
+
+</v-click>
+<v-click>
+
+**Antivirus false positives:**
+
+Some antivirus tools flag unsigned Tauri binaries. Add an exception for the Mokumo install directory if this occurs.
+
+</v-click>
+
+---
+
+## Appendix B: Platform Install Details — macOS
+
+**Installer type:** `.dmg` disk image with drag-to-Applications
+
+<v-click>
+
+**Gatekeeper bypass:**
+
+- Right-click the app → "Open" → confirm on the dialog
+- macOS remembers the choice — subsequent launches work normally
+
+</v-click>
+<v-click>
+
+**Quarantine attribute:**
+
+If you see "Mokumo is damaged and can't be opened", the quarantine extended attribute is stuck. Remove it:
+
+```bash
+xattr -cr /Applications/Mokumo.app
+```
+
+Then relaunch normally.
+
+</v-click>
+<v-click>
+
+**Architecture:** Universal binary — runs natively on both Intel and Apple Silicon. No Rosetta required.
+
+</v-click>
+<v-click>
+
+**Uninstall:** Drag Mokumo from Applications to Trash. App data lives in `~/Library/Application Support/Mokumo/` — delete that folder to remove all data.
+
+</v-click>


### PR DESCRIPTION
## Summary

- Add help icon with popover in sidebar footer linking to the external demo guide
- Replace Slidev m0.md placeholder with full 10-section + 2-appendix walkthrough (781 lines)
- Create `Checklist.vue` Slidev component for step-by-step verification lists
- Add Getting Started section to README with download link and platform notes

## Commits

1. `chore(web)`: Constants + playwright routing foundation
2. `feat(web)`: Help icon + popover + 7 BDD scenarios (all green)
3. `docs`: Slidev M0 walkthrough slides
4. `docs`: README Getting Started + changelog

## Test plan

- [x] `moon run web:check` — 0 errors, 0 warnings
- [x] `playwright test --project=app --grep help-popover` — 7/7 passed
- [x] No Gary/4Ink references in any deliverable
- [ ] `pnpm dev` in `docs/demo-guide/` — verify slides render and Checklist component works
- [ ] Verify README renders correctly on GitHub

## Follow-ups

- #144 — Screenshot capture with Playwright (replaces `<!-- SCREENSHOT -->` placeholders)

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)