### PR TITLE
test(web): add demo-banner component tests (#219)

### DIFF
--- a/apps/web/src/lib/components/demo-banner.test.ts
+++ b/apps/web/src/lib/components/demo-banner.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect } from "vitest";
+import DemoBanner from "./demo-banner.svelte";
+
+// Override setup default: demo-banner is browser-only, jsdom IS browser-like
+vi.mock("$app/environment", () => ({ browser: true, dev: false, building: false }));
+
+describe("DemoBanner", () => {
+  it('shows banner when setupMode is "demo"', () => {
+    render(DemoBanner, { setupMode: "demo" });
+    expect(screen.getByTestId("demo-banner")).toBeInTheDocument();
+  });
+
+  it('hides banner when setupMode is not "demo"', () => {
+    render(DemoBanner, { setupMode: null });
+    expect(screen.queryByTestId("demo-banner")).not.toBeInTheDocument();
+  });
+
+  it("persists dismiss to localStorage and hides banner", async () => {
+    render(DemoBanner, { setupMode: "demo" });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(localStorage.getItem("demo_banner_dismissed")).toBe("true");
+    expect(screen.queryByTestId("demo-banner")).not.toBeInTheDocument();
+  });
+
+  it("hides banner on mount when already dismissed", () => {
+    localStorage.setItem("demo_banner_dismissed", "true"); // set before render
+    render(DemoBanner, { setupMode: "demo" });
+    expect(screen.queryByTestId("demo-banner")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/components/demo-banner.test.ts
+++ b/apps/web/src/lib/components/demo-banner.test.ts
@@ -5,7 +5,8 @@ import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect } from "vitest";
 import DemoBanner from "./demo-banner.svelte";
 
-// Override setup default: demo-banner is browser-only, jsdom IS browser-like
+// browser: true required — demo-banner reads `browser && localStorage.getItem(...)` on mount.
+// Without this override, `dismissed` always initializes to false regardless of localStorage.
 vi.mock("$app/environment", () => ({ browser: true, dev: false, building: false }));
 
 describe("DemoBanner", () => {


### PR DESCRIPTION
## Summary

- Adds 4 component tests for `demo-banner.svelte` using `@testing-library/svelte` (W1.1 of #219)
- Tests: show/hide by setupMode, dismiss persists to localStorage, already-dismissed on mount
- `data-testid="demo-banner"` was already present — no component changes needed

## Test plan
- [x] `moon run web:test` passes: 4 new + 189 existing = 193 total
- [x] Banner visible when setupMode is "demo"
- [x] Banner hidden when setupMode is not "demo"
- [x] Dismiss button writes to localStorage and hides banner
- [x] Already-dismissed banner hidden on mount (pre-set localStorage)

## Component testing patterns (A7)

### Per-file jsdom pragma
First line of every component test file:
```typescript
// @vitest-environment jsdom
```

### browser:true override pattern
`vitest-setup.ts` sets `browser: false` as the global default (preserves node-env semantics for all 189 existing tests). Component tests that read `browser && localStorage.getItem(...)` must override per-file:
```typescript
vi.mock('$app/environment', () => ({ browser: true, dev: false, building: false }));
```
This file-scoped mock overrides the setup mock for this file only.

### screen queries only
Never use `within(container)` for portal content. `screen` queries search `document.body`, which is where Bits UI portals render.

### Shape A → B migration
When component test count reaches 10+, switch from per-file pragma to `environmentMatchGlobs` in `vite.config.ts` to avoid pragma boilerplate.

Closes part of #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the demo banner component: verifies it displays only in the demo setup mode, confirms the dismiss button removes the banner, and ensures the dismissed state is persisted so the banner stays hidden on subsequent loads. Tests also cover initial load behavior when the dismissed state is already set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->