### PR TITLE
feat(test): 20 serial screenshot captures for M0 demo guide (#144)

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -84,9 +84,6 @@ export default defineConfig({
 			testDir: 'tests/demo-captures',
 			use: {
 				browserName: 'chromium',
-				viewport: { width: 1280, height: 720 },
-				colorScheme: 'dark',
-				deviceScaleFactor: 1,
 				screenshot: 'only-on-failure',
 				trace: 'retain-on-failure',
 			},

--- a/apps/web/tests/demo-captures/m0.spec.ts
+++ b/apps/web/tests/demo-captures/m0.spec.ts
@@ -1,11 +1,283 @@
-import { test, expect } from "../support/demo.fixture";
+import type { Page } from "@playwright/test";
+import { test, expect, SCREENSHOT_BASE } from "../support/demo.fixture";
+import { TEST_ADMIN } from "../support/app-helpers";
+
+/** Wait for animations to settle, then capture screenshot. */
+async function stableScreenshot(page: Page, name: string): Promise<void> {
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(300);
+  await page.screenshot({
+    path: `${SCREENSHOT_BASE}/${name}.png`,
+    fullPage: false,
+  });
+}
 
 test.describe("M0 Demo Screenshots", () => {
   test.describe.configure({ mode: "serial" });
   test.setTimeout(120_000);
 
-  test("smoke: Axum server responds", async ({ demoPage }) => {
-    const response = await demoPage.request.get("/api/health");
-    expect(response.ok()).toBe(true);
+  // ── V2: Setup Wizard (screenshots #10-#12) ──────────────────────────
+
+  test("#10 setup-wizard-shop-name", async ({ demoPage, setupToken }) => {
+    await demoPage.goto(`/setup?setup_token=${setupToken}`);
+    await expect(demoPage.getByText("Welcome to Mokumo Print")).toBeVisible();
+    // Step 1 → Step 2 (shop name)
+    await demoPage.getByRole("button", { name: "Get Started" }).click();
+    await expect(demoPage.getByLabel("Shop name")).toBeVisible();
+    await demoPage.getByLabel("Shop name").fill(TEST_ADMIN.shopName);
+    await stableScreenshot(demoPage, "10-setup-wizard-shop-name");
+  });
+
+  test("#11 setup-wizard-password", async ({ demoPage }) => {
+    // Step 2 → Step 3 (admin account)
+    await demoPage.getByRole("button", { name: "Continue" }).click();
+    await expect(demoPage.getByLabel("Password")).toBeVisible();
+    await demoPage.getByLabel("Name").fill(TEST_ADMIN.name);
+    await demoPage.getByLabel("Email").fill(TEST_ADMIN.email);
+    await demoPage.getByLabel("Password").fill(TEST_ADMIN.password);
+    await stableScreenshot(demoPage, "11-setup-wizard-password");
+  });
+
+  test("#12 setup-wizard-recovery-code", async ({ demoPage, setupToken }) => {
+    // Fill setup token if visible, then submit
+    const tokenField = demoPage.locator("#setup-token");
+    if (await tokenField.isVisible()) {
+      await tokenField.fill(setupToken);
+    }
+    await demoPage.getByRole("button", { name: "Create Account" }).click();
+    // Step 4: Recovery codes
+    await expect(demoPage.getByText("Recovery Codes", { exact: true })).toBeVisible();
+    // Assert codes container has child elements (not just an empty container)
+    const codeElements = demoPage.locator("[data-testid='recovery-codes'] code, .font-mono");
+    await expect(codeElements.first()).toBeVisible();
+    await stableScreenshot(demoPage, "12-setup-wizard-recovery-code");
+  });
+
+  // ── V3: Login + Dashboard + Shell (screenshots #13-#18) ─────────────
+
+  test("#13 login-screen", async ({ demoPage }) => {
+    // Save codes and continue to completion
+    await demoPage.getByLabel("I have saved my recovery codes").click();
+    await demoPage.getByRole("button", { name: "Continue" }).click();
+    await expect(demoPage.getByText("You're all set!")).toBeVisible();
+    // Complete wizard → goes to dashboard (auto-logged-in after setup)
+    await demoPage.getByRole("button", { name: "Open Dashboard" }).click();
+    await expect(demoPage.getByRole("heading", { name: "Your Shop" })).toBeVisible({
+      timeout: 15_000,
+    });
+    // Log out to capture the login screen
+    await demoPage.goto("/login");
+    await expect(
+      demoPage.locator("[data-slot='card-title']").filter({ hasText: "Sign in" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await stableScreenshot(demoPage, "13-login-screen");
+  });
+
+  test("#14 dashboard-after-login", async ({ demoPage }) => {
+    // UI-driven login (the visual flow IS the point)
+    await demoPage.locator("#email").fill(TEST_ADMIN.email);
+    await demoPage.locator("#password").fill(TEST_ADMIN.password);
+    await demoPage.getByRole("button", { name: "Sign in" }).click();
+    await expect(demoPage.getByRole("heading", { name: "Your Shop" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await stableScreenshot(demoPage, "14-dashboard-after-login");
+  });
+
+  test("#15 sidebar-navigation", async ({ demoPage }) => {
+    // Sidebar is visible after login with navigation items
+    await expect(demoPage.locator("[data-sidebar='content']")).toBeVisible();
+    await stableScreenshot(demoPage, "15-sidebar-navigation");
+  });
+
+  test("#16 sidebar-collapsed", async ({ demoPage }) => {
+    // Click trigger to collapse (NOT viewport resize — 768px triggers mobile sheet overlay)
+    await demoPage.locator("[data-sidebar='trigger']").click();
+    // Wait for CSS animation to complete — collapsed sidebar is narrow (3rem ≈ 47-48px)
+    await expect(demoPage.locator("[data-sidebar='sidebar']")).toHaveCSS("width", /^4[7-8]px$/, {
+      timeout: 5_000,
+    });
+    await stableScreenshot(demoPage, "16-sidebar-collapsed");
+    // Re-expand for subsequent tests
+    await demoPage.locator("[data-sidebar='trigger']").click();
+    await demoPage.waitForTimeout(500);
+  });
+
+  test("#17 empty-state-customers", async ({ demoPage }) => {
+    await demoPage.goto("/customers");
+    await expect(
+      demoPage
+        .getByText("No customers yet")
+        .or(demoPage.getByRole("heading", { name: "Customers" })),
+    ).toBeVisible({ timeout: 10_000 });
+    await stableScreenshot(demoPage, "17-empty-state-customers");
+  });
+
+  test("#18 theme-switcher", async ({ demoPage }) => {
+    // First close the Help popover if open from navigation
+    await demoPage.keyboard.press("Escape");
+    await demoPage.waitForTimeout(200);
+    // The theme switcher is inside the sidebar footer Owner popover
+    await demoPage.getByText("Owner", { exact: true }).click();
+    await expect(demoPage.getByLabel("Toggle light/dark mode")).toBeVisible({ timeout: 5_000 });
+    await demoPage.waitForTimeout(300);
+    await stableScreenshot(demoPage, "18-theme-switcher");
+    // Close popover
+    await demoPage.keyboard.press("Escape");
+  });
+
+  // ── V4: Customer CRUD (screenshots #19-#24) ─────────────────────────
+
+  test("#19 new-customer-button", async ({ demoPage }) => {
+    await demoPage.goto("/customers");
+    await expect(demoPage.getByRole("button", { name: "Add Customer" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await stableScreenshot(demoPage, "19-new-customer-button");
+  });
+
+  test("#20 customer-form-filled", async ({ demoPage }) => {
+    await demoPage.getByRole("button", { name: "Add Customer" }).click();
+    const dialog = demoPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await demoPage.waitForTimeout(300);
+    // Fill with demo data
+    await dialog.locator("#display_name").fill("Acme Screen Printing");
+    await dialog.locator("#company_name").fill("Acme Apparel Co");
+    await dialog.locator("#email").fill("orders@acmeprinting.com");
+    await dialog.locator("#phone").fill("(555) 867-5309");
+    await stableScreenshot(demoPage, "20-customer-form-filled");
+  });
+
+  test("#21 customer-detail", async ({ demoPage }) => {
+    // Submit the form and wait for API response
+    const dialog = demoPage.getByRole("dialog");
+    await Promise.all([
+      demoPage.waitForResponse((r) => r.url().includes("/api/customers") && r.status() === 201),
+      dialog.getByRole("button", { name: "Create" }).click(),
+    ]);
+    // Wait for sheet to close
+    await expect(dialog).toHaveCount(0, { timeout: 10_000 });
+    // Reload customer list to see the new customer
+    await demoPage.goto("/customers");
+    await expect(demoPage.locator("table tbody tr").first()).toBeVisible({ timeout: 10_000 });
+    // Click into detail
+    await demoPage.locator("table").getByText("Acme Screen Printing").click();
+    await expect(demoPage.getByRole("heading", { name: "Acme Screen Printing" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await stableScreenshot(demoPage, "21-customer-detail");
+  });
+
+  test("#22 customer-edit", async ({ demoPage }) => {
+    await demoPage.getByRole("button", { name: "Edit" }).click();
+    const dialog = demoPage.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await demoPage.waitForTimeout(300);
+    // Assert form has existing data
+    await expect(dialog.locator("#display_name")).toHaveValue("Acme Screen Printing");
+    await stableScreenshot(demoPage, "22-customer-edit");
+    // Close without saving
+    await demoPage.keyboard.press("Escape");
+    await expect(demoPage.getByRole("dialog")).toHaveCount(0, { timeout: 5_000 });
+  });
+
+  test("#23 customer-search", async ({ demoPage }) => {
+    // Navigate to list — should have at least 1 customer
+    await demoPage.goto("/customers");
+    await expect(demoPage.getByRole("heading", { name: "Customers" })).toBeVisible({
+      timeout: 10_000,
+    });
+    const rows = demoPage.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+    const initialCount = await rows.count();
+    // Type in search
+    const searchInput = demoPage.getByPlaceholder("Search customers");
+    await Promise.all([
+      demoPage.waitForResponse((r) => r.url().includes("/api/customers") && r.ok()),
+      searchInput.fill("Acme"),
+    ]);
+    // Assert row count decreased (or stayed same if only 1) and at least 1 row visible
+    const filteredCount = await rows.count();
+    expect(filteredCount).toBeLessThanOrEqual(initialCount);
+    expect(filteredCount).toBeGreaterThan(0);
+    await stableScreenshot(demoPage, "23-customer-search");
+  });
+
+  test("#24 customer-kpi-cards", async ({ demoPage }) => {
+    // Clear search to show all customers with KPI strip
+    const searchInput = demoPage.getByPlaceholder("Search customers");
+    await Promise.all([
+      demoPage.waitForResponse((r) => r.url().includes("/api/customers") && r.ok()),
+      searchInput.clear(),
+    ]);
+    await expect(demoPage.getByText(/total customer/)).toBeVisible();
+    await stableScreenshot(demoPage, "24-customer-kpi-cards");
+  });
+
+  // ── V5: Soft Delete + Restore + Activity + Settings (#25-#28, #33) ──
+
+  test("#25 soft-delete-confirm", async ({ demoPage }) => {
+    // Navigate to the customer detail
+    await demoPage.locator("table").getByText("Acme Screen Printing").click();
+    await expect(demoPage.getByRole("heading", { name: "Acme Screen Printing" })).toBeVisible({
+      timeout: 10_000,
+    });
+    // Click archive
+    await demoPage.getByRole("button", { name: "Archive" }).click();
+    const dialog = demoPage.getByRole("alertdialog").or(demoPage.getByRole("dialog"));
+    await expect(dialog).toBeVisible();
+    await demoPage.waitForTimeout(300);
+    await stableScreenshot(demoPage, "25-soft-delete-confirm");
+  });
+
+  test("#26 show-deleted-toggle", async ({ demoPage }) => {
+    // Confirm archive
+    const dialog = demoPage.getByRole("alertdialog").or(demoPage.getByRole("dialog"));
+    await dialog.getByRole("button", { name: "Archive" }).click();
+    // Wait for redirect — navigate to list with include_deleted to show the toggle + archived row
+    await expect(demoPage).toHaveURL(/\/customers/, { timeout: 10_000 });
+    await demoPage.goto("/customers?include_deleted=true");
+    await expect(demoPage.locator("table tbody tr").first()).toBeVisible({ timeout: 10_000 });
+    // Assert archived row has visual indicator
+    const archivedRow = demoPage
+      .locator("table tbody tr")
+      .filter({ hasText: "Acme Screen Printing" });
+    await expect(archivedRow).toBeVisible();
+    await stableScreenshot(demoPage, "26-show-deleted-toggle");
+  });
+
+  test("#27 restore-customer", async ({ demoPage }) => {
+    // Click into the archived customer detail
+    await demoPage.locator("table").getByText("Acme Screen Printing").click();
+    await expect(demoPage.getByRole("heading", { name: "Acme Screen Printing" })).toBeVisible({
+      timeout: 10_000,
+    });
+    // Assert Restore button visible (from #89)
+    await expect(demoPage.getByRole("button", { name: "Restore" })).toBeVisible();
+    await stableScreenshot(demoPage, "27-restore-customer");
+  });
+
+  test("#28 activity-log-list", async ({ demoPage }) => {
+    // Restore the customer first so we have a rich activity log
+    await demoPage.getByRole("button", { name: "Restore" }).click();
+    const dialog = demoPage.getByRole("alertdialog").or(demoPage.getByRole("dialog"));
+    await dialog.getByRole("button", { name: "Restore" }).click();
+    // Wait for restore to complete
+    await expect(demoPage.getByText("Archived")).toHaveCount(0, { timeout: 5_000 });
+    // Navigate to Activity tab
+    const tabNav = demoPage.getByLabel("Tab navigation");
+    await tabNav.getByRole("link", { name: "Activity" }).click();
+    await expect(demoPage.getByTestId("activity-entry").first()).toBeVisible({ timeout: 10_000 });
+    await stableScreenshot(demoPage, "28-activity-log-list");
+  });
+
+  test("#33 settings-page", async ({ demoPage }) => {
+    await demoPage.goto("/settings/shop");
+    await expect(demoPage.getByRole("heading", { name: "Shop Settings" })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(demoPage.getByTestId("lan-status-badge")).toBeVisible();
+    await stableScreenshot(demoPage, "33-settings-page");
   });
 });

--- a/apps/web/tests/demo-captures/m0.spec.ts
+++ b/apps/web/tests/demo-captures/m0.spec.ts
@@ -2,6 +2,13 @@ import type { Page } from "@playwright/test";
 import { test, expect, SCREENSHOT_BASE } from "../support/demo.fixture";
 import { TEST_ADMIN } from "../support/app-helpers";
 
+const DEMO_CUSTOMER = {
+  displayName: "Acme Screen Printing",
+  companyName: "Acme Apparel Co",
+  email: "orders@acmeprinting.com",
+  phone: "(555) 867-5309",
+};
+
 /**
  * Wait for animations to settle, then capture screenshot.
  * networkidle is safe here because we run against a local Axum server with no
@@ -105,7 +112,13 @@ test.describe("M0 Demo Screenshots", () => {
     await stableScreenshot(demoPage, "16-sidebar-collapsed");
     // Re-expand for subsequent tests
     await demoPage.locator("[data-sidebar='trigger']").click();
-    await demoPage.waitForTimeout(500);
+    await expect(demoPage.locator("[data-sidebar='sidebar']")).not.toHaveCSS(
+      "width",
+      /^4[7-8]px$/,
+      {
+        timeout: 5_000,
+      },
+    );
   });
 
   test("#17 empty-state-customers", async ({ demoPage }) => {
@@ -119,13 +132,14 @@ test.describe("M0 Demo Screenshots", () => {
   });
 
   test("#18 theme-switcher", async ({ demoPage }) => {
-    // First close the Help popover if open from navigation
+    // First close any open popover from navigation
     await demoPage.keyboard.press("Escape");
-    await demoPage.waitForTimeout(200);
+    await expect(demoPage.getByTestId("help-popover"))
+      .not.toBeVisible({ timeout: 3_000 })
+      .catch(() => {});
     // The theme switcher is inside the sidebar footer Owner popover
     await demoPage.getByText("Owner", { exact: true }).click();
     await expect(demoPage.getByLabel("Toggle light/dark mode")).toBeVisible({ timeout: 5_000 });
-    await demoPage.waitForTimeout(300);
     await stableScreenshot(demoPage, "18-theme-switcher");
     // Close popover
     await demoPage.keyboard.press("Escape");
@@ -145,12 +159,11 @@ test.describe("M0 Demo Screenshots", () => {
     await demoPage.getByRole("button", { name: "Add Customer" }).click();
     const dialog = demoPage.getByRole("dialog");
     await expect(dialog).toBeVisible();
-    await demoPage.waitForTimeout(300);
     // Fill with demo data
-    await dialog.locator("#display_name").fill("Acme Screen Printing");
-    await dialog.locator("#company_name").fill("Acme Apparel Co");
-    await dialog.locator("#email").fill("orders@acmeprinting.com");
-    await dialog.locator("#phone").fill("(555) 867-5309");
+    await dialog.locator("#display_name").fill(DEMO_CUSTOMER.displayName);
+    await dialog.locator("#company_name").fill(DEMO_CUSTOMER.companyName);
+    await dialog.locator("#email").fill(DEMO_CUSTOMER.email);
+    await dialog.locator("#phone").fill(DEMO_CUSTOMER.phone);
     await stableScreenshot(demoPage, "20-customer-form-filled");
   });
 
@@ -167,8 +180,8 @@ test.describe("M0 Demo Screenshots", () => {
     await demoPage.goto("/customers");
     await expect(demoPage.locator("table tbody tr").first()).toBeVisible({ timeout: 10_000 });
     // Click into detail
-    await demoPage.locator("table").getByText("Acme Screen Printing").click();
-    await expect(demoPage.getByRole("heading", { name: "Acme Screen Printing" })).toBeVisible({
+    await demoPage.locator("table").getByText(DEMO_CUSTOMER.displayName).click();
+    await expect(demoPage.getByRole("heading", { name: DEMO_CUSTOMER.displayName })).toBeVisible({
       timeout: 10_000,
     });
     await stableScreenshot(demoPage, "21-customer-detail");
@@ -178,9 +191,8 @@ test.describe("M0 Demo Screenshots", () => {
     await demoPage.getByRole("button", { name: "Edit" }).click();
     const dialog = demoPage.getByRole("dialog");
     await expect(dialog).toBeVisible();
-    await demoPage.waitForTimeout(300);
     // Assert form has existing data
-    await expect(dialog.locator("#display_name")).toHaveValue("Acme Screen Printing");
+    await expect(dialog.locator("#display_name")).toHaveValue(DEMO_CUSTOMER.displayName);
     await stableScreenshot(demoPage, "22-customer-edit");
     // Close without saving
     await demoPage.keyboard.press("Escape");
@@ -224,15 +236,14 @@ test.describe("M0 Demo Screenshots", () => {
 
   test("#25 soft-delete-confirm", async ({ demoPage }) => {
     // Navigate to the customer detail
-    await demoPage.locator("table").getByText("Acme Screen Printing").click();
-    await expect(demoPage.getByRole("heading", { name: "Acme Screen Printing" })).toBeVisible({
+    await demoPage.locator("table").getByText(DEMO_CUSTOMER.displayName).click();
+    await expect(demoPage.getByRole("heading", { name: DEMO_CUSTOMER.displayName })).toBeVisible({
       timeout: 10_000,
     });
     // Click archive
     await demoPage.getByRole("button", { name: "Archive" }).click();
     const dialog = demoPage.getByRole("alertdialog").or(demoPage.getByRole("dialog"));
     await expect(dialog).toBeVisible();
-    await demoPage.waitForTimeout(300);
     await stableScreenshot(demoPage, "25-soft-delete-confirm");
   });
 
@@ -247,15 +258,15 @@ test.describe("M0 Demo Screenshots", () => {
     // Assert archived row has visual indicator
     const archivedRow = demoPage
       .locator("table tbody tr")
-      .filter({ hasText: "Acme Screen Printing" });
+      .filter({ hasText: DEMO_CUSTOMER.displayName });
     await expect(archivedRow).toBeVisible();
     await stableScreenshot(demoPage, "26-show-deleted-toggle");
   });
 
   test("#27 restore-customer", async ({ demoPage }) => {
     // Click into the archived customer detail
-    await demoPage.locator("table").getByText("Acme Screen Printing").click();
-    await expect(demoPage.getByRole("heading", { name: "Acme Screen Printing" })).toBeVisible({
+    await demoPage.locator("table").getByText(DEMO_CUSTOMER.displayName).click();
+    await expect(demoPage.getByRole("heading", { name: DEMO_CUSTOMER.displayName })).toBeVisible({
       timeout: 10_000,
     });
     // Assert Restore button visible (from #89)

--- a/apps/web/tests/demo-captures/m0.spec.ts
+++ b/apps/web/tests/demo-captures/m0.spec.ts
@@ -2,7 +2,12 @@ import type { Page } from "@playwright/test";
 import { test, expect, SCREENSHOT_BASE } from "../support/demo.fixture";
 import { TEST_ADMIN } from "../support/app-helpers";
 
-/** Wait for animations to settle, then capture screenshot. */
+/**
+ * Wait for animations to settle, then capture screenshot.
+ * networkidle is safe here because we run against a local Axum server with no
+ * external requests, WebSockets, or SSE. If the server adds persistent connections,
+ * replace with targeted waitForResponse/waitForSelector per screenshot.
+ */
 async function stableScreenshot(page: Page, name: string): Promise<void> {
   await page.waitForLoadState("networkidle");
   await page.waitForTimeout(300);

--- a/apps/web/tests/support/demo.fixture.ts
+++ b/apps/web/tests/support/demo.fixture.ts
@@ -90,7 +90,13 @@ export const test = base.extend<object, DemoWorkerFixtures>({
 
   setupToken: [
     async ({ _demoServer }, use) => {
-      await use(_demoServer.setupToken ?? "");
+      if (!_demoServer.setupToken) {
+        throw new Error(
+          "Setup token was not captured from Axum stdout. " +
+            "Check startAxumServer token regex matches the server log format.",
+        );
+      }
+      await use(_demoServer.setupToken);
     },
     { scope: "worker" },
   ],

--- a/apps/web/tests/support/demo.fixture.ts
+++ b/apps/web/tests/support/demo.fixture.ts
@@ -62,7 +62,7 @@ export const test = base.extend<object, DemoWorkerFixtures>({
       handle.process?.kill("SIGTERM");
       rmSync(tmpDir, { recursive: true, force: true });
     },
-    { scope: "worker" },
+    { scope: "worker", timeout: 60_000 },
   ],
 
   demoPage: [


### PR DESCRIPTION
## Summary

- Replace stub smoke test with 20 serial screenshot captures across the full M0 demo flow
- Setup wizard → login → dashboard → sidebar → customers → CRUD → archive/restore → activity → settings
- `stableScreenshot()` helper handles animation stabilization (networkidle + 300ms floor)
- Fresh DB per run — spec builds cumulative state through the UI (no demo.db dependency)
- 60s worker fixture timeout for Axum server startup
- mode-watcher localStorage fix: bare `dark` value (not JSON-escaped `"dark"`)
- Explicit setupToken guard with clear error message

## Test plan

- [x] `moon run web:demo-captures` — 20 tests pass in 17s, 20 PNGs generated
- [x] Re-run produces same screenshots (idempotent)
- [x] `moon run web:test-e2e` — 55 BDD tests unaffected
- [x] Spot-checked 4 screenshots (setup, dashboard, customer detail, settings) — all correct
- [x] `test-results/` empty on success (trace/screenshot only on failure)
- [x] Pre-push hooks pass (clippy, oxlint, oxfmt)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded UI test coverage with comprehensive screenshot-based flows for setup, authentication, dashboard, navigation, customer management, archival/restore, activity logs, and settings.
  * Added a stable screenshot approach and stricter network/idling waits to reduce flakiness and improve visual test reliability.
  * Hardened test fixtures with explicit timeouts and stronger validation for test setup tokens to ensure consistent test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->