### PR TITLE
fix(web): clipboard fallback for HTTP and consolidate LAN URL cards

### DIFF
--- a/apps/web/src/lib/components/copyable-url.svelte
+++ b/apps/web/src/lib/components/copyable-url.svelte
@@ -11,13 +11,27 @@
 
   let { url, label, testId }: Props = $props();
 
+  function fallbackCopy(text: string): boolean {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      return document.execCommand("copy");
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+
   async function copyUrl() {
     try {
       await navigator.clipboard.writeText(url);
       toast.success("URL copied to clipboard");
     } catch {
-      if (!window.isSecureContext) {
-        toast.error("Clipboard requires HTTPS — copy the URL manually");
+      if (fallbackCopy(url)) {
+        toast.success("URL copied to clipboard");
       } else {
         toast.error("Failed to copy URL");
       }

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -39,7 +39,7 @@
     <p class="text-sm text-muted-foreground">Powered by Mokumo</p>
   </div>
 
-  <div class="grid gap-4 md:grid-cols-3">
+  <div class="grid gap-4 md:grid-cols-2">
     <Card.Card>
       <Card.CardHeader class="pb-2">
         <Card.CardTitle class="text-sm font-medium"
@@ -68,23 +68,6 @@
       </Card.CardHeader>
       <Card.CardContent>
         <p class="text-sm">{version || "—"}</p>
-      </Card.CardContent>
-    </Card.Card>
-
-    <Card.Card>
-      <Card.CardHeader class="pb-2">
-        <Card.CardTitle class="text-sm font-medium">LAN URL</Card.CardTitle>
-      </Card.CardHeader>
-      <Card.CardContent>
-        {#if displayUrl}
-          <CopyableUrl
-            url={displayUrl}
-            label="Copy LAN URL to clipboard"
-            testId="copy-lan-url"
-          />
-        {:else}
-          <p class="text-sm">—</p>
-        {/if}
       </Card.CardContent>
     </Card.Card>
   </div>


### PR DESCRIPTION
## Summary

- Add textarea+execCommand fallback for clipboard copy on HTTP (LAN) connections where the Clipboard API is blocked
- Remove redundant "LAN URL" status card from dashboard — the "Connect Your Team" card already displays the same URL with copy functionality

Follow-up fix from smoke testing #146.

## Test plan

- [x] 12 onboarding BDD scenarios pass
- [x] Type-check clean
- [ ] Manual: access dashboard over LAN (HTTP) and click copy — should succeed with fallback
- [ ] Manual: verify only one card shows the LAN URL (Connect Your Team)

🤖 Generated with [Claude Code](https://claude.com/claude-code)