### PR TITLE
fix(api): prevent orphaned server processes in api:dev

### DIFF
--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -27,7 +27,12 @@ tasks:
     options:
       runFromWorkspaceRoot: true
   dev:
-    command: cargo run --package mokumo-api
+    # Build first, then exec the binary directly so Moon holds the actual server PID.
+    # `cargo run` forks a child and doesn't forward signals — the binary becomes an
+    # orphan when the parent is killed. `exec` replaces the shell with the server process.
+    script: |
+      cargo build --package mokumo-api
+      exec target/debug/mokumo-api
     deps:
     - web:build
     options:

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -31,6 +31,7 @@ tasks:
     # `cargo run` forks a child and doesn't forward signals — the binary becomes an
     # orphan when the parent is killed. `exec` replaces the shell with the server process.
     script: |
+      set -euo pipefail
       cargo build --package mokumo-api
       exec target/debug/mokumo-api
     deps:


### PR DESCRIPTION
## Summary
- Replace `cargo run --package mokumo-api` with a build-then-exec script
- `exec target/debug/mokumo-api` replaces the shell process with the binary, so Moon holds the actual server PID
- When Moon receives SIGTERM/SIGINT (Ctrl+C), the signal lands on mokumo-api directly — no orphans

**Root cause**: `cargo run` forks the compiled binary as a child and does not forward signals to it. Killing the parent leaves the child running indefinitely.

## Test plan
- [ ] `moon run api:dev` starts the server as before
- [ ] Pressing Ctrl+C kills the process cleanly with no orphaned `mokumo-api` processes in Activity Monitor
- [ ] `moon run api:test` still passes

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build process configuration for the API service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->