### PR TITLE
chore(ci,demo): harden demo-smoke CI gate and reset timing (#218)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -259,7 +259,6 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true')
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
     steps:
@@ -360,9 +359,10 @@ jobs:
           TEST_RUST: ${{ needs.test-rust.result }}
           QUALITY_TS: ${{ needs.quality-ts.result }}
           SEAM_CHECK: ${{ needs.seam-check.result }}
+          DEMO_SMOKE: ${{ needs.demo-smoke.result }}
         run: |
           # Jobs that were skipped due to path filtering are fine
-          for job in LINT_RUST TEST_RUST QUALITY_TS SEAM_CHECK; do
+          for job in LINT_RUST TEST_RUST QUALITY_TS SEAM_CHECK DEMO_SMOKE; do
             result=$(eval echo "\$$job")
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "Job $job failed with result: $result"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Demo reset shutdown delay increased from 100ms to 500ms to prevent truncated responses (#218)
+- `demo-smoke` CI job now gates PR merge via verdict check (was `continue-on-error`, now enforced) (#218)
 - `waitForServer` no longer swallows unexpected errors (malformed URL, DNS failure) — only retries connection-refused and abort-timeout (#221)
 - Timeout error message now includes the last error seen for easier debugging
 

--- a/apps/web/src/lib/fixtures/customer.ts
+++ b/apps/web/src/lib/fixtures/customer.ts
@@ -58,7 +58,7 @@ function createFullCustomer(): CreateCustomerBody {
     display_name: faker.person.fullName(),
     company_name: faker.company.name(),
     email: faker.internet.email(),
-    phone: faker.phone.number(),
+    phone: faker.phone.number({ style: "national" }),
     address_line1: faker.location.streetAddress(),
     address_line2: faker.helpers.maybe(() => faker.location.secondaryAddress()) ?? null,
     city: faker.location.city(),
@@ -80,7 +80,7 @@ function createStandardCustomer(): CreateCustomerBody {
     display_name: faker.person.fullName(),
     company_name: faker.company.name(),
     email: faker.internet.email(),
-    phone: faker.phone.number(),
+    phone: faker.phone.number({ style: "national" }),
   };
 }
 

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -503,23 +503,31 @@ pub async fn demo_reset(State(state): State<SharedState>) -> Response {
         );
     }
 
-    // Respond before shutdown
+    // Write a restart sentinel so the server loop knows to restart (not exit).
+    // Must happen before constructing the response so the message reflects reality.
+    let sentinel = state.data_dir.join(".restart");
+    let message = match std::fs::write(&sentinel, b"reset") {
+        Ok(()) => "Demo data reset successfully. Server will restart.".to_string(),
+        Err(e) => {
+            tracing::error!(
+                "Demo reset: sentinel write failed ({e}). \
+                 Server will shut down but may NOT restart automatically."
+            );
+            "Demo data reset, but automatic restart may fail. \
+             Please restart the server manually if it does not come back online."
+                .to_string()
+        }
+    };
+
     let response = (
         StatusCode::OK,
         Json(mokumo_types::setup::DemoResetResponse {
             success: true,
-            message: "Demo data reset successfully. Server will restart.".into(),
+            message,
         }),
     )
         .into_response();
 
-    // Write a restart sentinel so the server loop knows to restart (not exit)
-    let sentinel = state.data_dir.join(".restart");
-    if let Err(e) = std::fs::write(&sentinel, b"reset") {
-        tracing::error!(
-            "Demo reset: sentinel write failed ({e}). Server will shut down but may NOT restart automatically."
-        );
-    }
     let shutdown = state.shutdown.clone();
     tokio::spawn(async move {
         // Grace period for Axum to flush the response before the

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -516,12 +516,15 @@ pub async fn demo_reset(State(state): State<SharedState>) -> Response {
     // Write a restart sentinel so the server loop knows to restart (not exit)
     let sentinel = state.data_dir.join(".restart");
     if let Err(e) = std::fs::write(&sentinel, b"reset") {
-        tracing::warn!("Failed to write restart sentinel: {e}");
+        tracing::error!(
+            "Demo reset: sentinel write failed ({e}). Server will shut down but may NOT restart automatically."
+        );
     }
     let shutdown = state.shutdown.clone();
     tokio::spawn(async move {
-        // Small delay to allow the response to be sent
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Grace period for Axum to flush the response before the
+        // CancellationToken tears down the server.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         shutdown.cancel();
     });
 


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from `demo-smoke` CI job and wire it into the verdict check loop — failures now block PR merge
- Increase demo reset shutdown grace period from 100ms → 500ms to prevent truncated responses
- Escalate sentinel write failure from `warn` to `error` level (review finding)

Closes #218

## Review Agents

4 agents dispatched: code reviewer (clean), code simplifier (trimmed comment), silent failure hunter (caught warn→error upgrade), CEng (approve).

## Test plan

- [x] `moon run api:test api:lint api:fmt web:check` — 225 tests pass, lint/fmt green
- [ ] CI `demo-smoke` job runs without `continue-on-error` and verdict checks it
- [ ] Verify `DEMO_SMOKE` appears in verdict env + check loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved server restart reliability by extending shutdown grace period to allow response completion.
  * Enhanced error messages when automatic restart operations encounter issues.
  * Updated phone number formatting in test data to standardized national format.

* **Chores**
  * Strengthened CI quality gates to enforce smoke test validation for merge requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->