### PR TITLE
fix(web): submit regen-codes dialog on Enter key

### DIFF
--- a/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
+++ b/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
@@ -49,7 +49,13 @@
       <AlertDialog.Title>{title}</AlertDialog.Title>
       <AlertDialog.Description>{description}</AlertDialog.Description>
     </AlertDialog.Header>
-    <div class="space-y-2">
+    <form
+      onsubmit={(e) => {
+        e.preventDefault();
+        if (!loading && password) handleConfirm();
+      }}
+      class="space-y-2"
+    >
       <label for="regen-password" class="text-sm font-medium">
         Current Password
       </label>
@@ -61,7 +67,7 @@
         placeholder="Enter your current password"
         disabled={loading}
       />
-    </div>
+    </form>
     {#if error}
       <div
         class="rounded-md bg-error/10 border border-error px-3 py-2 text-sm text-foreground"

--- a/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
+++ b/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
@@ -30,6 +30,7 @@
   });
 
   async function handleConfirm() {
+    if (loading || !password) return;
     loading = true;
     error = null;
     try {


### PR DESCRIPTION
## Summary
- Wrap the password input in a `<form>` so pressing Enter fires the native submit event and calls `handleConfirm`
- Button remains clickable as before; `disabled` guard prevents double-submit

## Test plan
- [ ] Open regenerate recovery codes dialog
- [ ] Type password and press Enter — dialog should submit (same as clicking Regenerate)
- [ ] Clicking the Regenerate button still works
- [ ] Escape still keeps the dialog open (existing `onEscapeKeydown` prevention is unaffected)
- [ ] 206 web tests pass (`moon run web:test`)

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the password confirmation dialog to prevent duplicate submissions, block submission when no password is entered, and ensure form submission is handled safely (prevents default browser submit and only proceeds when ready).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->