### PR TITLE
fix(desktop): flatten demo.db resource path in Tauri bundle

### DIFF
--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -13,9 +13,9 @@
   "bundle": {
     "active": true,
     "targets": ["dmg", "nsis"],
-    "resources": [
-      "../../apps/web/scripts/demo.db"
-    ],
+    "resources": {
+      "../../apps/web/scripts/demo.db": "demo.db"
+    },
     "windows": {
       "nsis": {
         "installMode": "currentUser"


### PR DESCRIPTION
## Summary
- Fix Tauri v2 resource bundling: `demo.db` was placed at `_up_/_up_/apps/web/scripts/demo.db` instead of `Resources/demo.db`
- Switch from array to object syntax in `tauri.conf.json` to flatten the path
- Without this fix, the demo sidecar is never found at startup, so `copy_sidecar_if_needed` skips, and users land on a blank setup wizard instead of the demo

## Context
Discovered during M0 smoke testing. The root cause of demo mode not working in the bundled desktop app.

Related: #262 (demo ↔ production profile switching)

## Test plan
- [ ] `moon run desktop:build --force`
- [ ] Verify `demo.db` exists at `Mokumo.app/Contents/Resources/demo.db` (not in nested `_up_` dirs)
- [ ] Clean install: delete `~/Library/Application Support/com.breezybayslabs.mokumo/demo/` and relaunch — should auto-copy sidecar and show demo data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop application resource bundling configuration to explicitly define how demo data files are packaged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->