### PR TITLE
refactor(api): consolidate demo module and reduce startup duplication (#217)

### DIFF
--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -99,35 +99,8 @@ async fn init_server(
     let pool = mokumo_db::initialize_database(&database_url).await?;
     tracing::info!("Database ready at {}", db_path.display());
 
-    // Run startup migrations on the NON-ACTIVE profile database (if it exists)
-    {
-        use mokumo_core::setup::SetupMode;
-        let other_profile = match profile {
-            SetupMode::Demo => "production",
-            SetupMode::Production => "demo",
-        };
-        let other_db_path = config.data_dir.join(other_profile).join("mokumo.db");
-        if other_db_path.try_exists().unwrap_or(false) {
-            if let Err(e) = mokumo_db::pre_migration_backup(&other_db_path).await {
-                tracing::warn!(
-                    "Pre-migration backup failed for {}: {e}",
-                    other_db_path.display()
-                );
-            }
-            let other_url = format!("sqlite:{}?mode=rwc", other_db_path.display());
-            match mokumo_db::initialize_database(&other_url).await {
-                Ok(_db) => {
-                    tracing::info!("Startup migrations applied to {} database", other_profile);
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to run migrations on {} database: {e}",
-                        other_profile
-                    );
-                }
-            }
-        }
-    }
+    // Run startup migrations on the non-active profile database (if it exists)
+    mokumo_api::migrate_non_active_profile(&config.data_dir, profile).await;
 
     // Pre-allocate mDNS status (will be populated after mDNS registration)
     let mdns_status = discovery::MdnsStatus::shared();

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -22,7 +22,6 @@ use mokumo_types::error::{ErrorBody, ErrorCode};
 use mokumo_types::user::UserResponse;
 
 use crate::SharedState;
-use crate::demo;
 
 use backend::{Backend, Credentials};
 
@@ -472,69 +471,4 @@ pub async fn require_auth_with_demo_auto_login(
     }
 
     next.run(request).await
-}
-
-/// POST /api/demo/reset — reset the demo database to its original sidecar state.
-///
-/// Guards: demo mode only. Authentication is enforced by the
-/// `require_auth_with_demo_auto_login` route layer — this handler is only
-/// reachable by authenticated users.
-pub async fn demo_reset(State(state): State<SharedState>) -> Response {
-    use mokumo_core::setup::SetupMode;
-
-    // Must be demo mode
-    if state.setup_mode != Some(SetupMode::Demo) {
-        return error_response(
-            StatusCode::FORBIDDEN,
-            ErrorCode::Forbidden,
-            "Demo reset is only available in demo mode",
-        );
-    }
-
-    // Force-copy fresh sidecar over the demo database.
-    // The existing connection pool still holds the old file descriptor — this is fine
-    // because the server is about to shut down and restart with the fresh copy.
-    if let Err(e) = demo::force_copy_sidecar(&state.data_dir) {
-        tracing::error!("Demo reset: failed to copy sidecar: {e}");
-        return error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorCode::InternalError,
-            "Failed to reset demo database",
-        );
-    }
-
-    // Write a restart sentinel so the server loop knows to restart (not exit).
-    // Must happen before constructing the response so the message reflects reality.
-    let sentinel = state.data_dir.join(".restart");
-    let message = match std::fs::write(&sentinel, b"reset") {
-        Ok(()) => "Demo data reset successfully. Server will restart.".to_string(),
-        Err(e) => {
-            tracing::error!(
-                "Demo reset: sentinel write failed ({e}). \
-                 Server will shut down but may NOT restart automatically."
-            );
-            "Demo data reset, but automatic restart may fail. \
-             Please restart the server manually if it does not come back online."
-                .to_string()
-        }
-    };
-
-    let response = (
-        StatusCode::OK,
-        Json(mokumo_types::setup::DemoResetResponse {
-            success: true,
-            message,
-        }),
-    )
-        .into_response();
-
-    let shutdown = state.shutdown.clone();
-    tokio::spawn(async move {
-        // Grace period for Axum to flush the response before the
-        // CancellationToken tears down the server.
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        shutdown.cancel();
-    });
-
-    response
 }

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -1,5 +1,90 @@
 use std::path::Path;
 
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use mokumo_types::error::{ErrorBody, ErrorCode};
+
+use crate::SharedState;
+
+fn error_response(status: StatusCode, code: ErrorCode, message: &str) -> Response {
+    (
+        status,
+        Json(ErrorBody {
+            code,
+            message: message.into(),
+            details: None,
+        }),
+    )
+        .into_response()
+}
+
+/// POST /api/demo/reset — reset the demo database to its original sidecar state.
+///
+/// Guards: demo mode only. Authentication is enforced by the
+/// `require_auth_with_demo_auto_login` route layer — this handler is only
+/// reachable by authenticated users.
+pub async fn demo_reset(State(state): State<SharedState>) -> Response {
+    use mokumo_core::setup::SetupMode;
+
+    // Must be demo mode
+    if state.setup_mode != Some(SetupMode::Demo) {
+        return error_response(
+            StatusCode::FORBIDDEN,
+            ErrorCode::Forbidden,
+            "Demo reset is only available in demo mode",
+        );
+    }
+
+    // Force-copy fresh sidecar over the demo database.
+    // The existing connection pool still holds the old file descriptor — this is fine
+    // because the server is about to shut down and restart with the fresh copy.
+    if let Err(e) = force_copy_sidecar(&state.data_dir) {
+        tracing::error!("Demo reset: failed to copy sidecar: {e}");
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorCode::InternalError,
+            "Failed to reset demo database",
+        );
+    }
+
+    // Write a restart sentinel so the server loop knows to restart (not exit).
+    // Must happen before constructing the response so the message reflects reality.
+    let sentinel = state.data_dir.join(".restart");
+    let message = match std::fs::write(&sentinel, b"reset") {
+        Ok(()) => "Demo data reset successfully. Server will restart.".to_string(),
+        Err(e) => {
+            tracing::error!(
+                "Demo reset: sentinel write failed ({e}). \
+                 Server will shut down but may NOT restart automatically."
+            );
+            "Demo data reset, but automatic restart may fail. \
+             Please restart the server manually if it does not come back online."
+                .to_string()
+        }
+    };
+
+    let response = (
+        StatusCode::OK,
+        Json(mokumo_types::setup::DemoResetResponse {
+            success: true,
+            message,
+        }),
+    )
+        .into_response();
+
+    let shutdown = state.shutdown.clone();
+    tokio::spawn(async move {
+        // Grace period for Axum to flush the response before the
+        // CancellationToken tears down the server.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        shutdown.cancel();
+    });
+
+    response
+}
+
 /// Copy the demo sidecar database to `data_dir/demo/mokumo.db` if it doesn't already exist.
 ///
 /// Sidecar lookup order:

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -156,6 +156,40 @@ pub fn migrate_flat_layout(data_dir: &Path) -> Result<(), std::io::Error> {
     Ok(())
 }
 
+/// Run startup migrations on the non-active profile database (if it exists).
+///
+/// When running in demo mode this migrates the production database, and vice versa.
+/// Idempotent and non-fatal: failures are logged as warnings but do not prevent startup.
+pub async fn migrate_non_active_profile(
+    data_dir: &Path,
+    active_profile: mokumo_core::setup::SetupMode,
+) {
+    use mokumo_core::setup::SetupMode;
+    let other_profile = match active_profile {
+        SetupMode::Demo => "production",
+        SetupMode::Production => "demo",
+    };
+    let other_db_path = data_dir.join(other_profile).join("mokumo.db");
+    if !other_db_path.try_exists().unwrap_or(false) {
+        return;
+    }
+    if let Err(e) = mokumo_db::pre_migration_backup(&other_db_path).await {
+        tracing::warn!(
+            "Pre-migration backup failed for {}: {e}",
+            other_db_path.display()
+        );
+    }
+    let other_url = format!("sqlite:{}?mode=rwc", other_db_path.display());
+    if let Err(e) = mokumo_db::initialize_database(&other_url).await {
+        tracing::warn!(
+            "Failed to run migrations on {} database: {e}",
+            other_profile
+        );
+    } else {
+        tracing::info!("Startup migrations applied to {} database", other_profile);
+    }
+}
+
 /// Attempt to bind a TCP listener, trying ports from `port` through `port + 10`.
 ///
 /// Returns the listener and the actual port that was bound. Logs at INFO when
@@ -411,7 +445,7 @@ fn build_app_inner(
             "/api/account/recovery-codes/regenerate",
             post(auth::regenerate_recovery_codes),
         )
-        .route("/api/demo/reset", post(auth::demo_reset))
+        .route("/api/demo/reset", post(demo::demo_reset))
         .route("/ws", get(ws::ws_handler))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -350,6 +350,9 @@ async fn main() {
         std::process::exit(1);
     }
 
+    // Run startup migrations on the non-active profile database (if it exists)
+    mokumo_api::migrate_non_active_profile(&config.data_dir, profile).await;
+
     // Server loop: runs once normally, restarts on demo reset.
     // Each iteration gets a fresh shutdown token, DB pool, and app state.
     // Master shutdown token — Ctrl+C cancels this once; child tokens per loop iteration.

--- a/services/api/tests/bdd_world/demo_steps.rs
+++ b/services/api/tests/bdd_world/demo_steps.rs
@@ -1,34 +1,38 @@
 use super::ApiWorld;
 use cucumber::{given, then, when};
 
-/// Rebuild the BDD world with a demo-mode server.
+/// Configuration for rebuilding the BDD world with a specific profile.
+struct WorldConfig {
+    profile: &'static str,
+    dir_name: &'static str,
+    seed: &'static SeedConfig,
+}
+
+/// Rebuild the BDD world with a fresh server in the specified mode.
 ///
-/// This creates a fresh data directory with:
-/// - active_profile = "demo"
-/// - demo/mokumo.db seeded via `initialize_database` (runs migrations)
-/// - A pre-seeded admin user (admin@demo.local) and setup_mode = "demo" in settings
-async fn rebuild_as_demo(w: &mut ApiWorld) {
+/// Creates a temp data directory, initializes the database with migrations,
+/// seeds test data, and starts an Axum test server.
+async fn rebuild_world(w: &mut ApiWorld, cfg: &WorldConfig) {
     let tmp = tempfile::tempdir().expect("failed to create temp dir");
-    let data_dir = tmp.path().join("demo_test");
+    let data_dir = tmp.path().join(cfg.dir_name);
     mokumo_api::ensure_data_dirs(&data_dir).expect("failed to create data dirs");
 
-    // Write active_profile = "demo"
-    std::fs::write(data_dir.join("active_profile"), "demo").unwrap();
+    std::fs::write(data_dir.join("active_profile"), cfg.profile).unwrap();
 
-    // Initialize the demo database with migrations
-    let demo_db_path = data_dir.join("demo").join("mokumo.db");
-    let database_url = format!("sqlite:{}?mode=rwc", demo_db_path.display());
+    let db_path = data_dir.join(cfg.profile).join("mokumo.db");
+    let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
     let db = mokumo_db::initialize_database(&database_url)
         .await
-        .expect("failed to initialize demo database");
+        .unwrap_or_else(|e| panic!("failed to initialize {0} database: {e}", cfg.profile));
 
-    // Seed the demo admin user and setup_mode
-    seed_demo_data(&db).await;
+    seed_test_data(&db, cfg.seed).await;
 
-    // Create a sidecar copy and set the env var so reset can find it
-    let sidecar_path = tmp.path().join("sidecar_for_reset.db");
-    std::fs::copy(&demo_db_path, &sidecar_path).expect("failed to copy sidecar for reset");
-    unsafe { std::env::set_var("MOKUMO_DEMO_SIDECAR", &sidecar_path) };
+    // Demo mode: create a sidecar copy so reset can find it
+    if cfg.profile == "demo" {
+        let sidecar_path = tmp.path().join("sidecar_for_reset.db");
+        std::fs::copy(&db_path, &sidecar_path).expect("failed to copy sidecar for reset");
+        unsafe { std::env::set_var("MOKUMO_DEMO_SIDECAR", &sidecar_path) };
+    }
 
     let pool = db.get_sqlite_connection_pool().clone();
 
@@ -82,86 +86,65 @@ async fn rebuild_as_demo(w: &mut ApiWorld) {
     w.recovery_dir = recovery_dir;
     w.auth_done = false;
     w._tmp = tmp;
+}
+
+/// Rebuild the BDD world with a demo-mode server.
+async fn rebuild_as_demo(w: &mut ApiWorld) {
+    rebuild_world(
+        w,
+        &WorldConfig {
+            profile: "demo",
+            dir_name: "demo_test",
+            seed: &DEMO_SEED,
+        },
+    )
+    .await;
 }
 
 /// Rebuild as a production-mode server with setup already completed.
 async fn rebuild_as_production_with_setup(w: &mut ApiWorld) {
-    let tmp = tempfile::tempdir().expect("failed to create temp dir");
-    let data_dir = tmp.path().join("prod_test");
-    mokumo_api::ensure_data_dirs(&data_dir).expect("failed to create data dirs");
-
-    // Write active_profile = "production"
-    std::fs::write(data_dir.join("active_profile"), "production").unwrap();
-
-    let prod_db_path = data_dir.join("production").join("mokumo.db");
-    let database_url = format!("sqlite:{}?mode=rwc", prod_db_path.display());
-    let db = mokumo_db::initialize_database(&database_url)
-        .await
-        .expect("failed to initialize production database");
-
-    // Seed a production admin and setup_mode
-    seed_production_data(&db).await;
-
-    let pool = db.get_sqlite_connection_pool().clone();
-
-    let recovery_dir = tmp.path().join("recovery");
-    std::fs::create_dir_all(&recovery_dir).expect("failed to create recovery dir");
-
-    let session_db_path = data_dir.join("sessions.db");
-    let session_url = format!("sqlite:{}?mode=rwc", session_db_path.display());
-    let session_pool = mokumo_db::open_raw_sqlite_pool(&session_url)
-        .await
-        .expect("failed to open session database");
-
-    let config = mokumo_api::ServerConfig {
-        port: 0,
-        host: "0.0.0.0".into(),
-        data_dir,
-        recovery_dir: recovery_dir.clone(),
-    };
-
-    let shutdown_token = tokio_util::sync::CancellationToken::new();
-    let mdns_status = mokumo_api::discovery::MdnsStatus::shared();
-    let (app, setup_token) = mokumo_api::build_app_with_shutdown(
-        &config,
-        db.clone(),
-        shutdown_token.clone(),
-        mdns_status.clone(),
+    rebuild_world(
+        w,
+        &WorldConfig {
+            profile: "production",
+            dir_name: "prod_test",
+            seed: &PRODUCTION_SEED,
+        },
     )
     .await;
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("failed to bind test listener");
-
-    let shutdown = shutdown_token.clone();
-    let serve = axum::serve(listener, app.into_make_service()).with_graceful_shutdown(async move {
-        shutdown.cancelled().await;
-    });
-
-    let server = axum_test::TestServer::builder()
-        .save_cookies()
-        .build(serve)
-        .expect("failed to create test server");
-
-    w.server = server;
-    w.shutdown_token = shutdown_token;
-    w.db = db;
-    w.db_pool = pool;
-    w.session_pool = session_pool;
-    w.mdns_status = mdns_status;
-    w.setup_token = setup_token;
-    w.recovery_dir = recovery_dir;
-    w.auth_done = false;
-    w._tmp = tmp;
 }
 
-/// Seed demo-specific data: admin user + setup_mode = "demo" in settings.
-async fn seed_demo_data(db: &mokumo_db::DatabaseConnection) {
+/// Configuration for seeding a test database with an admin user and settings.
+struct SeedConfig {
+    setup_mode: &'static str,
+    shop_name: &'static str,
+    admin_email: &'static str,
+    admin_name: &'static str,
+    admin_password: &'static str,
+}
+
+const DEMO_SEED: SeedConfig = SeedConfig {
+    setup_mode: "demo",
+    shop_name: "Demo Shop",
+    admin_email: "admin@demo.local",
+    admin_name: "Demo Admin",
+    admin_password: "demo-password",
+};
+
+const PRODUCTION_SEED: SeedConfig = SeedConfig {
+    setup_mode: "production",
+    shop_name: "Test Shop",
+    admin_email: "admin@test.local",
+    admin_name: "Test Admin",
+    admin_password: "test-password",
+};
+
+/// Seed a test database with settings and an admin user.
+async fn seed_test_data(db: &mokumo_db::DatabaseConnection, cfg: &SeedConfig) {
     let pool = db.get_sqlite_connection_pool();
 
-    // Insert setup_mode = "demo" and setup_complete
-    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('setup_mode', 'demo')")
+    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('setup_mode', ?)")
+        .bind(cfg.setup_mode)
         .execute(pool)
         .await
         .expect("failed to insert setup_mode");
@@ -169,49 +152,23 @@ async fn seed_demo_data(db: &mokumo_db::DatabaseConnection) {
         .execute(pool)
         .await
         .expect("failed to insert setup_complete");
-    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('shop_name', 'Demo Shop')")
+    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('shop_name', ?)")
+        .bind(cfg.shop_name)
         .execute(pool)
         .await
         .expect("failed to insert shop_name");
 
-    // Insert the demo admin user with a known password hash
-    let hash = password_auth::generate_hash("demo-password");
+    let hash = password_auth::generate_hash(cfg.admin_password);
     sqlx::query(
         "INSERT INTO users (email, name, password_hash, role_id, is_active) \
-         VALUES ('admin@demo.local', 'Demo Admin', ?, 1, 1)",
+         VALUES (?, ?, ?, 1, 1)",
     )
+    .bind(cfg.admin_email)
+    .bind(cfg.admin_name)
     .bind(&hash)
     .execute(pool)
     .await
-    .expect("failed to insert demo admin");
-}
-
-/// Seed production-specific data: admin user + setup_mode = "production" in settings.
-async fn seed_production_data(db: &mokumo_db::DatabaseConnection) {
-    let pool = db.get_sqlite_connection_pool();
-
-    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('setup_mode', 'production')")
-        .execute(pool)
-        .await
-        .expect("failed to insert setup_mode");
-    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('setup_complete', 'true')")
-        .execute(pool)
-        .await
-        .expect("failed to insert setup_complete");
-    sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES ('shop_name', 'Test Shop')")
-        .execute(pool)
-        .await
-        .expect("failed to insert shop_name");
-
-    let hash = password_auth::generate_hash("test-password");
-    sqlx::query(
-        "INSERT INTO users (email, name, password_hash, role_id, is_active) \
-         VALUES ('admin@test.local', 'Test Admin', ?, 1, 1)",
-    )
-    .bind(&hash)
-    .execute(pool)
-    .await
-    .expect("failed to insert production admin");
+    .expect("failed to insert admin user");
 }
 
 // =====================================================================
@@ -680,7 +637,7 @@ async fn create_test_sidecar(path: &std::path::Path) {
     let db = mokumo_db::initialize_database(&url)
         .await
         .expect("failed to create test sidecar");
-    seed_demo_data(&db).await;
+    seed_test_data(&db, &DEMO_SEED).await;
     db.close().await.ok();
 }
 


### PR DESCRIPTION
## Summary

- Move `demo_reset` handler from `auth/mod.rs` to `demo.rs` — demo lifecycle belongs in the demo module, not auth
- Extract `migrate_non_active_profile()` shared helper from `desktop/lib.rs` into `lib.rs`, now called from both CLI and desktop entry points for consistency
- DRY BDD test setup via `WorldConfig`/`SeedConfig` structs, eliminating ~90% duplication between `rebuild_as_demo` and `rebuild_as_production_with_setup` in `demo_steps.rs`

## Review Notes

- Pure refactoring — no behavioral changes except CLI now migrates non-active profile on startup (already documented in `adr-demo-mode-architecture.md` Decision 4)
- 5-agent review (CAO, CEng, CQO/SFH, Code Reviewer, Code Simplifier) — all approved
- Net -14 lines (193 added, 207 removed)

## Test plan

- [x] `moon run api:test` — 227/227 pass
- [x] `moon run api:lint` — Clippy clean
- [x] `moon run api:fmt` — formatted

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized demo reset handling and startup migration flow for clearer separation of responsibilities.

* **New Features**
  * Added a demo reset endpoint that restores demo data, writes a restart sentinel, and triggers a short delayed restart.
  * Added a non-active profile migration step during startup to keep alternate-profile databases initialized.

* **Tests**
  * Parameterized test infrastructure for demo/production profiles and consolidated test data seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->