### PR TITLE
fix(auth): forgot password UX — Desktop guidance, unknown email error, auto-open recovery file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Forgot password step 2 now tells Desktop users where to find the recovery file; Desktop app auto-opens the file on submission (#260)
+- Forgot password now shows an error when the email address is not found, instead of silently advancing to step 2 (#260)
 - Demo guide slides now show real screenshots instead of invisible HTML comment placeholders (#228)
 - Demo reset shutdown delay increased from 100ms to 500ms to prevent truncated responses (#218)
 - `demo-smoke` CI job now gates PR merge via verdict check (was `continue-on-error`, now enforced) (#218)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,6 +61,7 @@
     "vitest": "^4.0.0"
   },
   "dependencies": {
+    "@tauri-apps/plugin-opener": "^2",
     "clsx": "^2.1.1",
     "mode-watcher": "^1.1.0",
     "runed": "0.37.1",

--- a/apps/web/src/routes/(auth)/forgot-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/forgot-password/+page.svelte
@@ -28,6 +28,7 @@
   let pin = $state("");
   let newPassword = $state("");
 
+  let isTauri = $derived("__TAURI_INTERNALS__" in window);
   let emailValid = $derived(email.length > 0);
   let resetValid = $derived(pin.length === 6 && newPassword.length >= 8);
 
@@ -98,9 +99,12 @@
     <CardDescription>
       {#if phase === "email"}
         Enter your email to receive a recovery file with a PIN.
-      {:else}
+      {:else if isTauri}
         A recovery file has been saved to your Desktop. Open it to find your
         6-digit PIN, then choose a new password.
+      {:else}
+        A recovery file has been saved on the computer running Mokumo. Open it
+        there to find your 6-digit PIN, then choose a new password.
       {/if}
     </CardDescription>
   </CardHeader>

--- a/apps/web/src/routes/(auth)/forgot-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/forgot-password/+page.svelte
@@ -55,16 +55,16 @@
       "data" in result ? (result.data.recovery_file_path ?? null) : null;
     phase = "reset";
 
-    if (
-      recoveryFilePath &&
-      typeof window !== "undefined" &&
-      "__TAURI_INTERNALS__" in window
-    ) {
+    if (recoveryFilePath && "__TAURI_INTERNALS__" in window) {
       try {
         const { openPath } = await import("@tauri-apps/plugin-opener");
         await openPath(recoveryFilePath);
-      } catch {
+      } catch (openErr) {
         // Non-fatal: user can still open the file manually from their Desktop
+        console.warn(
+          "[forgot-password] openPath failed, user must open file manually:",
+          openErr,
+        );
       }
     }
   }

--- a/apps/web/src/routes/(auth)/forgot-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/forgot-password/+page.svelte
@@ -19,6 +19,7 @@
   let phase = $state<"email" | "reset">("email");
   let error = $state<string | null>(null);
   let loading = $state(false);
+  let recoveryFilePath = $state<string | null>(null);
 
   // Phase 1
   let email = $state("");
@@ -35,7 +36,10 @@
     error = null;
     loading = true;
 
-    const result = await apiFetch("/api/auth/forgot-password", {
+    const result = await apiFetch<{
+      message: string;
+      recovery_file_path?: string;
+    }>("/api/auth/forgot-password", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email }),
@@ -47,7 +51,22 @@
       return;
     }
 
+    recoveryFilePath =
+      "data" in result ? (result.data.recovery_file_path ?? null) : null;
     phase = "reset";
+
+    if (
+      recoveryFilePath &&
+      typeof window !== "undefined" &&
+      "__TAURI_INTERNALS__" in window
+    ) {
+      try {
+        const { openPath } = await import("@tauri-apps/plugin-opener");
+        await openPath(recoveryFilePath);
+      } catch {
+        // Non-fatal: user can still open the file manually from their Desktop
+      }
+    }
   }
 
   async function handleReset(e: Event) {
@@ -80,7 +99,8 @@
       {#if phase === "email"}
         Enter your email to receive a recovery file with a PIN.
       {:else}
-        Enter the 6-digit PIN from your recovery file and choose a new password.
+        A recovery file has been saved to your Desktop. Open it to find your
+        6-digit PIN, then choose a new password.
       {/if}
     </CardDescription>
   </CardHeader>

--- a/apps/web/src/routes/(auth)/forgot-password/page.test.ts
+++ b/apps/web/src/routes/(auth)/forgot-password/page.test.ts
@@ -82,14 +82,16 @@ describe("ForgotPasswordPage", () => {
       return user;
     }
 
-    it("step 2 description tells user the recovery file is on their Desktop", async () => {
+    it("step 2 description mentions Desktop when in Tauri context", async () => {
+      vi.stubGlobal("__TAURI_INTERNALS__", {});
       await advanceToResetPhase();
       expect(screen.getByText(/desktop/i)).toBeInTheDocument();
     });
 
-    it("step 2 description includes guidance to open the recovery file", async () => {
+    it("step 2 description mentions server machine when in browser context", async () => {
+      // __TAURI_INTERNALS__ is not set (unstubAllGlobals in beforeEach)
       await advanceToResetPhase();
-      expect(screen.getByText(/recovery file/i)).toBeInTheDocument();
+      expect(screen.getByText(/computer running mokumo/i)).toBeInTheDocument();
     });
 
     it("opens recovery file via Tauri opener when in Tauri context", async () => {

--- a/apps/web/src/routes/(auth)/forgot-password/page.test.ts
+++ b/apps/web/src/routes/(auth)/forgot-password/page.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import ForgotPasswordPage from "./+page.svelte";
+
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }));
+vi.mock("$lib/api", () => ({ apiFetch: vi.fn() }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openPath: vi.fn().mockResolvedValue(undefined) }));
+
+import { apiFetch } from "$lib/api";
+import { openPath } from "@tauri-apps/plugin-opener";
+
+const mockApiFetch = vi.mocked(apiFetch);
+const mockOpenPath = vi.mocked(openPath);
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    mockOpenPath.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("phase: email", () => {
+    it("renders email form initially", () => {
+      render(ForgotPasswordPage);
+      expect(screen.getByText(/forgot password/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /send recovery file/i })).toBeInTheDocument();
+    });
+
+    it("shows error when API returns 400 for unknown email", async () => {
+      mockApiFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        error: {
+          code: "validation_error",
+          message: "No account found for that email address",
+          details: null,
+        },
+      });
+
+      render(ForgotPasswordPage);
+      const user = userEvent.setup();
+
+      await user.type(screen.getByLabelText(/email/i), "nobody@shop.local");
+      await user.click(screen.getByRole("button", { name: /send recovery file/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/no account found/i)).toBeInTheDocument();
+      });
+      // Should NOT advance to reset phase
+      expect(screen.queryByLabelText(/pin/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("phase: reset", () => {
+    async function advanceToResetPhase(
+      recoveryFilePath = "/Users/test/Desktop/mokumo-recovery-abc.html",
+    ) {
+      mockApiFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: { message: "Recovery file placed", recovery_file_path: recoveryFilePath },
+      });
+
+      render(ForgotPasswordPage);
+      const user = userEvent.setup();
+
+      await user.type(screen.getByLabelText(/email/i), "admin@shop.local");
+      await user.click(screen.getByRole("button", { name: /send recovery file/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/pin/i)).toBeInTheDocument();
+      });
+
+      return user;
+    }
+
+    it("step 2 description tells user the recovery file is on their Desktop", async () => {
+      await advanceToResetPhase();
+      expect(screen.getByText(/desktop/i)).toBeInTheDocument();
+    });
+
+    it("step 2 description includes guidance to open the recovery file", async () => {
+      await advanceToResetPhase();
+      expect(screen.getByText(/recovery file/i)).toBeInTheDocument();
+    });
+
+    it("opens recovery file via Tauri opener when in Tauri context", async () => {
+      vi.stubGlobal("__TAURI_INTERNALS__", {});
+
+      await advanceToResetPhase("/Users/test/Desktop/mokumo-recovery-abc.html");
+
+      await waitFor(() => {
+        expect(mockOpenPath).toHaveBeenCalledWith("/Users/test/Desktop/mokumo-recovery-abc.html");
+      });
+    });
+
+    it("does not call opener when not in Tauri context", async () => {
+      // __TAURI_INTERNALS__ is not set (unstubAllGlobals in beforeEach)
+      await advanceToResetPhase();
+      // Give time for any async calls to settle
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockOpenPath).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@tauri-apps/plugin-opener':
+        specifier: ^2
+        version: 2.5.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1569,6 +1572,12 @@ packages:
     resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tauri-apps/api@2.10.1':
+    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
 
   '@teppeis/multimaps@3.0.0':
     resolution: {integrity: sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==}
@@ -4657,6 +4666,12 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
       vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  '@tauri-apps/api@2.10.1': {}
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@teppeis/multimaps@3.0.0': {}
 

--- a/services/api/src/auth/reset.rs
+++ b/services/api/src/auth/reset.rs
@@ -76,6 +76,17 @@ pub async fn forgot_password(
         AppError::InternalError("An internal error occurred".into())
     })?;
 
+    let dir = &state.recovery_dir;
+    if let Err(e) = tokio::fs::create_dir_all(dir).await {
+        tracing::error!("Failed to create recovery dir {}: {e}", dir.display());
+        return Err(AppError::InternalError("An internal error occurred".into()));
+    }
+    let file_path = recovery_file_path_for_email(dir, &req.email);
+    if let Err(e) = tokio::fs::write(&file_path, recovery_html(&pin)).await {
+        tracing::error!("Failed to write recovery file {}: {e}", file_path.display());
+        return Err(AppError::InternalError("An internal error occurred".into()));
+    }
+
     state.reset_pins.insert(
         req.email.clone(),
         PendingReset {
@@ -83,19 +94,6 @@ pub async fn forgot_password(
             created_at: SystemTime::now(),
         },
     );
-
-    let dir = &state.recovery_dir;
-    if let Err(e) = tokio::fs::create_dir_all(dir).await {
-        tracing::error!("Failed to create recovery dir {}: {e}", dir.display());
-        state.reset_pins.remove(&req.email);
-        return Err(AppError::InternalError("An internal error occurred".into()));
-    }
-    let file_path = recovery_file_path_for_email(dir, &req.email);
-    if let Err(e) = tokio::fs::write(&file_path, recovery_html(&pin)).await {
-        tracing::error!("Failed to write recovery file {}: {e}", file_path.display());
-        state.reset_pins.remove(&req.email);
-        return Err(AppError::InternalError("An internal error occurred".into()));
-    }
 
     let path_str = file_path.to_string_lossy().into_owned();
     Ok(Json(serde_json::json!({

--- a/services/api/src/auth/reset.rs
+++ b/services/api/src/auth/reset.rs
@@ -54,42 +54,51 @@ pub async fn forgot_password(
 
     let user = repo.find_by_email(&req.email).await.ok().flatten();
 
-    if let Some(_user) = user {
-        let pin: String = {
-            use rand::Rng;
-            let mut rng = rand::rng();
-            format!("{:06}", rng.random_range(0..1_000_000u32))
-        };
-
-        let pin_hash = match password::hash_password(pin.clone()).await {
-            Ok(hash) => hash,
-            Err(e) => {
-                tracing::error!("PIN hash failed: {e}");
-                return AppError::InternalError("An internal error occurred".into())
-                    .into_response();
-            }
-        };
-
-        state.reset_pins.insert(
-            req.email.clone(),
-            PendingReset {
-                pin_hash,
-                created_at: SystemTime::now(),
-            },
-        );
-
-        let dir = &state.recovery_dir;
-        if let Err(e) = std::fs::create_dir_all(dir) {
-            tracing::error!("Failed to create recovery dir {}: {e}", dir.display());
-        }
-        let file_path = recovery_file_path_for_email(dir, &req.email);
-        if let Err(e) = std::fs::write(&file_path, recovery_html(&pin)) {
-            tracing::error!("Failed to write recovery file: {e}");
-        }
+    if user.is_none() {
+        return AppError::BadRequest(
+            ErrorCode::ValidationError,
+            "No account found for that email address".into(),
+        )
+        .into_response();
     }
 
-    // Always return 200 to avoid leaking which emails exist
-    Json(serde_json::json!({"message": "Recovery file placed"})).into_response()
+    let pin: String = {
+        use rand::Rng;
+        let mut rng = rand::rng();
+        format!("{:06}", rng.random_range(0..1_000_000u32))
+    };
+
+    let pin_hash = match password::hash_password(pin.clone()).await {
+        Ok(hash) => hash,
+        Err(e) => {
+            tracing::error!("PIN hash failed: {e}");
+            return AppError::InternalError("An internal error occurred".into()).into_response();
+        }
+    };
+
+    state.reset_pins.insert(
+        req.email.clone(),
+        PendingReset {
+            pin_hash,
+            created_at: SystemTime::now(),
+        },
+    );
+
+    let dir = &state.recovery_dir;
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        tracing::error!("Failed to create recovery dir {}: {e}", dir.display());
+    }
+    let file_path = recovery_file_path_for_email(dir, &req.email);
+    if let Err(e) = std::fs::write(&file_path, recovery_html(&pin)) {
+        tracing::error!("Failed to write recovery file: {e}");
+    }
+
+    let path_str = file_path.to_string_lossy().into_owned();
+    Json(serde_json::json!({
+        "message": "Recovery file placed",
+        "recovery_file_path": path_str
+    }))
+    .into_response()
 }
 
 pub async fn reset_password(

--- a/services/api/src/auth/reset.rs
+++ b/services/api/src/auth/reset.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, SystemTime};
 
 use axum::Json;
 use axum::extract::State;
-use axum::response::{IntoResponse, Response};
 use mokumo_core::user::traits::UserRepository;
 use mokumo_db::user::password;
 use mokumo_db::user::repo::SeaOrmUserRepo;
@@ -49,17 +48,21 @@ fn recovery_html(pin: &str) -> String {
 pub async fn forgot_password(
     State(state): State<SharedState>,
     Json(req): Json<ForgotPasswordRequest>,
-) -> Response {
+) -> Result<Json<serde_json::Value>, AppError> {
     let repo = SeaOrmUserRepo::new(state.db.clone());
 
-    let user = repo.find_by_email(&req.email).await.ok().flatten();
-
-    if user.is_none() {
-        return AppError::BadRequest(
-            ErrorCode::ValidationError,
-            "No account found for that email address".into(),
-        )
-        .into_response();
+    match repo.find_by_email(&req.email).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return Err(AppError::BadRequest(
+                ErrorCode::ValidationError,
+                "No account found for that email address".into(),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("DB error during forgot-password lookup: {e}");
+            return Err(AppError::InternalError("An internal error occurred".into()));
+        }
     }
 
     let pin: String = {
@@ -68,13 +71,10 @@ pub async fn forgot_password(
         format!("{:06}", rng.random_range(0..1_000_000u32))
     };
 
-    let pin_hash = match password::hash_password(pin.clone()).await {
-        Ok(hash) => hash,
-        Err(e) => {
-            tracing::error!("PIN hash failed: {e}");
-            return AppError::InternalError("An internal error occurred".into()).into_response();
-        }
-    };
+    let pin_hash = password::hash_password(pin.clone()).await.map_err(|e| {
+        tracing::error!("PIN hash failed: {e}");
+        AppError::InternalError("An internal error occurred".into())
+    })?;
 
     state.reset_pins.insert(
         req.email.clone(),
@@ -87,34 +87,31 @@ pub async fn forgot_password(
     let dir = &state.recovery_dir;
     if let Err(e) = std::fs::create_dir_all(dir) {
         tracing::error!("Failed to create recovery dir {}: {e}", dir.display());
+        state.reset_pins.remove(&req.email);
+        return Err(AppError::InternalError("An internal error occurred".into()));
     }
     let file_path = recovery_file_path_for_email(dir, &req.email);
     if let Err(e) = std::fs::write(&file_path, recovery_html(&pin)) {
-        tracing::error!("Failed to write recovery file: {e}");
+        tracing::error!("Failed to write recovery file {}: {e}", file_path.display());
+        state.reset_pins.remove(&req.email);
+        return Err(AppError::InternalError("An internal error occurred".into()));
     }
 
     let path_str = file_path.to_string_lossy().into_owned();
-    Json(serde_json::json!({
+    Ok(Json(serde_json::json!({
         "message": "Recovery file placed",
         "recovery_file_path": path_str
-    }))
-    .into_response()
+    })))
 }
 
 pub async fn reset_password(
     State(state): State<SharedState>,
     Json(req): Json<ResetPasswordRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    let entry = state.reset_pins.get(&req.email);
-    let (pin_hash, created_at) = match entry {
-        Some(ref e) => (e.pin_hash.clone(), e.created_at),
-        None => {
-            return Err(AppError::BadRequest(
-                ErrorCode::ValidationError,
-                "No reset request found".into(),
-            ));
-        }
-    };
+    let entry = state.reset_pins.get(&req.email).ok_or_else(|| {
+        AppError::BadRequest(ErrorCode::ValidationError, "No reset request found".into())
+    })?;
+    let (pin_hash, created_at) = (entry.pin_hash.clone(), entry.created_at);
     drop(entry);
 
     let elapsed = SystemTime::now()
@@ -128,13 +125,12 @@ pub async fn reset_password(
         ));
     }
 
-    let valid = match password::verify_password(req.pin.clone(), pin_hash).await {
-        Ok(v) => v,
-        Err(e) => {
+    let valid = password::verify_password(req.pin.clone(), pin_hash)
+        .await
+        .map_err(|e| {
             tracing::error!("PIN verify failed: {e}");
-            return Err(AppError::InternalError("An internal error occurred".into()));
-        }
-    };
+            AppError::InternalError("An internal error occurred".into())
+        })?;
 
     if !valid {
         return Err(AppError::BadRequest(
@@ -146,18 +142,24 @@ pub async fn reset_password(
     let repo = SeaOrmUserRepo::new(state.db.clone());
     let user = match repo.find_by_email(&req.email).await {
         Ok(Some(u)) => u,
-        _ => {
+        Ok(None) => {
             return Err(AppError::BadRequest(
                 ErrorCode::ValidationError,
                 "No reset request found".into(),
             ));
         }
+        Err(e) => {
+            tracing::error!("DB error during reset-password lookup: {e}");
+            return Err(AppError::InternalError("An internal error occurred".into()));
+        }
     };
 
-    if let Err(e) = repo.update_password(&user.id, &req.new_password).await {
-        tracing::error!("Failed to update password: {e}");
-        return Err(AppError::InternalError("Failed to update password".into()));
-    }
+    repo.update_password(&user.id, &req.new_password)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to update password: {e}");
+            AppError::InternalError("Failed to update password".into())
+        })?;
 
     state.reset_pins.remove(&req.email);
     let file_path = recovery_file_path_for_email(&state.recovery_dir, &req.email);

--- a/services/api/src/auth/reset.rs
+++ b/services/api/src/auth/reset.rs
@@ -85,13 +85,13 @@ pub async fn forgot_password(
     );
 
     let dir = &state.recovery_dir;
-    if let Err(e) = std::fs::create_dir_all(dir) {
+    if let Err(e) = tokio::fs::create_dir_all(dir).await {
         tracing::error!("Failed to create recovery dir {}: {e}", dir.display());
         state.reset_pins.remove(&req.email);
         return Err(AppError::InternalError("An internal error occurred".into()));
     }
     let file_path = recovery_file_path_for_email(dir, &req.email);
-    if let Err(e) = std::fs::write(&file_path, recovery_html(&pin)) {
+    if let Err(e) = tokio::fs::write(&file_path, recovery_html(&pin)).await {
         tracing::error!("Failed to write recovery file {}: {e}", file_path.display());
         state.reset_pins.remove(&req.email);
         return Err(AppError::InternalError("An internal error occurred".into()));

--- a/services/api/tests/auth_reset_regressions.rs
+++ b/services/api/tests/auth_reset_regressions.rs
@@ -292,6 +292,58 @@ async fn recovery_code_reset_rejects_short_passwords() {
     assert_eq!(body["message"], "Password must be at least 8 characters");
 }
 
+#[tokio::test]
+async fn forgot_password_returns_error_for_unknown_email() {
+    let server = RunningServer::start("forgot_unknown_email").await;
+
+    let response = server
+        .server
+        .post("/api/auth/forgot-password")
+        .json(&json!({ "email": "nobody@shop.local" }))
+        .await;
+
+    assert_eq!(response.status_code(), http::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = response.json();
+    assert!(
+        body["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("No account found"),
+        "expected 'No account found' in message, got: {:?}",
+        body
+    );
+}
+
+#[tokio::test]
+async fn forgot_password_success_returns_recovery_file_path() {
+    let server = RunningServer::start("forgot_returns_path").await;
+    let repo = SeaOrmUserRepo::new(server.db.clone());
+
+    repo.create_admin_with_setup("admin@shop.local", "Admin", "password123", "Test Shop")
+        .await
+        .unwrap();
+
+    let response = server
+        .server
+        .post("/api/auth/forgot-password")
+        .json(&json!({ "email": "admin@shop.local" }))
+        .await;
+
+    assert_eq!(response.status_code(), http::StatusCode::OK);
+    let body: serde_json::Value = response.json();
+    let path = body["recovery_file_path"]
+        .as_str()
+        .expect("response should include recovery_file_path");
+    assert!(
+        path.ends_with(".html"),
+        "recovery_file_path should end with .html, got: {path}"
+    );
+    assert!(
+        path.contains("mokumo-recovery-"),
+        "recovery_file_path should contain 'mokumo-recovery-', got: {path}"
+    );
+}
+
 /// Intentional behavior: recovery code regeneration does NOT invalidate existing
 /// sessions. Session invalidation on credential change is deferred to M1
 /// (per CAO + Ada review).


### PR DESCRIPTION
## Summary

Fixes three UX gaps in the forgot-password flow discovered during M0 smoke testing (#260):

- **Step 2 copy**: Description now mentions "Desktop" and tells users to open the recovery file to find their PIN
- **Unknown email error**: API returns HTTP 400 (not silent 200) for unrecognized email addresses; error is surfaced in the UI
- **Auto-open recovery file**: Desktop app automatically opens the recovery HTML file via `@tauri-apps/plugin-opener` on submission; browser users get the updated copy guidance

Also addresses review findings: DB lookup errors and file-write failures now surface as 500s instead of being silently swallowed, and the Tauri `openPath` catch is bound to enable console.warn on failure.

## Test plan

- [ ] `moon run api:test` — 268 tests pass (2 new: unknown email 400, recovery_file_path in response)
- [ ] `moon run web:test` — 206 tests pass (6 new: email phase error, step 2 Desktop copy, Tauri opener in/out of context)
- [ ] Smoke test forgot-password in browser: enter unknown email → see error message
- [ ] Smoke test forgot-password in browser: enter valid email → step 2 shows Desktop guidance
- [ ] Smoke test forgot-password in Desktop app: enter valid email → recovery file opens automatically

## Advisory follow-ups (filed as issues, not blocking)

- breezy-bays-labs/mokumo#270 — extract reset logic (PIN gen + hash) out of handler
- breezy-bays-labs/mokumo#271 — replace `SeaOrmUserRepo` direct construction with `state.user_repo()` pattern
- ADR needed: email enumeration tradeoff (explicit 400 vs silent 200 in self-hosted context)
- ADR needed: filesystem path in API response (exception to "no internal details on the wire")

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery file now automatically opens on Desktop after submitting a forgot-password request.
  * UI shows context-aware instructions for locating the recovery file and retrieving the PIN.

* **Bug Fixes**
  * Forgot-password now displays a clear error when the provided email address is not found.

* **Tests**
  * Added integration and UI tests covering unknown-email error, successful recovery responses (including recovery file path), and Desktop vs. non-Desktop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->