### PR TITLE
fix(demo): prepare_database extraction + demo_reset hardening

### DIFF
--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -5,10 +5,7 @@ use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;
 
 use mokumo_api::discovery::MdnsHandle;
-use mokumo_api::{
-    ServerConfig, build_app_with_shutdown, discovery, ensure_data_dirs, migrate_flat_layout,
-    resolve_active_profile, try_bind,
-};
+use mokumo_api::{ServerConfig, build_app_with_shutdown, discovery, prepare_database, try_bind};
 
 const DEFAULT_PORT: u16 = 6565;
 const DEFAULT_HOST: &str = "0.0.0.0";
@@ -73,34 +70,8 @@ async fn init_server(
         data_dir,
     };
 
-    ensure_data_dirs(&config.data_dir)?;
-
-    // Migrate flat layout to dual-directory structure (idempotent)
-    migrate_flat_layout(&config.data_dir)?;
-
-    // Copy demo sidecar if needed (first launch)
-    if let Err(e) = mokumo_api::demo::copy_sidecar_if_needed(&config.data_dir) {
-        tracing::warn!("Failed to copy demo sidecar: {e}");
-    }
-
-    // Resolve which profile to use
-    let profile = resolve_active_profile(&config.data_dir);
-    let db_path = config.data_dir.join(profile.as_str()).join("mokumo.db");
-
-    // Pre-migration backup — fatal for existing databases, skipped for first run.
-    let db_exists = db_path
-        .try_exists()
-        .map_err(|e| format!("Cannot check database at {}: {e}", db_path.display()))?;
-    if db_exists {
-        mokumo_db::pre_migration_backup(&db_path).await?;
-    }
-
-    let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
-    let pool = mokumo_db::initialize_database(&database_url).await?;
-    tracing::info!("Database ready at {}", db_path.display());
-
-    // Run startup migrations on the non-active profile database (if it exists)
-    mokumo_api::migrate_non_active_profile(&config.data_dir, profile).await;
+    // Shared startup: dirs, layout migration, sidecar copy, backup, DB init, non-active migration
+    let (pool, _profile) = prepare_database(&config.data_dir).await?;
 
     // Pre-allocate mDNS status (will be populated after mDNS registration)
     let mdns_status = discovery::MdnsStatus::shared();

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -63,7 +63,7 @@ fn user_to_response(user: &mokumo_core::user::User) -> UserResponse {
     }
 }
 
-fn error_response(status: StatusCode, code: ErrorCode, message: &str) -> Response {
+pub(crate) fn error_response(status: StatusCode, code: ErrorCode, message: &str) -> Response {
     (
         status,
         Json(ErrorBody {

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -4,21 +4,11 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use mokumo_types::error::{ErrorBody, ErrorCode};
+use mokumo_core::setup::SetupMode;
+use mokumo_types::error::ErrorCode;
 
 use crate::SharedState;
-
-fn error_response(status: StatusCode, code: ErrorCode, message: &str) -> Response {
-    (
-        status,
-        Json(ErrorBody {
-            code,
-            message: message.into(),
-            details: None,
-        }),
-    )
-        .into_response()
-}
+use crate::auth::error_response;
 
 /// POST /api/demo/reset — reset the demo database to its original sidecar state.
 ///
@@ -26,8 +16,6 @@ fn error_response(status: StatusCode, code: ErrorCode, message: &str) -> Respons
 /// `require_auth_with_demo_auto_login` route layer — this handler is only
 /// reachable by authenticated users.
 pub async fn demo_reset(State(state): State<SharedState>) -> Response {
-    use mokumo_core::setup::SetupMode;
-
     // Must be demo mode
     if state.setup_mode != Some(SetupMode::Demo) {
         return error_response(
@@ -37,9 +25,12 @@ pub async fn demo_reset(State(state): State<SharedState>) -> Response {
         );
     }
 
+    // Close the database connection pool before replacing the file.
+    // This releases file handles that would block std::fs::rename on Windows.
+    // Other in-flight requests will get errors, but the server is about to shut down.
+    state.db.get_sqlite_connection_pool().close().await;
+
     // Force-copy fresh sidecar over the demo database.
-    // The existing connection pool still holds the old file descriptor — this is fine
-    // because the server is about to shut down and restart with the fresh copy.
     if let Err(e) = force_copy_sidecar(&state.data_dir) {
         tracing::error!("Demo reset: failed to copy sidecar: {e}");
         return error_response(
@@ -49,36 +40,33 @@ pub async fn demo_reset(State(state): State<SharedState>) -> Response {
         );
     }
 
-    // Write a restart sentinel so the server loop knows to restart (not exit).
-    // Must happen before constructing the response so the message reflects reality.
+    // Write the restart sentinel BEFORE responding — if this fails, the server
+    // loop won't know to restart and the server would just die. Fail the request
+    // rather than returning success and leaving the user with a dead server.
     let sentinel = state.data_dir.join(".restart");
-    let message = match std::fs::write(&sentinel, b"reset") {
-        Ok(()) => "Demo data reset successfully. Server will restart.".to_string(),
-        Err(e) => {
-            tracing::error!(
-                "Demo reset: sentinel write failed ({e}). \
-                 Server will shut down but may NOT restart automatically."
-            );
-            "Demo data reset, but automatic restart may fail. \
-             Please restart the server manually if it does not come back online."
-                .to_string()
-        }
-    };
+    if let Err(e) = std::fs::write(&sentinel, b"reset") {
+        tracing::error!("Demo reset: failed to write restart sentinel: {e}");
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorCode::InternalError,
+            "Failed to prepare server restart after reset",
+        );
+    }
 
+    // Respond before shutdown
     let response = (
         StatusCode::OK,
         Json(mokumo_types::setup::DemoResetResponse {
             success: true,
-            message,
+            message: "Demo data reset successfully. Server will restart.".into(),
         }),
     )
         .into_response();
 
     let shutdown = state.shutdown.clone();
     tokio::spawn(async move {
-        // Grace period for Axum to flush the response before the
-        // CancellationToken tears down the server.
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        // Small delay to allow the response to be sent
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         shutdown.cancel();
     });
 
@@ -118,9 +106,9 @@ pub fn copy_sidecar_if_needed(data_dir: &Path) -> Result<bool, std::io::Error> {
 /// Force-copy the demo sidecar database to `data_dir/demo/mokumo.db`,
 /// replacing any existing file. Used by the reset endpoint.
 ///
-/// Uses atomic rename: copies to a temp file in the same directory, then
-/// renames over the destination. This avoids corrupting an in-use SQLite
-/// file if any connections are still draining during graceful shutdown.
+/// Strategy: copies to a temp file, then atomic-renames over the destination.
+/// On Windows (where rename fails with open handles), falls back to
+/// remove + rename. Callers should close the connection pool first.
 ///
 /// Returns an error if no sidecar can be found.
 pub fn force_copy_sidecar(data_dir: &Path) -> Result<(), std::io::Error> {
@@ -140,13 +128,39 @@ pub fn force_copy_sidecar(data_dir: &Path) -> Result<(), std::io::Error> {
     std::fs::copy(&src, &tmp)?;
 
     // Atomic rename replaces the destination without truncating the live file.
-    // Existing file descriptors (from draining connections) continue reading
-    // the old inode; new connections open the fresh copy.
-    std::fs::rename(&tmp, &dest)?;
+    // On Unix, existing file descriptors continue reading the old inode.
+    // On Windows, rename may fail if any handle is still open — fall back to
+    // remove + rename which works once the pool is closed by the caller.
+    if let Err(rename_err) = std::fs::rename(&tmp, &dest) {
+        tracing::warn!("Atomic rename failed ({rename_err}), trying remove + rename fallback");
+        // Remove the destination first (Windows requires this), then retry rename.
+        if let Err(remove_err) = std::fs::remove_file(&dest)
+            && remove_err.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!("Failed to remove old database: {remove_err}");
+        }
+        std::fs::rename(&tmp, &dest).map_err(|e| {
+            // Clean up the temp file on failure
+            let _ = std::fs::remove_file(&tmp);
+            std::io::Error::new(
+                e.kind(),
+                format!(
+                    "Failed to replace demo database (rename failed after fallback): {e}. \
+                     Ensure no other processes have the database open."
+                ),
+            )
+        })?;
+    }
 
-    // Remove WAL/SHM files after the rename — they belong to the old DB
-    let _ = std::fs::remove_file(demo_dir.join("mokumo.db-wal"));
-    let _ = std::fs::remove_file(demo_dir.join("mokumo.db-shm"));
+    // Remove WAL/SHM files — they belong to the old DB
+    for suffix in &["mokumo.db-wal", "mokumo.db-shm"] {
+        let path = demo_dir.join(suffix);
+        if let Err(e) = std::fs::remove_file(&path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!("Failed to remove {}: {e}", path.display());
+        }
+    }
 
     tracing::info!(
         "Force-copied demo sidecar from {} to {}",

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -156,38 +156,82 @@ pub fn migrate_flat_layout(data_dir: &Path) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-/// Run startup migrations on the non-active profile database (if it exists).
+/// Shared startup sequence: create directories, migrate layout, copy sidecar,
+/// resolve profile, back up and initialize the database, and run migrations on
+/// the non-active profile database.
 ///
-/// When running in demo mode this migrates the production database, and vice versa.
-/// Idempotent and non-fatal: failures are logged as warnings but do not prevent startup.
-pub async fn migrate_non_active_profile(
+/// Used by both the CLI server (`main.rs`) and the desktop app (`lib.rs`).
+/// Returns `(db, profile)` on success.
+pub async fn prepare_database(
     data_dir: &Path,
-    active_profile: mokumo_core::setup::SetupMode,
-) {
+) -> Result<(DatabaseConnection, mokumo_core::setup::SetupMode), Box<dyn std::error::Error>> {
     use mokumo_core::setup::SetupMode;
-    let other_profile = match active_profile {
+
+    ensure_data_dirs(data_dir)?;
+    migrate_flat_layout(data_dir)?;
+
+    if let Err(e) = demo::copy_sidecar_if_needed(data_dir) {
+        tracing::warn!("Failed to copy demo sidecar: {e}");
+    }
+
+    let profile = resolve_active_profile(data_dir);
+    let db_path = data_dir.join(profile.as_str()).join("mokumo.db");
+
+    // Pre-migration backup on active profile DB
+    let db_exists = db_path
+        .try_exists()
+        .map_err(|e| format!("Cannot check database at {}: {e}", db_path.display()))?;
+    if db_exists {
+        mokumo_db::pre_migration_backup(&db_path)
+            .await
+            .map_err(|e| {
+                format!(
+                    "Pre-migration backup failed for {}: {e}. \
+                     Refusing to run migrations without a backup. \
+                     Check disk space and permissions.",
+                    db_path.display()
+                )
+            })?;
+    }
+
+    let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    let db = mokumo_db::initialize_database(&database_url).await?;
+    tracing::info!("Database ready at {}", db_path.display());
+
+    // Run startup migrations on the non-active profile database (if it exists)
+    let other_profile = match profile {
         SetupMode::Demo => "production",
         SetupMode::Production => "demo",
     };
     let other_db_path = data_dir.join(other_profile).join("mokumo.db");
-    if !other_db_path.try_exists().unwrap_or(false) {
-        return;
+    match other_db_path.try_exists() {
+        Ok(true) => {
+            if let Err(e) = mokumo_db::pre_migration_backup(&other_db_path).await {
+                tracing::warn!(
+                    "Pre-migration backup failed for {}: {e}",
+                    other_db_path.display()
+                );
+            }
+            let other_url = format!("sqlite:{}?mode=rwc", other_db_path.display());
+            match mokumo_db::initialize_database(&other_url).await {
+                Ok(_) => {
+                    tracing::info!("Startup migrations applied to {other_profile} database")
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to run migrations on {other_profile} database: {e}")
+                }
+            }
+        }
+        Ok(false) => {}
+        Err(e) => {
+            tracing::warn!(
+                "Could not check for {other_profile} database at {}: {e}",
+                other_db_path.display()
+            );
+        }
     }
-    if let Err(e) = mokumo_db::pre_migration_backup(&other_db_path).await {
-        tracing::warn!(
-            "Pre-migration backup failed for {}: {e}",
-            other_db_path.display()
-        );
-    }
-    let other_url = format!("sqlite:{}?mode=rwc", other_db_path.display());
-    if let Err(e) = mokumo_db::initialize_database(&other_url).await {
-        tracing::warn!(
-            "Failed to run migrations on {} database: {e}",
-            other_profile
-        );
-    } else {
-        tracing::info!("Startup migrations applied to {} database", other_profile);
-    }
+
+    Ok((db, profile))
 }
 
 /// Attempt to bind a TCP listener, trying ports from `port` through `port + 10`.

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -213,13 +213,10 @@ pub async fn prepare_database(
                 );
             }
             let other_url = format!("sqlite:{}?mode=rwc", other_db_path.display());
-            match mokumo_db::initialize_database(&other_url).await {
-                Ok(_) => {
-                    tracing::info!("Startup migrations applied to {other_profile} database")
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to run migrations on {other_profile} database: {e}")
-                }
+            if let Err(e) = mokumo_db::initialize_database(&other_url).await {
+                tracing::warn!("Failed to run migrations on {other_profile} database: {e}");
+            } else {
+                tracing::info!("Startup migrations applied to {other_profile} database");
             }
         }
         Ok(false) => {}

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -264,9 +264,7 @@ async fn main() {
         recovery_dir,
     };
 
-    // Acquire process-level flock — prevents concurrent server instances and
-    // signals to `reset-db` that this process is running. Held for the entire
-    // server lifetime; the OS releases it automatically on exit or crash.
+    // Create data directories (including demo/ and production/)
     if let Err(e) = ensure_data_dirs(&config.data_dir) {
         eprintln!(
             "Cannot create data directory {}: {e}",
@@ -279,6 +277,9 @@ async fn main() {
         std::process::exit(1);
     }
 
+    // Acquire process-level flock — prevents concurrent server instances and
+    // signals to `reset-db` that this process is running. Held for the entire
+    // server lifetime; the OS releases it automatically on exit or crash.
     let lock_path = lock_file_path(&config.data_dir);
     let lock_file = match std::fs::OpenOptions::new()
         .create(true)

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::EnvFilter;
 
 use mokumo_api::{
     DB_SIDECAR_SUFFIXES, ServerConfig, build_app_with_shutdown, cli_reset_db, cli_reset_password,
-    demo, discovery, ensure_data_dirs, lock_file_path, migrate_flat_layout, resolve_active_profile,
+    discovery, ensure_data_dirs, lock_file_path, prepare_database, resolve_active_profile,
     try_bind,
 };
 
@@ -264,7 +264,9 @@ async fn main() {
         recovery_dir,
     };
 
-    // Create data directories (including demo/ and production/)
+    // Acquire process-level flock — prevents concurrent server instances and
+    // signals to `reset-db` that this process is running. Held for the entire
+    // server lifetime; the OS releases it automatically on exit or crash.
     if let Err(e) = ensure_data_dirs(&config.data_dir) {
         eprintln!(
             "Cannot create data directory {}: {e}",
@@ -277,9 +279,6 @@ async fn main() {
         std::process::exit(1);
     }
 
-    // Acquire process-level flock — prevents concurrent server instances and
-    // signals to `reset-db` that this process is running. Held for the entire
-    // server lifetime; the OS releases it automatically on exit or crash.
     let lock_path = lock_file_path(&config.data_dir);
     let lock_file = match std::fs::OpenOptions::new()
         .create(true)
@@ -314,44 +313,16 @@ async fn main() {
         }
     };
 
-    // Migrate flat layout to dual-directory structure (idempotent)
-    if let Err(e) = migrate_flat_layout(&config.data_dir) {
-        eprintln!("Failed to migrate data directory layout: {e}");
-        tracing::error!("Failed to migrate data directory layout: {e}");
-        std::process::exit(1);
-    }
-
-    // Copy demo sidecar if needed (first launch)
-    if let Err(e) = demo::copy_sidecar_if_needed(&config.data_dir) {
-        tracing::warn!("Failed to copy demo sidecar: {e}");
-    }
-
-    // Resolve which profile to use
-    let profile = resolve_active_profile(&config.data_dir);
-    let db_path = config.data_dir.join(profile.as_str()).join("mokumo.db");
-
-    // Pre-migration backup on ACTIVE PROFILE DB
-    let db_exists = match db_path.try_exists() {
-        Ok(exists) => exists,
+    // Shared startup: dirs, layout migration, sidecar copy, backup, DB init, non-active migration
+    let (_initial_db, profile) = match prepare_database(&config.data_dir).await {
+        Ok(result) => result,
         Err(e) => {
-            eprintln!("Cannot check database at {}: {e}", db_path.display());
-            tracing::error!("Cannot check database at {}: {e}", db_path.display());
+            eprintln!("Startup failed: {e}");
+            tracing::error!("Startup failed: {e}");
             std::process::exit(1);
         }
     };
-    if db_exists && let Err(e) = mokumo_db::pre_migration_backup(&db_path).await {
-        eprintln!(
-            "Pre-migration backup failed for {}: {e}. \
-             Refusing to run migrations without a backup. \
-             Check disk space and permissions.",
-            db_path.display()
-        );
-        tracing::error!("Pre-migration backup failed for existing database: {e}");
-        std::process::exit(1);
-    }
-
-    // Run startup migrations on the non-active profile database (if it exists)
-    mokumo_api::migrate_non_active_profile(&config.data_dir, profile).await;
+    let db_path = config.data_dir.join(profile.as_str()).join("mokumo.db");
 
     // Server loop: runs once normally, restarts on demo reset.
     // Each iteration gets a fresh shutdown token, DB pool, and app state.
@@ -468,6 +439,7 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mokumo_api::migrate_flat_layout;
     use mokumo_core::setup::SetupMode;
     use tempfile::tempdir;
 


### PR DESCRIPTION
## Summary

Follow-up to PR #242 (#217 refactor) carrying four improvements identified during review that #242 missed:

1. **`prepare_database` shared startup helper** — replaces `migrate_non_active_profile` with a single function that runs the full 7-step startup sequence. Eliminates shotgun surgery where both `main.rs` and `desktop/lib.rs` independently orchestrated the same sequence. [CAO: BLOCKING]

2. **`error_response` deduplication** — removes the private copy of `error_response` from `demo.rs`, imports the `pub(crate)` version from `auth` instead. [CAO: Advisory]

3. **Sentinel write failure returns HTTP 500** — previously returned 200 with a degraded message, leaving the frontend expecting a server restart that would never happen (dead server scenario). Now fails the request and keeps the server running. [CAO: BLOCKING]

4. **Windows rename fallback in `force_copy_sidecar`** — closes DB pool before sidecar replace, adds `remove + rename` fallback for Windows where atomic rename fails with open handles. [CAO: Advisory]

Architectural review by CAO confirmed all four as improvements over #242's implementation. Item #5 from the review (`recovery_dir_error` field) was intentionally NOT carried forward — main's non-fatal pattern is correct for macOS sandboxing.

Closes #217

## Test plan

- [x] 253/253 backend tests pass (`moon run api:test`)
- [x] Clippy clean (`moon run api:lint`)
- [x] Formatting clean (`moon run api:fmt`)
- [ ] CI green
- [ ] Verify demo reset works in Tauri desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)