### PR TITLE
fix(cli): reset-db aware of dual-profile layout (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Fixed
+
+- `reset-db` CLI now targets the correct profile database (`demo/mokumo.db` by default); use `--production` flag to reset the production profile with a stronger confirmation prompt (#258)
+
 ### Added
 
 - shadcn-svelte components: hover-card, carousel, drawer, menubar, calendar with Storybook stories (#247)

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -144,9 +144,9 @@ pub fn migrate_flat_layout(data_dir: &Path) -> Result<(), std::io::Error> {
         tracing::info!("Set active profile to 'production' (migrated from flat layout)");
     }
 
-    // Step 3: Clean up flat DB if production copy now exists
-    let production_now_exists = production_exists || flat_exists;
-    if production_now_exists && flat_exists {
+    // Step 3: Remove flat DB — at this point production either already existed
+    // (crash recovery) or was just created by Step 1. Either way, flat is redundant.
+    if flat_exists {
         std::fs::remove_file(&flat_db)?;
         tracing::info!("Removed flat database after migration");
         let _ = std::fs::remove_file(data_dir.join("mokumo.db-wal"));
@@ -158,7 +158,7 @@ pub fn migrate_flat_layout(data_dir: &Path) -> Result<(), std::io::Error> {
 
 /// Shared startup sequence: create directories, migrate layout, copy sidecar,
 /// resolve profile, back up and initialize the database, and run migrations on
-/// the non-active profile database.
+/// the non-active profile database (if it already exists).
 ///
 /// Used by both the CLI server (`main.rs`) and the desktop app (`lib.rs`).
 /// Returns `(db, profile)` on success.
@@ -544,7 +544,9 @@ pub fn cli_reset_password(db_path: &Path, email: &str, new_password: &str) -> Re
 
 /// Resolve the directory for password-reset recovery files.
 ///
-/// Priority: MOKUMO_RECOVERY_DIR env var > user's Desktop > cwd.
+/// Priority: MOKUMO_RECOVERY_DIR env var > user's Desktop (macOS/Windows) > cwd.
+/// On Linux, Desktop may not be available (XDG Desktop is optional), so the
+/// effective priority is env var > cwd.
 pub fn resolve_recovery_dir() -> PathBuf {
     std::env::var("MOKUMO_RECOVERY_DIR")
         .ok()
@@ -588,6 +590,8 @@ pub struct ResetReport {
     /// Non-fatal: recovery directory could not be scanned (e.g. EPERM on macOS).
     /// Contains (directory path, io error) when the scan was skipped.
     pub recovery_dir_error: Option<(PathBuf, std::io::Error)>,
+    /// Non-fatal: backup directory could not be scanned (only set when `include_backups` is true).
+    pub backup_dir_error: Option<(PathBuf, std::io::Error)>,
 }
 
 /// Fatal errors during database reset (not partial file failures).
@@ -602,6 +606,9 @@ pub enum ResetError {
 /// `profile_dir` is the directory containing `mokumo.db` for the target profile
 /// (e.g. `data_dir/demo` or `data_dir/production`). The caller resolves this
 /// from the `--production` flag before calling.
+///
+/// If `profile_dir` does not exist, all database and backup entries will appear
+/// in `report.not_found`; the function does not return `Err` in this case.
 ///
 /// This is a pure filesystem function with no stdin/stdout interaction.
 /// The caller (main.rs) handles confirmation prompts and result display.
@@ -619,13 +626,23 @@ pub fn cli_reset_db(
     }
 
     // 2. Backup files (opt-in)
-    if include_backups && let Ok(entries) = std::fs::read_dir(profile_dir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            if let Some(name_str) = name.to_str()
-                && name_str.starts_with("mokumo.db.backup-v")
-            {
-                delete_file(&entry.path(), &mut report);
+    if include_backups {
+        match std::fs::read_dir(profile_dir) {
+            Ok(entries) => {
+                for entry in entries.flatten() {
+                    let name = entry.file_name();
+                    if let Some(name_str) = name.to_str()
+                        && name_str.starts_with("mokumo.db.backup-v")
+                    {
+                        delete_file(&entry.path(), &mut report);
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // profile_dir doesn't exist — nothing to scan
+            }
+            Err(e) => {
+                report.backup_dir_error = Some((profile_dir.to_path_buf(), e));
             }
         }
     }

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -599,10 +599,14 @@ pub enum ResetError {
 
 /// Delete database files, sidecars, and optionally backups + recovery files.
 ///
+/// `profile_dir` is the directory containing `mokumo.db` for the target profile
+/// (e.g. `data_dir/demo` or `data_dir/production`). The caller resolves this
+/// from the `--production` flag before calling.
+///
 /// This is a pure filesystem function with no stdin/stdout interaction.
 /// The caller (main.rs) handles confirmation prompts and result display.
 pub fn cli_reset_db(
-    data_dir: &Path,
+    profile_dir: &Path,
     recovery_dir: &Path,
     include_backups: bool,
 ) -> Result<ResetReport, ResetError> {
@@ -610,12 +614,12 @@ pub fn cli_reset_db(
 
     // 1. Database file + sidecars
     for suffix in DB_SIDECAR_SUFFIXES {
-        let path = data_dir.join(format!("mokumo.db{suffix}"));
+        let path = profile_dir.join(format!("mokumo.db{suffix}"));
         delete_file(&path, &mut report);
     }
 
     // 2. Backup files (opt-in)
-    if include_backups && let Ok(entries) = std::fs::read_dir(data_dir) {
+    if include_backups && let Ok(entries) = std::fs::read_dir(profile_dir) {
         for entry in entries.flatten() {
             let name = entry.file_name();
             if let Some(name_str) = name.to_str()

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -46,7 +46,7 @@ enum Commands {
         #[arg(long)]
         include_backups: bool,
         /// Reset the production profile instead of the default demo profile.
-        /// Requires an additional confirmation prompt.
+        /// Requires typing "reset production" to confirm (irreversible).
         #[arg(long)]
         production: bool,
     },
@@ -122,11 +122,38 @@ async fn main() {
             };
             let db_path = profile_dir.join("mokumo.db");
 
-            // Early exit when neither profile database exists (idempotent, exit 0)
+            // Ensure data directories exist so the lock file can be created if needed.
+            if let Err(e) = ensure_data_dirs(&data_dir) {
+                eprintln!("Cannot create data directory {}: {e}", data_dir.display());
+                std::process::exit(1);
+            }
+
+            // Early exit when neither profile database exists (idempotent, exit 0).
+            // Use explicit match on each path so I/O errors surface rather than silently
+            // becoming "not found" via unwrap_or(false).
             let demo_db = data_dir.join("demo").join("mokumo.db");
             let production_db = data_dir.join("production").join("mokumo.db");
-            let any_db_exists = demo_db.try_exists().unwrap_or(false)
-                || production_db.try_exists().unwrap_or(false);
+            let demo_exists = match demo_db.try_exists() {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "Cannot access demo database path {}: {e}",
+                        demo_db.display()
+                    );
+                    std::process::exit(1);
+                }
+            };
+            let production_exists_check = match production_db.try_exists() {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "Cannot access production database path {}: {e}",
+                        production_db.display()
+                    );
+                    std::process::exit(1);
+                }
+            };
+            let any_db_exists = demo_exists || production_exists_check;
 
             match db_path.try_exists() {
                 Ok(false) if !any_db_exists => {
@@ -182,16 +209,26 @@ async fn main() {
             let mut preview_files: Vec<PathBuf> = Vec::new();
             for suffix in DB_SIDECAR_SUFFIXES {
                 let path = profile_dir.join(format!("mokumo.db{suffix}"));
-                if path.exists() {
+                if path.try_exists().unwrap_or(false) {
                     preview_files.push(path);
                 }
             }
-            if include_backups && let Ok(entries) = std::fs::read_dir(&profile_dir) {
-                for entry in entries.flatten() {
-                    if let Some(name) = entry.file_name().to_str()
-                        && name.starts_with("mokumo.db.backup-v")
-                    {
-                        preview_files.push(entry.path());
+            if include_backups {
+                match std::fs::read_dir(&profile_dir) {
+                    Ok(entries) => {
+                        for entry in entries.flatten() {
+                            if let Some(name) = entry.file_name().to_str()
+                                && name.starts_with("mokumo.db.backup-v")
+                            {
+                                preview_files.push(entry.path());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: cannot scan {} for backups: {e}",
+                            profile_dir.display()
+                        );
                     }
                 }
             }
@@ -202,14 +239,23 @@ async fn main() {
             }
 
             let recovery_dir = mokumo_api::resolve_recovery_dir();
-            if let Ok(entries) = std::fs::read_dir(&recovery_dir) {
-                for entry in entries.flatten() {
-                    if let Some(name) = entry.file_name().to_str()
-                        && name.starts_with("mokumo-recovery-")
-                        && name.ends_with(".html")
-                    {
-                        println!("  {}", entry.path().display());
+            match std::fs::read_dir(&recovery_dir) {
+                Ok(entries) => {
+                    for entry in entries.flatten() {
+                        if let Some(name) = entry.file_name().to_str()
+                            && name.starts_with("mokumo-recovery-")
+                            && name.ends_with(".html")
+                        {
+                            println!("  {}", entry.path().display());
+                        }
                     }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    eprintln!(
+                        "Warning: cannot scan recovery directory {}: {e}",
+                        recovery_dir.display()
+                    );
                 }
             }
             println!();
@@ -225,7 +271,10 @@ async fn main() {
                          This cannot be undone. All production data will be lost.\n"
                     );
                     print!("Type \"reset production\" to confirm: ");
-                    std::io::stdout().flush().unwrap_or(());
+                    if let Err(e) = std::io::stdout().flush() {
+                        eprintln!("Cannot write to terminal: {e}");
+                        std::process::exit(1);
+                    }
                     let mut input = String::new();
                     if std::io::stdin().read_line(&mut input).is_err()
                         || input.trim() != "reset production"
@@ -235,7 +284,10 @@ async fn main() {
                     }
                 } else {
                     print!("Type \"reset\" to confirm: ");
-                    std::io::stdout().flush().unwrap_or(());
+                    if let Err(e) = std::io::stdout().flush() {
+                        eprintln!("Cannot write to terminal: {e}");
+                        std::process::exit(1);
+                    }
                     let mut input = String::new();
                     if std::io::stdin().read_line(&mut input).is_err() || input.trim() != "reset" {
                         println!("Cancelled.");
@@ -260,6 +312,13 @@ async fn main() {
                     "Warning: could not scan recovery directory {}: {err}\n\
                      Recovery files were not cleaned up. \
                      You may need to remove them manually.",
+                    dir.display()
+                );
+            }
+            if let Some((dir, err)) = &report.backup_dir_error {
+                eprintln!(
+                    "Warning: could not scan {} for backups: {err}\n\
+                     Backup files may not have been deleted.",
                     dir.display()
                 );
             }
@@ -366,10 +425,12 @@ async fn main() {
     };
     let db_path = config.data_dir.join(profile.as_str()).join("mokumo.db");
 
+    // Master shutdown token — Ctrl+C cancels this once. Each loop iteration creates
+    // a child token so individual restarts don't tear down the master signal.
+    let master_shutdown = CancellationToken::new();
+
     // Server loop: runs once normally, restarts on demo reset.
     // Each iteration gets a fresh shutdown token, DB pool, and app state.
-    // Master shutdown token — Ctrl+C cancels this once; child tokens per loop iteration.
-    let master_shutdown = CancellationToken::new();
     {
         let token = master_shutdown.clone();
         tokio::spawn(async move {

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -45,6 +45,10 @@ enum Commands {
         /// Also delete pre-migration backup files
         #[arg(long)]
         include_backups: bool,
+        /// Reset the production profile instead of the default demo profile.
+        /// Requires an additional confirmation prompt.
+        #[arg(long)]
+        production: bool,
     },
 }
 
@@ -107,13 +111,32 @@ async fn main() {
         Some(Commands::ResetDb {
             force,
             include_backups,
+            production,
         }) => {
-            let db_path = data_dir.join("mokumo.db");
+            // Determine which profile to target.
+            // Default: demo (safe). Production requires explicit --production flag.
+            let profile_dir = if production {
+                data_dir.join("production")
+            } else {
+                data_dir.join("demo")
+            };
+            let db_path = profile_dir.join("mokumo.db");
 
-            // Early exit if no database exists (idempotent, exit 0)
+            // Early exit when neither profile database exists (idempotent, exit 0)
+            let demo_db = data_dir.join("demo").join("mokumo.db");
+            let production_db = data_dir.join("production").join("mokumo.db");
+            let any_db_exists = demo_db.try_exists().unwrap_or(false)
+                || production_db.try_exists().unwrap_or(false);
+
             match db_path.try_exists() {
-                Ok(false) => {
+                Ok(false) if !any_db_exists => {
                     println!("No database found at {}.", data_dir.display());
+                    return;
+                }
+                Ok(false) => {
+                    // The other profile has a DB but not the targeted one
+                    let profile_name = if production { "production" } else { "demo" };
+                    println!("No database found for the {profile_name} profile.");
                     return;
                 }
                 Err(e) => {
@@ -158,12 +181,12 @@ async fn main() {
             // File inventory preview
             let mut preview_files: Vec<PathBuf> = Vec::new();
             for suffix in DB_SIDECAR_SUFFIXES {
-                let path = data_dir.join(format!("mokumo.db{suffix}"));
+                let path = profile_dir.join(format!("mokumo.db{suffix}"));
                 if path.exists() {
                     preview_files.push(path);
                 }
             }
-            if include_backups && let Ok(entries) = std::fs::read_dir(&data_dir) {
+            if include_backups && let Ok(entries) = std::fs::read_dir(&profile_dir) {
                 for entry in entries.flatten() {
                     if let Some(name) = entry.file_name().to_str()
                         && name.starts_with("mokumo.db.backup-v")
@@ -191,22 +214,40 @@ async fn main() {
             }
             println!();
 
-            // Confirmation gate
+            // Confirmation gate.
+            // --production requires an additional explicit confirmation step
+            // because wiping production data is irreversible.
             if !force {
                 use std::io::Write;
-                print!("Type \"reset\" to confirm: ");
-                std::io::stdout().flush().unwrap_or(());
-                let mut input = String::new();
-                if std::io::stdin().read_line(&mut input).is_err() || input.trim() != "reset" {
-                    println!("Cancelled.");
-                    return;
+                if production {
+                    eprintln!(
+                        "WARNING: You are about to permanently delete the PRODUCTION database.\n\
+                         This cannot be undone. All production data will be lost.\n"
+                    );
+                    print!("Type \"reset production\" to confirm: ");
+                    std::io::stdout().flush().unwrap_or(());
+                    let mut input = String::new();
+                    if std::io::stdin().read_line(&mut input).is_err()
+                        || input.trim() != "reset production"
+                    {
+                        println!("Cancelled.");
+                        return;
+                    }
+                } else {
+                    print!("Type \"reset\" to confirm: ");
+                    std::io::stdout().flush().unwrap_or(());
+                    let mut input = String::new();
+                    if std::io::stdin().read_line(&mut input).is_err() || input.trim() != "reset" {
+                        println!("Cancelled.");
+                        return;
+                    }
                 }
             }
 
             // Execute the reset while flock is held. The flock is on a
             // separate sentinel file (not the db), so it does not interfere
             // with file deletion on any platform.
-            let report = match cli_reset_db(&data_dir, &recovery_dir, include_backups) {
+            let report = match cli_reset_db(&profile_dir, &recovery_dir, include_backups) {
                 Ok(r) => r,
                 Err(e) => {
                     eprintln!("Reset failed: {e}");

--- a/services/api/tests/cli_reset_db_binary.rs
+++ b/services/api/tests/cli_reset_db_binary.rs
@@ -22,17 +22,21 @@ impl Drop for ServerGuard {
 }
 
 /// Strip ANSI escape sequences from a string.
+///
+/// Handles all CSI sequences per ECMA-48: terminates on any character in the
+/// range 0x40–0x7E, not just 'm'. This covers cursor movement, clear-screen,
+/// and other codes that tracing-subscriber may emit on unusual terminals.
 fn strip_ansi(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c == '\x1b' {
-            // Skip until 'm' (end of ANSI escape sequence)
-            for esc_c in chars.by_ref() {
-                if esc_c == 'm' {
-                    break;
-                }
+    let mut in_escape = false;
+    for c in s.chars() {
+        if in_escape {
+            // End of CSI sequence: any byte in 0x40–0x7E (ECMA-48 §5.4)
+            if c.is_ascii() && (0x40u8..=0x7Eu8).contains(&(c as u8)) {
+                in_escape = false;
             }
+        } else if c == '\x1b' {
+            in_escape = true;
         } else {
             result.push(c);
         }
@@ -219,10 +223,11 @@ fn reset_db_default_targets_demo_profile() {
     // Set up profile structure: demo/ and production/ subdirectories
     mokumo_api::ensure_data_dirs(data_dir).unwrap();
 
-    // Place a database only in the demo profile
+    // Seed both profiles so the isolation assertion is meaningful
     let demo_db = data_dir.join("demo").join("mokumo.db");
     let production_db = data_dir.join("production").join("mokumo.db");
     fs::write(&demo_db, b"demo-data").unwrap();
+    fs::write(&production_db, b"production-data").unwrap();
 
     let recovery_dir = data_dir.join("recovery");
     fs::create_dir_all(&recovery_dir).unwrap();
@@ -247,8 +252,8 @@ fn reset_db_default_targets_demo_profile() {
     );
     assert!(!demo_db.exists(), "demo/mokumo.db should have been deleted");
     assert!(
-        !production_db.exists(),
-        "production/mokumo.db should not have been touched"
+        production_db.exists(),
+        "production/mokumo.db should not have been deleted"
     );
 }
 
@@ -260,10 +265,11 @@ fn reset_db_production_flag_targets_production_profile() {
 
     mokumo_api::ensure_data_dirs(data_dir).unwrap();
 
-    // Place a database only in the production profile
+    // Seed both profiles so the isolation assertion is meaningful
     let demo_db = data_dir.join("demo").join("mokumo.db");
     let production_db = data_dir.join("production").join("mokumo.db");
     fs::write(&production_db, b"production-data").unwrap();
+    fs::write(&demo_db, b"demo-data").unwrap();
 
     let recovery_dir = data_dir.join("recovery");
     fs::create_dir_all(&recovery_dir).unwrap();
@@ -292,8 +298,8 @@ fn reset_db_production_flag_targets_production_profile() {
         "production/mokumo.db should have been deleted"
     );
     assert!(
-        !demo_db.exists(),
-        "demo/mokumo.db should not have been touched"
+        demo_db.exists(),
+        "demo/mokumo.db should not have been deleted"
     );
 }
 
@@ -333,6 +339,161 @@ fn reset_db_no_db_found_when_neither_profile_exists() {
         stdout.contains("No database found"),
         "stdout should mention 'No database found', got: {stdout}"
     );
+}
+
+/// Targeted profile is absent but the OTHER profile has a database.
+/// Verifies the per-profile early-exit message and that the other DB is untouched.
+#[test]
+fn reset_db_demo_profile_absent_when_production_exists() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+
+    // Only production DB exists — demo is absent
+    let demo_db = data_dir.join("demo").join("mokumo.db");
+    let production_db = data_dir.join("production").join("mokumo.db");
+    fs::write(&production_db, b"production-data").unwrap();
+
+    let recovery_dir = data_dir.join("recovery");
+    fs::create_dir_all(&recovery_dir).unwrap();
+
+    let output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "reset-db",
+            "--force",
+        ])
+        .env("MOKUMO_RECOVERY_DIR", &recovery_dir)
+        .output()
+        .expect("failed to spawn reset-db");
+
+    assert!(
+        output.status.success(),
+        "reset-db should exit 0 when demo profile is absent, got exit {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No database found for the demo profile"),
+        "stdout should report missing demo profile, got: {stdout}"
+    );
+    assert!(
+        production_db.exists(),
+        "production/mokumo.db should not have been deleted"
+    );
+    assert!(!demo_db.exists(), "demo/mokumo.db was never created");
+}
+
+/// `reset-db --production` is blocked by a running server (flock guard).
+#[tokio::test]
+async fn reset_db_production_blocked_by_running_server() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().to_path_buf();
+
+    mokumo_api::ensure_data_dirs(&data_dir).unwrap();
+
+    // Initialize both profile DBs. The server uses demo (default active profile).
+    // Production must be a valid SQLite DB so prepare_database's non-active migration
+    // step doesn't fail; and it must exist so reset-db --production passes the early-exit check.
+    let demo_db_path = data_dir.join("demo").join("mokumo.db");
+    let production_db_path = data_dir.join("production").join("mokumo.db");
+    for db_url in [
+        format!("sqlite:{}?mode=rwc", demo_db_path.display()),
+        format!("sqlite:{}?mode=rwc", production_db_path.display()),
+    ] {
+        let db = mokumo_db::initialize_database(&db_url).await.unwrap();
+        db.close().await.ok();
+    }
+
+    let mut server_proc = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "--port",
+            "0",
+            "--host",
+            "127.0.0.1",
+        ])
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn server");
+
+    let stderr = server_proc.stderr.take().expect("stderr not captured");
+    let stdout = server_proc.stdout.take().expect("stdout not captured");
+    let guard = ServerGuard { child: server_proc };
+
+    let (port_tx, port_rx) = std::sync::mpsc::channel();
+    let port_tx_clone = port_tx.clone();
+    let stdout_thread = std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines().map_while(Result::ok) {
+            if let Some(port) = parse_port_from_log(&line) {
+                let _ = port_tx_clone.send(port);
+            }
+        }
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            if let Some(port) = parse_port_from_log(&line) {
+                let _ = port_tx.send(port);
+            }
+        }
+    });
+
+    let port = match port_rx.recv_timeout(Duration::from_secs(30)) {
+        Ok(p) => p,
+        Err(_) => {
+            drop(guard);
+            panic!("server did not report its port within 30s");
+        }
+    };
+    wait_for_health(port, Duration::from_secs(10))
+        .await
+        .expect("server health check failed");
+
+    let recovery_dir = data_dir.join("recovery");
+    std::fs::create_dir_all(&recovery_dir).unwrap();
+
+    // reset-db --production should be blocked by the same flock as demo
+    let reset_output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "reset-db",
+            "--force",
+            "--production",
+        ])
+        .env("MOKUMO_RECOVERY_DIR", &recovery_dir)
+        .output()
+        .expect("failed to spawn reset-db --production");
+
+    let reset_stderr = String::from_utf8_lossy(&reset_output.stderr);
+
+    assert!(
+        !reset_output.status.success(),
+        "reset-db --production should have been blocked, but succeeded. stderr: {reset_stderr}"
+    );
+    assert!(
+        reset_stderr.contains("in use by a running server"),
+        "stderr should contain the flock rejection message, got: {reset_stderr}"
+    );
+    assert!(
+        production_db_path.exists(),
+        "production/mokumo.db should still exist after blocked reset"
+    );
+
+    drop(guard);
+    let _ = stdout_thread.join();
+    let _ = stderr_thread.join();
 }
 
 #[test]

--- a/services/api/tests/cli_reset_db_binary.rs
+++ b/services/api/tests/cli_reset_db_binary.rs
@@ -4,6 +4,7 @@
 //! `mokumo-api reset-db --force` against the same data directory and asserts
 //! that the flock guard rejects the reset.
 
+use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -163,18 +164,13 @@ async fn reset_db_blocked_by_running_server() {
         .await
         .expect("server health check failed");
 
-    // reset-db checks for mokumo.db at the data_dir root (flat layout path).
-    // Create a sentinel file AFTER the server has started so migrate_flat_layout
-    // doesn't interfere with server startup.
-    let root_db_path = data_dir.join("mokumo.db");
-    std::fs::write(&root_db_path, b"").unwrap();
-
     // Point reset-db at the temp dir for recovery files so it never touches
     // the real Desktop or cwd, even if the flock guard regresses.
     let recovery_dir = data_dir.join("recovery");
     std::fs::create_dir_all(&recovery_dir).unwrap();
 
-    // Now run reset-db against the same data directory — it should be blocked
+    // Now run reset-db against the same data directory — it should be blocked.
+    // No --production flag: targets demo profile (the server's active profile).
     let reset_output = Command::new(binary)
         .args([
             "--data-dir",
@@ -198,11 +194,7 @@ async fn reset_db_blocked_by_running_server() {
         "stderr should contain the flock rejection message, got: {reset_stderr}"
     );
 
-    // Verify the databases still exist (reset-db didn't delete anything)
-    assert!(
-        root_db_path.exists(),
-        "root database file should still exist after blocked reset-db"
-    );
+    // Verify the profile database still exists (reset-db didn't delete anything)
     assert!(
         profile_db_path.exists(),
         "profile database file should still exist after blocked reset-db"
@@ -212,6 +204,135 @@ async fn reset_db_blocked_by_running_server() {
     drop(guard);
     let _ = stdout_thread.join();
     let _ = stderr_thread.join();
+}
+
+// ---------------------------------------------------------------------------
+// Profile-aware reset-db tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reset_db_default_targets_demo_profile() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+
+    // Set up profile structure: demo/ and production/ subdirectories
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+
+    // Place a database only in the demo profile
+    let demo_db = data_dir.join("demo").join("mokumo.db");
+    let production_db = data_dir.join("production").join("mokumo.db");
+    fs::write(&demo_db, b"demo-data").unwrap();
+
+    let recovery_dir = data_dir.join("recovery");
+    fs::create_dir_all(&recovery_dir).unwrap();
+
+    // reset-db without --production should target demo/ by default
+    let output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "reset-db",
+            "--force",
+        ])
+        .env("MOKUMO_RECOVERY_DIR", &recovery_dir)
+        .output()
+        .expect("failed to spawn reset-db");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "reset-db should succeed, got exit {}: {stderr}",
+        output.status
+    );
+    assert!(!demo_db.exists(), "demo/mokumo.db should have been deleted");
+    assert!(
+        !production_db.exists(),
+        "production/mokumo.db should not have been touched"
+    );
+}
+
+#[test]
+fn reset_db_production_flag_targets_production_profile() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+
+    // Place a database only in the production profile
+    let demo_db = data_dir.join("demo").join("mokumo.db");
+    let production_db = data_dir.join("production").join("mokumo.db");
+    fs::write(&production_db, b"production-data").unwrap();
+
+    let recovery_dir = data_dir.join("recovery");
+    fs::create_dir_all(&recovery_dir).unwrap();
+
+    // reset-db with --production should target production/
+    let output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "reset-db",
+            "--force",
+            "--production",
+        ])
+        .env("MOKUMO_RECOVERY_DIR", &recovery_dir)
+        .output()
+        .expect("failed to spawn reset-db");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "reset-db --production should succeed, got exit {}: {stderr}",
+        output.status
+    );
+    assert!(
+        !production_db.exists(),
+        "production/mokumo.db should have been deleted"
+    );
+    assert!(
+        !demo_db.exists(),
+        "demo/mokumo.db should not have been touched"
+    );
+}
+
+#[test]
+fn reset_db_no_db_found_when_neither_profile_exists() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+    // No databases created in either profile
+
+    let recovery_dir = data_dir.join("recovery");
+    fs::create_dir_all(&recovery_dir).unwrap();
+
+    let output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "reset-db",
+            "--force",
+        ])
+        .env("MOKUMO_RECOVERY_DIR", &recovery_dir)
+        .output()
+        .expect("failed to spawn reset-db");
+
+    // Should exit 0 (idempotent)
+    assert!(
+        output.status.success(),
+        "reset-db with no database should exit 0, got exit {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No database found"),
+        "stdout should mention 'No database found', got: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `reset-db` now targets `data_dir/demo/mokumo.db` by default (was incorrectly looking at the old flat `data_dir/mokumo.db`)
- New `--production` flag targets `data_dir/production/mokumo.db` with a stronger confirmation prompt (`"reset production"` instead of `"reset"`)
- Early-exit message is now accurate: reports per-profile when only one profile is missing, and a general message when neither exists

## Changes

- `services/api/src/main.rs` — `ResetDb` subcommand: add `--production` flag, compute `profile_dir` from flag, update early-exit check, file preview, deletion, and confirmation copy
- `services/api/src/lib.rs` — rename `cli_reset_db` first param `data_dir` → `profile_dir` (semantic clarification; callers now resolve the profile before calling)
- `services/api/tests/cli_reset_db_binary.rs` — 3 new binary tests + update existing flock test to remove stale flat-path sentinel

## Test plan

- [x] `reset_db_default_targets_demo_profile` — no `--production` flag deletes `demo/mokumo.db`, leaves `production/` untouched
- [x] `reset_db_production_flag_targets_production_profile` — `--production` deletes `production/mokumo.db`, leaves `demo/` untouched
- [x] `reset_db_no_db_found_when_neither_profile_exists` — exits 0 with "No database found"
- [x] `reset_db_blocked_by_running_server` — flock guard still rejects reset while server is running
- [x] All 269 tests pass (`moon run api:test`)
- [x] Clippy and `cargo fmt` clean

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * reset-db CLI now targets the correct profile database by default.

* **New Features**
  * Added --production flag to reset-db to target the production profile.
  * Stronger confirmation for production resets (requires explicit confirmation).

* **User-facing Behavior**
  * Profile-aware idempotency: command exits cleanly when no target DB exists and reports which profile was checked.
  * Backup-directory scan failures now surface as warnings.

* **Tests**
  * Added profile-aware integration tests for reset-db scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->