### PR TITLE
fix(customers): list refresh after mutations + archive empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Customer list now refreshes automatically after creating, editing, or archiving a customer (#231)
+- Archiving all customers no longer strands users on the empty state — "Show archived" toggle is visible when archived customers exist (#229)
 - Recovery code redemption now retries on any SQLite contention error (not just the update step), preventing "database is locked" failures under concurrent access (#207)
 
 ### Changed

--- a/apps/web/src/lib/components/customer-form-sheet.svelte
+++ b/apps/web/src/lib/components/customer-form-sheet.svelte
@@ -135,7 +135,7 @@
           toast.success(`"${parsed.data.display_name}" updated`);
           open = false;
           onClose();
-          await invalidate((url) => url.pathname.startsWith("/api/customers"));
+          await invalidate("app:customers");
         } else {
           applyApiErrors(result.error);
         }
@@ -150,7 +150,7 @@
           toast.success(`"${parsed.data.display_name}" created`);
           open = false;
           onClose();
-          await invalidate((url) => url.pathname.startsWith("/api/customers"));
+          await invalidate("app:customers");
         } else {
           applyApiErrors(result.error);
         }

--- a/apps/web/src/routes/(app)/customers/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/+page.svelte
@@ -102,6 +102,20 @@
   }
 </script>
 
+{#snippet showArchivedToggle(id: string)}
+  <div class="flex items-center gap-2">
+    <Switch
+      {id}
+      checked={params.include_deleted}
+      onCheckedChange={(checked) => {
+        params.include_deleted = checked;
+        params.page = 1;
+      }}
+    />
+    <Label for={id} class="text-sm">Show archived</Label>
+  </div>
+{/snippet}
+
 {#if error}
   <div class="flex flex-col items-center justify-center py-24 text-center">
     <div class="bg-destructive/10 text-destructive rounded-lg p-6 max-w-md">
@@ -155,17 +169,7 @@
       </div>
       <Button onclick={handleAddCustomer}>Add Customer</Button>
     </div>
-    <div class="flex items-center gap-2">
-      <Switch
-        id="show-deleted-empty"
-        checked={params.include_deleted}
-        onCheckedChange={(checked) => {
-          params.include_deleted = checked;
-          params.page = 1;
-        }}
-      />
-      <Label for="show-deleted-empty" class="text-sm">Show archived</Label>
-    </div>
+    {@render showArchivedToggle("show-deleted-empty")}
   </div>
 {:else if customers}
   <div class="space-y-4">
@@ -190,17 +194,7 @@
           params.page = 1;
         }}
       />
-      <div class="flex items-center gap-2">
-        <Switch
-          id="show-deleted"
-          checked={params.include_deleted}
-          onCheckedChange={(checked) => {
-            params.include_deleted = checked;
-            params.page = 1;
-          }}
-        />
-        <Label for="show-deleted" class="text-sm">Show archived</Label>
-      </div>
+      {@render showArchivedToggle("show-deleted")}
     </div>
 
     {#if isFilteredEmpty}

--- a/apps/web/src/routes/(app)/customers/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/+page.svelte
@@ -57,9 +57,19 @@
     data.customers as PaginatedList<CustomerResponse> | null,
   );
   let error = $derived(data.error as string | null);
+  let hasArchivedCustomers = $derived(data.hasArchivedCustomers as boolean);
   let isLoading = $derived(!customers && !error);
   let isEmpty = $derived(
-    customers?.total === 0 && !params.search && !params.include_deleted,
+    customers?.total === 0 &&
+      !params.search &&
+      !params.include_deleted &&
+      !hasArchivedCustomers,
+  );
+  let hasOnlyArchived = $derived(
+    customers?.total === 0 &&
+      !params.search &&
+      !params.include_deleted &&
+      hasArchivedCustomers,
   );
   let isFilteredEmpty = $derived(
     customers?.total === 0 && (!!params.search || params.include_deleted),
@@ -135,6 +145,27 @@
   />
   <div class="flex justify-center -mt-12">
     <Button onclick={handleAddCustomer}>Add Customer</Button>
+  </div>
+{:else if hasOnlyArchived}
+  <div class="space-y-4">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold tracking-tight">Customers</h1>
+        <p class="text-sm text-muted-foreground">All customers are archived</p>
+      </div>
+      <Button onclick={handleAddCustomer}>Add Customer</Button>
+    </div>
+    <div class="flex items-center gap-2">
+      <Switch
+        id="show-deleted-empty"
+        checked={params.include_deleted}
+        onCheckedChange={(checked) => {
+          params.include_deleted = checked;
+          params.page = 1;
+        }}
+      />
+      <Label for="show-deleted-empty" class="text-sm">Show archived</Label>
+    </div>
   </div>
 {:else if customers}
   <div class="space-y-4">

--- a/apps/web/src/routes/(app)/customers/+page.svelte
+++ b/apps/web/src/routes/(app)/customers/+page.svelte
@@ -85,7 +85,7 @@
       toast.success(`"${archiveTarget.display_name}" archived`);
       archiveDialogOpen = false;
       archiveTarget = null;
-      await invalidate((url) => url.pathname === "/api/customers");
+      await invalidate("app:customers");
     } else {
       throw new Error(result.error.message);
     }
@@ -100,7 +100,7 @@
       <Button
         variant="outline"
         class="mt-4"
-        onclick={() => invalidate((url) => url.pathname === "/api/customers")}
+        onclick={() => invalidate("app:customers")}
       >
         Try again
       </Button>

--- a/apps/web/src/routes/(app)/customers/+page.ts
+++ b/apps/web/src/routes/(app)/customers/+page.ts
@@ -20,15 +20,31 @@ export async function load({ url, depends }) {
     return {
       customers: null as PaginatedList<CustomerResponse> | null,
       error: result.error.message,
+      hasArchivedCustomers: false,
     };
   }
 
   if ("data" in result) {
-    return { customers: result.data, error: null as string | null };
+    const customers = result.data;
+    let hasArchivedCustomers = false;
+
+    // When no active customers and no search filter, check if archived customers exist
+    if (customers.total === 0 && !search && !includeDeleted) {
+      const archivedCheck = await listCustomers({
+        include_deleted: true,
+        per_page: 1,
+      });
+      if (archivedCheck.ok && "data" in archivedCheck) {
+        hasArchivedCustomers = archivedCheck.data.total > 0;
+      }
+    }
+
+    return { customers, error: null as string | null, hasArchivedCustomers };
   }
 
   return {
     customers: null as PaginatedList<CustomerResponse> | null,
     error: "Unexpected empty response",
+    hasArchivedCustomers: false,
   };
 }

--- a/apps/web/src/routes/(app)/customers/+page.ts
+++ b/apps/web/src/routes/(app)/customers/+page.ts
@@ -36,6 +36,8 @@ export async function load({ url, depends }) {
       });
       if (archivedCheck.ok && "data" in archivedCheck) {
         hasArchivedCustomers = archivedCheck.data.total > 0;
+      } else if (!archivedCheck.ok) {
+        console.error("Failed to check for archived customers:", archivedCheck.error.message);
       }
     }
 

--- a/apps/web/src/routes/(app)/customers/+page.ts
+++ b/apps/web/src/routes/(app)/customers/+page.ts
@@ -2,7 +2,8 @@ import { listCustomers } from "$lib/api/customers";
 import type { CustomerResponse } from "$lib/types/CustomerResponse";
 import type { PaginatedList } from "$lib/types/PaginatedList";
 
-export async function load({ url }) {
+export async function load({ url, depends }) {
+  depends("app:customers");
   const search = url.searchParams.get("search") ?? "";
   const page = Number(url.searchParams.get("page") ?? "1") || 1;
   const perPage = Number(url.searchParams.get("per_page") ?? "25") || 25;


### PR DESCRIPTION
## Summary\n\n- **#231**: Customer list now refreshes automatically after creating, editing, or archiving a customer. Replaced brittle URL-matcher `invalidate()` with SvelteKit's idiomatic `depends(\"app:customers\")` + `invalidate(\"app:customers\")` pattern.\n- **#229**: When all customers are archived, the page now shows a dedicated \"all archived\" state with the \"Show archived\" toggle visible, instead of the misleading \"No customers yet\" empty state. A lightweight secondary API check (`per_page=1, include_deleted=true`) detects archived customers only when the active list is empty.\n\nCloses #231\nCloses #229\n\n## Test plan\n\n- [x] `moon run web:check` — 0 errors, 0 warnings\n- [x] `moon run web:test` — 155/155 tests pass\n- [ ] Manual: create a customer via form sheet → list refreshes without page reload\n- [ ] Manual: edit a customer via form sheet → list refreshes without page reload\n- [ ] Manual: archive a customer → list refreshes without page reload\n- [ ] Manual: archive all customers → \"Show archived\" toggle appears (not \"No customers yet\")\n- [ ] Manual: toggle \"Show archived\" in all-archived state → archived customers appear\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)