### PR TITLE
fix(db): wrap recovery code transaction in full SQLITE_BUSY retry (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Demo mode section on System Settings page with "Reset Demo Data" button and confirmation dialog
 - CI demo-smoke job: validates seed pipeline produces a valid demo database
 
+### Fixed
+
+- Recovery code redemption now retries on any SQLite contention error (not just the update step), preventing "database is locked" failures under concurrent access (#207)
+
 ### Changed
 
 - Dashboard LAN URL now shows real server info from `/api/server-info` instead of `window.location.origin`

--- a/crates/db/src/user/repo.rs
+++ b/crates/db/src/user/repo.rs
@@ -261,6 +261,7 @@ impl SeaOrmUserRepo {
         new_password: &str,
     ) -> Result<bool, DomainError> {
         let normalized = recovery_code.replace('-', "");
+        let new_hash = password::hash_password(new_password.to_string()).await?;
 
         for attempt in 0..3u64 {
             let result: Result<bool, DomainError> = async {
@@ -315,11 +316,10 @@ impl SeaOrmUserRepo {
                         message: format!("failed to serialize updated recovery codes: {e}"),
                     })?;
 
-                let new_hash = password::hash_password(new_password.to_string()).await?;
                 let update_result = UserEntity::update_many()
                     .col_expr(
                         entity::Column::PasswordHash,
-                        sea_orm::sea_query::Expr::value(new_hash),
+                        sea_orm::sea_query::Expr::value(new_hash.clone()),
                     )
                     .col_expr(
                         entity::Column::RecoveryCodeHash,

--- a/crates/db/src/user/repo.rs
+++ b/crates/db/src/user/repo.rs
@@ -355,14 +355,22 @@ impl SeaOrmUserRepo {
             match result {
                 Ok(val) => return Ok(val),
                 Err(ref err) if attempt < 2 && is_sqlite_busy_domain(err) => {
-                    tokio::time::sleep(std::time::Duration::from_millis(50 * (attempt + 1))).await;
+                    let backoff_ms = 50 * (attempt + 1);
+                    tracing::warn!(
+                        attempt = attempt + 1,
+                        backoff_ms,
+                        "SQLITE_BUSY during recovery code verification, retrying"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
                     continue;
                 }
                 Err(err) => return Err(err),
             }
         }
 
-        Ok(false)
+        Err(DomainError::Internal {
+            message: "recovery code verification failed: database busy after retries".into(),
+        })
     }
 }
 

--- a/crates/db/src/user/repo.rs
+++ b/crates/db/src/user/repo.rs
@@ -354,15 +354,18 @@ impl SeaOrmUserRepo {
 
             match result {
                 Ok(val) => return Ok(val),
-                Err(ref err) if attempt < 2 && is_sqlite_busy_domain(err) => {
-                    let backoff_ms = 50 * (attempt + 1);
-                    tracing::warn!(
-                        attempt = attempt + 1,
-                        backoff_ms,
-                        "SQLITE_BUSY during recovery code verification, retrying"
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
-                    continue;
+                Err(ref err) if is_sqlite_busy_domain(err) => {
+                    if attempt < 2 {
+                        let backoff_ms = 50 * (attempt + 1);
+                        tracing::warn!(
+                            attempt = attempt + 1,
+                            backoff_ms,
+                            "SQLITE_BUSY during recovery code verification, retrying"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
+                        continue;
+                    }
+                    break;
                 }
                 Err(err) => return Err(err),
             }

--- a/crates/db/src/user/repo.rs
+++ b/crates/db/src/user/repo.rs
@@ -52,8 +52,8 @@ fn split_user_and_hash(m: entity::Model) -> (User, String) {
     (User::from(m), hash)
 }
 
-fn is_sqlite_busy(err: &sea_orm::DbErr) -> bool {
-    err.to_string().contains("database is locked")
+fn is_sqlite_busy_domain(err: &DomainError) -> bool {
+    matches!(err, DomainError::Internal { message } if message.contains("database is locked"))
 }
 
 /// Generate 10 recovery codes with argon2 hashes.
@@ -262,99 +262,104 @@ impl SeaOrmUserRepo {
     ) -> Result<bool, DomainError> {
         let normalized = recovery_code.replace('-', "");
 
-        for attempt in 0..2 {
-            let txn = self.db.begin().await.map_err(sea_err)?;
+        for attempt in 0..3u64 {
+            let result: Result<bool, DomainError> = async {
+                let txn = self.db.begin().await.map_err(sea_err)?;
 
-            let model = UserEntity::find()
-                .filter(entity::Column::Email.eq(email))
-                .filter(entity::Column::DeletedAt.is_null())
-                .one(&txn)
-                .await
-                .map_err(sea_err)?;
-
-            let model = match model {
-                Some(m) => m,
-                None => return Ok(false),
-            };
-
-            let recovery_json = match &model.recovery_code_hash {
-                Some(json) => json.clone(),
-                None => return Ok(false),
-            };
-
-            let mut codes: Vec<serde_json::Value> =
-                serde_json::from_str(&recovery_json).map_err(|e| DomainError::Internal {
-                    message: format!("failed to parse recovery codes: {e}"),
-                })?;
-
-            let mut matched_index = None;
-            for (i, entry) in codes.iter().enumerate() {
-                let used = entry.get("used").and_then(|v| v.as_bool()).unwrap_or(true);
-                if used {
-                    continue;
-                }
-                let hash = entry
-                    .get("hash")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default();
-                if password::verify_password(normalized.clone(), hash.to_string()).await? {
-                    matched_index = Some(i);
-                    break;
-                }
-            }
-
-            let matched_index = match matched_index {
-                Some(i) => i,
-                None => return Ok(false),
-            };
-
-            codes[matched_index]["used"] = serde_json::Value::Bool(true);
-            let updated_json =
-                serde_json::to_string(&codes).map_err(|e| DomainError::Internal {
-                    message: format!("failed to serialize updated recovery codes: {e}"),
-                })?;
-
-            let new_hash = password::hash_password(new_password.to_string()).await?;
-            let update_result = match UserEntity::update_many()
-                .col_expr(
-                    entity::Column::PasswordHash,
-                    sea_orm::sea_query::Expr::value(new_hash),
-                )
-                .col_expr(
-                    entity::Column::RecoveryCodeHash,
-                    sea_orm::sea_query::Expr::value(updated_json),
-                )
-                .filter(entity::Column::Id.eq(model.id))
-                .filter(entity::Column::RecoveryCodeHash.eq(recovery_json))
-                .exec(&txn)
-                .await
-            {
-                Ok(result) => result,
-                Err(err) if attempt == 0 && is_sqlite_busy(&err) => {
-                    let _ = txn.rollback().await;
-                    continue;
-                }
-                Err(err) => return Err(sea_err(err)),
-            };
-
-            if update_result.rows_affected == 0 {
-                txn.rollback().await.map_err(sea_err)?;
-                return Ok(false);
-            }
-
-            let user = User::from(
-                UserEntity::find_by_id(model.id)
+                let model = UserEntity::find()
+                    .filter(entity::Column::Email.eq(email))
+                    .filter(entity::Column::DeletedAt.is_null())
                     .one(&txn)
                     .await
-                    .map_err(sea_err)?
-                    .ok_or_else(|| DomainError::Internal {
-                        message: "user disappeared mid-transaction".into(),
-                    })?,
-            );
+                    .map_err(sea_err)?;
 
-            log_user_activity(&txn, &user, ActivityAction::PasswordReset).await?;
-            txn.commit().await.map_err(sea_err)?;
-            return Ok(true);
+                let model = match model {
+                    Some(m) => m,
+                    None => return Ok(false),
+                };
+
+                let recovery_json = match &model.recovery_code_hash {
+                    Some(json) => json.clone(),
+                    None => return Ok(false),
+                };
+
+                let mut codes: Vec<serde_json::Value> = serde_json::from_str(&recovery_json)
+                    .map_err(|e| DomainError::Internal {
+                        message: format!("failed to parse recovery codes: {e}"),
+                    })?;
+
+                let mut matched_index = None;
+                for (i, entry) in codes.iter().enumerate() {
+                    let used = entry.get("used").and_then(|v| v.as_bool()).unwrap_or(true);
+                    if used {
+                        continue;
+                    }
+                    let hash = entry
+                        .get("hash")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    if password::verify_password(normalized.clone(), hash.to_string()).await? {
+                        matched_index = Some(i);
+                        break;
+                    }
+                }
+
+                let matched_index = match matched_index {
+                    Some(i) => i,
+                    None => return Ok(false),
+                };
+
+                codes[matched_index]["used"] = serde_json::Value::Bool(true);
+                let updated_json =
+                    serde_json::to_string(&codes).map_err(|e| DomainError::Internal {
+                        message: format!("failed to serialize updated recovery codes: {e}"),
+                    })?;
+
+                let new_hash = password::hash_password(new_password.to_string()).await?;
+                let update_result = UserEntity::update_many()
+                    .col_expr(
+                        entity::Column::PasswordHash,
+                        sea_orm::sea_query::Expr::value(new_hash),
+                    )
+                    .col_expr(
+                        entity::Column::RecoveryCodeHash,
+                        sea_orm::sea_query::Expr::value(updated_json),
+                    )
+                    .filter(entity::Column::Id.eq(model.id))
+                    .filter(entity::Column::RecoveryCodeHash.eq(recovery_json))
+                    .exec(&txn)
+                    .await
+                    .map_err(sea_err)?;
+
+                if update_result.rows_affected == 0 {
+                    txn.rollback().await.map_err(sea_err)?;
+                    return Ok(false);
+                }
+
+                let user = User::from(
+                    UserEntity::find_by_id(model.id)
+                        .one(&txn)
+                        .await
+                        .map_err(sea_err)?
+                        .ok_or_else(|| DomainError::Internal {
+                            message: "user disappeared mid-transaction".into(),
+                        })?,
+                );
+
+                log_user_activity(&txn, &user, ActivityAction::PasswordReset).await?;
+                txn.commit().await.map_err(sea_err)?;
+                Ok(true)
+            }
+            .await;
+
+            match result {
+                Ok(val) => return Ok(val),
+                Err(ref err) if attempt < 2 && is_sqlite_busy_domain(err) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(50 * (attempt + 1))).await;
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
         }
 
         Ok(false)


### PR DESCRIPTION
## Summary
- Wraps the entire `verify_and_use_recovery_code` transaction body in an async block so SQLITE_BUSY errors at **any** point (begin, find, update, commit) trigger a retry with linear backoff — not just the `update_many` call
- Increases retry attempts from 2 to 3 with 50ms/100ms backoff between retries
- Replaces `is_sqlite_busy(DbErr)` with `is_sqlite_busy_domain(DomainError)` to match errors after conversion

## Root Cause
The previous retry logic only caught `SQLITE_BUSY` on the `update_many().exec()` call (line 333). But `begin()`, `find()`, and `commit()` could also fail with "database is locked" under concurrent write contention. Those errors hit `map_err(sea_err)?` and exited the function immediately — no retry. The concurrent test's `unwrap()` then panicked.

## Test plan
- [x] All 29 `mokumo-db` tests pass
- [x] All 133 tests across db/core/types crates pass
- [x] Concurrent recovery test passes 20/20 stress runs
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery code redemption now automatically retries on temporary database contention, reducing "database is locked" failures during high concurrent access.
  * Improved retry/backoff behavior and error handling so recovery attempts are more reliable; persistent contention now surfaces a clear failure after retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->