### PR TITLE
chore(quality): add crap4rs CRAP quality gate for unit-testable crates

### DIFF
--- a/crap4rs.toml
+++ b/crap4rs.toml
@@ -1,0 +1,13 @@
+# CRAP score configuration for Mokumo
+# Scoped to unit-testable crates only. Integration-only layers are excluded:
+#   - services/api/src/** — Axum handlers, covered by BDD integration tests (not --lib)
+#   - apps/desktop/**    — Tauri entry point, no unit test surface
+#   - **/tests/**        — Test helpers have 0% coverage by definition
+
+threshold = 8
+
+exclude = [
+  "services/api/src/**",
+  "apps/desktop/**",
+  "**/tests/**",
+]

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -55,6 +55,23 @@ tasks:
     - tests/features/**/*.feature
     options:
       runFromWorkspaceRoot: true
+  crap:
+    # CRAP (Change Risk Anti-Patterns) quality gate — scoped to unit-testable crates.
+    # Integration-only layers (services/api/src, apps/desktop) are excluded via crap4rs.toml.
+    # Generates LCOV coverage then runs crap4rs in one step.
+    script: |
+      set -euo pipefail
+      mkdir -p tmp
+      cargo llvm-cov nextest --lib --workspace --exclude mokumo-desktop --lcov --output-path tmp/lcov.info
+      crap4rs --coverage tmp/lcov.info --src .
+    deps:
+    - web:build
+    inputs:
+    - '@group(allRust)'
+    - crap4rs.toml
+    options:
+      cache: false
+      runFromWorkspaceRoot: true
   coverage:
     # --lib: unit tests only. Integration/BDD coverage excluded intentionally at M0.
     # Add --tests when domain logic in crates/core/ warrants full-stack coverage.

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -68,7 +68,7 @@ tasks:
     - web:build
     inputs:
     - '@group(allRust)'
-    - crap4rs.toml
+    - /crap4rs.toml
     options:
       cache: false
       runFromWorkspaceRoot: true


### PR DESCRIPTION
## Summary
- Adds `moon run api:crap` — generates LCOV coverage then runs crap4rs against `crates/` layer
- Adds `crap4rs.toml` config that scopes analysis to unit-testable code, excluding integration-only layers

## What's excluded and why
| Path | Reason |
|------|--------|
| `services/api/src/**` | Axum handlers covered by BDD/integration tests, not `--lib` unit tests |
| `apps/desktop/**` | Tauri entry point, no unit test surface |
| `**/tests/**` | Test helpers have 0% coverage by definition |

## Current baseline (15 failing functions in `crates/db/`)
| Function | CC | Cov% | CRAP |
|---|---|---|---|
| `pre_migration_backup` | 22 | 0% | 506 |
| `Migration::down` (x2) | 5-6 | 0% | 30-42 |
| `SqliteActivityLogRepo::list` | 4 | 0% | 20 |
| `get_setup_mode` | 4 | 0% | 20 |
| `SqliteSequenceGenerator::next_value` | 4 | 0% | 20 |
| `SeaOrmCustomerRepo::update` | 12 | 85% | 12.5 |
| `generate_recovery_codes` | 12 | 93% | 12 |
| `SeaOrmUserRepo::verify_and_use_recovery_code` | 10 | 83% | 10.5 |
| … +6 more near-threshold repo functions | 8-9 | 90-100% | 8-9 |

Threshold calibration for the near-threshold functions tracked in breezy-bays-labs/crap4rs#15.

## Test plan
- [x] `moon run api:crap` runs and exits 1 (expected — 15 real failures)
- [x] Config exclusions verified: only `crates/db/src/**` and `crates/db/src/migration/**` appear in results
- [x] 197 unit tests pass before crap4rs runs

Closes breezy-bays-labs/crap4rs#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a code-quality configuration that sets a CRAP score threshold and excludes specified paths from evaluation.
  * Integrated a new CI quality-gate step that generates coverage data and runs the CRAP analysis across the workspace as part of the pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->