### PR TITLE
fix: reset-db EPERM recovery dir scan is now non-fatal (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Customer list now refreshes automatically after creating, editing, or archiving a customer (#231)
 - Archiving all customers no longer strands users on the empty state — "Show archived" toggle is visible when archived customers exist (#229)
+- `reset-db` no longer fails when the recovery directory (e.g. `~/Desktop`) is unreadable due to macOS permissions — the scan is skipped with a warning instead of aborting the entire reset (#226)
 - Recovery code redemption now retries on any SQLite contention error (not just the update step), preventing "database is locked" failures under concurrent access (#207)
 
 ### Changed

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -510,6 +510,9 @@ pub struct ResetReport {
     pub deleted: Vec<PathBuf>,
     pub not_found: Vec<PathBuf>,
     pub failed: Vec<(PathBuf, std::io::Error)>,
+    /// Non-fatal: recovery directory could not be scanned (e.g. EPERM on macOS).
+    /// Contains (directory path, io error) when the scan was skipped.
+    pub recovery_dir_error: Option<(PathBuf, std::io::Error)>,
 }
 
 /// Fatal errors during database reset (not partial file failures).
@@ -564,7 +567,11 @@ pub fn cli_reset_db(
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // Recovery dir doesn't exist — nothing to clean up
         }
-        Err(e) => return Err(ResetError::Io(e)),
+        Err(e) => {
+            // Non-fatal: permission errors (e.g. macOS EPERM on ~/Desktop)
+            // are recorded as a warning, not a hard failure.
+            report.recovery_dir_error = Some((recovery_dir.to_path_buf(), e));
+        }
     }
 
     Ok(report)

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -214,6 +214,15 @@ async fn main() {
                 }
             };
 
+            if let Some((dir, err)) = &report.recovery_dir_error {
+                eprintln!(
+                    "Warning: could not scan recovery directory {}: {err}\n\
+                     Recovery files were not cleaned up. \
+                     You may need to remove them manually.",
+                    dir.display()
+                );
+            }
+
             if report.failed.is_empty() {
                 println!(
                     "\nDatabase reset complete ({} files deleted). \

--- a/services/api/tests/cli_reset_db.rs
+++ b/services/api/tests/cli_reset_db.rs
@@ -214,6 +214,56 @@ fn reset_db_ignores_subdirectory_in_recovery_dir() {
 }
 
 // ---------------------------------------------------------------------------
+// Recovery directory permission errors (EPERM / PermissionDenied)
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn reset_db_succeeds_when_recovery_dir_is_unreadable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+    let recovery_dir = tmp.path().join("recovery");
+    fs::create_dir(&recovery_dir).unwrap();
+
+    touch(&data_dir.join("mokumo.db"));
+    touch(&recovery_dir.join("mokumo-recovery-abc123.html"));
+
+    // Remove read permission so read_dir fails with PermissionDenied
+    fs::set_permissions(&recovery_dir, fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Reset should still succeed — recovery scan failure is non-fatal
+    let report = cli_reset_db(data_dir, &recovery_dir, false).unwrap();
+
+    // DB was deleted
+    assert!(report.deleted.contains(&data_dir.join("mokumo.db")));
+    // Recovery dir scan was skipped — check the warning field
+    assert!(report.recovery_dir_error.is_some());
+    let (dir, err) = report.recovery_dir_error.as_ref().unwrap();
+    assert_eq!(dir, &recovery_dir);
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+
+    // Restore permissions for tempdir cleanup
+    fs::set_permissions(&recovery_dir, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn reset_db_no_recovery_dir_error_when_readable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+    let recovery_dir = tmp.path().join("recovery");
+    fs::create_dir(&recovery_dir).unwrap();
+
+    touch(&data_dir.join("mokumo.db"));
+
+    let report = cli_reset_db(data_dir, &recovery_dir, false).unwrap();
+
+    assert!(report.recovery_dir_error.is_none());
+}
+
+// ---------------------------------------------------------------------------
 // Process-level lock (flock) integration tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `reset-db` no longer fails when the recovery directory (e.g. `~/Desktop`) is unreadable due to macOS Full Disk Access restrictions
- Recovery dir scan error is downgraded to a warning in `ResetReport.recovery_dir_error` — the reset reports success if the database files were deleted
- Warning message in stderr identifies the directory and error, advising manual cleanup

## Changes

- **`lib.rs`**: Added `recovery_dir_error: Option<(PathBuf, std::io::Error)>` to `ResetReport`; changed `Err(e) => return Err(...)` to record the error non-fatally
- **`main.rs`**: Display warning to stderr when recovery dir scan was skipped
- **`cli_reset_db.rs`**: 2 new tests — `reset_db_succeeds_when_recovery_dir_is_unreadable` (unix-only, chmod 000) and `reset_db_no_recovery_dir_error_when_readable`

## Test plan

- [x] 14/14 reset-db tests pass (12 existing + 2 new)
- [x] 227/227 full API test suite passes
- [x] Clippy clean, fmt clean
- [ ] Manual: run `mokumo reset-db --force` on macOS without Full Disk Access for terminal

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * reset-db no longer aborts when the recovery directory is unreadable; the reset completes and a warning is shown that recovery files may need manual cleanup.
* **Tests**
  * Added integration tests verifying reset-db succeeds when recovery directory permissions prevent scanning and that the recovery-error is reported.
* **Documentation**
  * Updated changelog with the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->