### PR TITLE
test(web): add demo-reset-dialog component tests (#219)

### DIFF
--- a/apps/web/src/lib/components/demo-reset-dialog.test.ts
+++ b/apps/web/src/lib/components/demo-reset-dialog.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import { fireEvent } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import DemoResetDialog from "./demo-reset-dialog.svelte";
@@ -28,7 +29,7 @@ describe("DemoResetDialog", () => {
       writable: true,
       value: { ...window.location, reload: vi.fn() },
     });
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
 
     render(DemoResetDialog, { open: true });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
@@ -45,10 +46,10 @@ describe("DemoResetDialog", () => {
   });
 
   it("API error: shows error message from response body", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ message: "DB locked" }),
-    });
+    } as Response);
 
     render(DemoResetDialog, { open: true });
     const user = userEvent.setup();
@@ -58,13 +59,28 @@ describe("DemoResetDialog", () => {
     expect(screen.getByRole("button", { name: /^reset$/i })).not.toBeDisabled();
   });
 
+  it("API error: falls back to default message when response body is not JSON", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => {
+        throw new Error("not JSON");
+      },
+    } as Response);
+
+    render(DemoResetDialog, { open: true });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    expect(screen.getByText(/failed to reset demo data/i)).toBeInTheDocument();
+  });
+
   it("network error: shows connection lost message, reloads after 3000ms", async () => {
     vi.useFakeTimers();
     Object.defineProperty(window, "location", {
       writable: true,
       value: { ...window.location, reload: vi.fn() },
     });
-    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+    vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
 
     render(DemoResetDialog, { open: true });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
@@ -85,18 +101,18 @@ describe("DemoResetDialog", () => {
     await user.click(screen.getByRole("button", { name: /cancel/i }));
 
     expect(fetch).not.toHaveBeenCalled();
+    expect(screen.queryByText(/reset demo data/i)).not.toBeInTheDocument();
   });
 
   it("reset button is disabled and shows resetting state during reset", async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockImplementation(() => new Promise(() => {})); // never resolves
+    vi.mocked(fetch).mockImplementation(() => new Promise(() => {})); // never resolves
 
     render(DemoResetDialog, { open: true });
-    const user = userEvent.setup();
-    // Don't await — the click starts the async handler but fetch never resolves
-    user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    // fireEvent.click is synchronous — starts the async handler without awaiting completion
+    fireEvent.click(screen.getByRole("button", { name: /^reset$/i }));
 
     // Wait for Svelte reactivity to flush `resetting = true` and re-render
-    const { waitFor } = await import("@testing-library/svelte");
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /resetting/i })).toBeDisabled();
     });

--- a/apps/web/src/lib/components/demo-reset-dialog.test.ts
+++ b/apps/web/src/lib/components/demo-reset-dialog.test.ts
@@ -29,7 +29,7 @@ describe("DemoResetDialog", () => {
       writable: true,
       value: { ...window.location, reload: vi.fn() },
     });
-    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({}) } as unknown as Response);
 
     render(DemoResetDialog, { open: true });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
@@ -49,7 +49,7 @@ describe("DemoResetDialog", () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,
       json: async () => ({ message: "DB locked" }),
-    } as Response);
+    } as unknown as Response);
 
     render(DemoResetDialog, { open: true });
     const user = userEvent.setup();
@@ -65,7 +65,7 @@ describe("DemoResetDialog", () => {
       json: async () => {
         throw new Error("not JSON");
       },
-    } as Response);
+    } as unknown as Response);
 
     render(DemoResetDialog, { open: true });
     const user = userEvent.setup();

--- a/apps/web/src/lib/components/demo-reset-dialog.test.ts
+++ b/apps/web/src/lib/components/demo-reset-dialog.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import DemoResetDialog from "./demo-reset-dialog.svelte";
+
+describe("DemoResetDialog", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("renders dialog content when open", () => {
+    render(DemoResetDialog, { open: true });
+    expect(screen.getByText(/reset demo data/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it("success: disables buttons, clears localStorage, reloads after 1500ms", async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...window.location, reload: vi.fn() },
+    });
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, json: async () => ({}) });
+
+    render(DemoResetDialog, { open: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+
+    await user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    // During reset: action button should be disabled
+    expect(screen.getByRole("button", { name: /resetting/i })).toBeDisabled();
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(localStorage.getItem("demo_banner_dismissed")).toBeNull();
+    expect(window.location.reload).toHaveBeenCalledOnce();
+  });
+
+  it("API error: shows error message from response body", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: "DB locked" }),
+    });
+
+    render(DemoResetDialog, { open: true });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    expect(screen.getByText(/db locked/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^reset$/i })).not.toBeDisabled();
+  });
+
+  it("network error: shows connection lost message, reloads after 3000ms", async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...window.location, reload: vi.fn() },
+    });
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+
+    render(DemoResetDialog, { open: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+
+    await user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    expect(screen.getByText(/connection lost/i)).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(window.location.reload).toHaveBeenCalledOnce();
+  });
+
+  it("cancel: closes dialog without calling fetch", async () => {
+    render(DemoResetDialog, { open: true });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("reset button is disabled and shows resetting state during reset", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockImplementation(() => new Promise(() => {})); // never resolves
+
+    render(DemoResetDialog, { open: true });
+    const user = userEvent.setup();
+    // Don't await — the click starts the async handler but fetch never resolves
+    user.click(screen.getByRole("button", { name: /^reset$/i }));
+
+    // Wait for Svelte reactivity to flush `resetting = true` and re-render
+    const { waitFor } = await import("@testing-library/svelte");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /resetting/i })).toBeDisabled();
+    });
+    // Cancel button: Bits UI AlertDialog.Cancel checks disabled internally but does not
+    // forward the `disabled` attribute to the DOM element — it only blocks the click handler.
+    // Verify the cancel button is present (not removed) but clicking it during reset is a no-op.
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 6 component tests for `demo-reset-dialog.svelte` using `@testing-library/svelte` (W1.2 of #219)
- Tests: dialog renders when open, success flow, API error, network error + reload, cancel without fetch, reset button disabled during reset
- Validates A5: portal content (Bits UI AlertDialog) found via `screen` queries in jsdom

## Test plan
- [x] `moon run web:test` passes: 6 new + 189 existing = 195 total
- [x] Dialog renders with buttons when open
- [x] Success: reset button disabled → localStorage cleared → reload after 1500ms
- [x] API error shows message from response body, re-enables reset button
- [x] Network error shows "connection lost" message → reload after 3000ms
- [x] Cancel closes dialog without calling fetch
- [x] Reset button disabled and shows "Resetting..." during active reset

## Discovery

**Bits UI `AlertDialog.Cancel` does not forward `disabled` to DOM button:** The component only checks `disabled.current` in its internal handlers — it does not propagate the attribute to the underlying `<button>` element. `AlertDialog.Action` (the reset button) does propagate. Test 6 verifies the reset button is disabled rather than asserting both buttons have the DOM disabled attribute. Potential a11y concern — cancel button won't be announced as disabled by screen readers.

## Notes
- `vi.stubGlobal('fetch')` in beforeEach, `vi.unstubAllGlobals()` + `vi.useRealTimers()` in afterEach
- `userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) })` required for fake timers + userEvent v14+
- Portal content found via `screen` queries validates A5 flagged unknown

Closes part of #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the demo reset dialog, validating successful reset operations, error handling, network failure scenarios, and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->