### PR TITLE
feat(api): dual-DB architecture with compound user ID (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+
+- **Session invalidation on deploy**: `AuthUser::Id` changed from `i64` to `ProfileUserId(SetupMode, i64)` (compound user ID for dual-DB routing). Any sessions created before this deploy are invalidated on first request. Pre-release with no active users — one-time logout only. (#276)
+
 ### Fixed
 
 - `reset-db` CLI now targets the correct profile database (`demo/mokumo.db` by default); use `--production` flag to reset the production profile with a stronger confirmation prompt (#258)

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -84,7 +84,7 @@ async fn init_server(
         shutdown,
         mdns_status.clone(),
     )
-    .await;
+    .await?;
 
     // Bind to port (with fallback)
     let (listener, actual_port) = try_bind(&config.host, config.port).await?;

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -71,13 +71,20 @@ async fn init_server(
     };
 
     // Shared startup: dirs, layout migration, sidecar copy, backup, DB init, non-active migration
-    let (pool, _profile) = prepare_database(&config.data_dir).await?;
+    let (demo_db, production_db, active_profile) = prepare_database(&config.data_dir).await?;
 
     // Pre-allocate mDNS status (will be populated after mDNS registration)
     let mdns_status = discovery::MdnsStatus::shared();
 
-    let (router, setup_token) =
-        build_app_with_shutdown(&config, pool, shutdown, mdns_status.clone()).await;
+    let (router, setup_token) = build_app_with_shutdown(
+        &config,
+        demo_db,
+        production_db,
+        active_profile,
+        shutdown,
+        mdns_status.clone(),
+    )
+    .await;
 
     // Bind to port (with fallback)
     let (listener, actual_port) = try_bind(&config.host, config.port).await?;

--- a/apps/web/scripts/seed-demo.ts
+++ b/apps/web/scripts/seed-demo.ts
@@ -154,21 +154,24 @@ async function createCustomerViaApi(
 }
 
 function findDatabase(dataDir: string): string {
-  // Dual-dir layout (S0.1): data_dir/demo/mokumo.db
-  const dualDirPath = join(dataDir, "demo", "mokumo.db");
-  if (existsSync(dualDirPath)) return dualDirPath;
+  // Dual-dir layout: setup wizard always writes to production/mokumo.db regardless
+  // of active_profile. Customers are created in production_db via the Production
+  // session returned by authenticate. The output is shipped as the demo sidecar
+  // (copied to data_dir/demo/mokumo.db at first launch via copy_sidecar_if_needed).
+  const productionPath = join(dataDir, "production", "mokumo.db");
+  if (existsSync(productionPath)) return productionPath;
 
-  // Fallback: data_dir/mokumo.db
+  // Fallback: data_dir/mokumo.db (pre-dual-dir layout)
   const flatPath = join(dataDir, "mokumo.db");
   if (existsSync(flatPath)) {
     console.warn(
-      `[seed] Warning: expected dual-dir layout (${dualDirPath}) not found, using flat layout`,
+      `[seed] Warning: expected dual-dir layout (${productionPath}) not found, using flat layout`,
     );
     return flatPath;
   }
 
   throw new Error(
-    `Database not found. Checked:\n  ${dualDirPath}\n  ${flatPath}\nDoes the Axum server create the DB in the expected location?`,
+    `Database not found. Checked:\n  ${productionPath}\n  ${flatPath}\nDoes the Axum server create the DB in the expected location?`,
   );
 }
 

--- a/apps/web/tests/features/demo-banner.feature
+++ b/apps/web/tests/features/demo-banner.feature
@@ -1,43 +1,15 @@
 @wip
 Feature: Demo mode banner
 
-  When Mokumo is running with demo data, a persistent banner
-  tells the user they are exploring demo data and offers a
-  link to Settings.
+  When Mokumo is running with demo data, a permanent banner tells the
+  user they are in demo mode and offers a CTA to open the profile
+  switcher. The banner cannot be dismissed.
+
+  # --- Visibility ---
 
   Scenario: Banner appears in demo mode
     Given the server is running in demo mode
     When the app shell loads
-    Then a demo banner is visible
-    And the banner text says "You're exploring demo data"
-
-  Scenario: Banner contains a link to Settings
-    Given the demo banner is visible
-    Then the banner contains a "Go to Settings" link
-
-  Scenario: Settings link navigates to System Settings
-    Given the demo banner is visible
-    When I click "Go to Settings"
-    Then I am on the System Settings page
-
-  Scenario: Banner can be dismissed
-    Given the demo banner is visible
-    When I click the dismiss button on the banner
-    Then the demo banner is no longer visible
-
-  Scenario: Banner dismissal persists across page loads
-    Given I have dismissed the demo banner
-    When I refresh the page
-    Then the demo banner is not visible
-
-  Scenario: Demo reset clears banner dismissal state
-    Given I have dismissed the demo banner
-    When the demo data is reset
-    Then the banner dismissal state is cleared
-
-  Scenario: Banner is visible after app reloads post-reset
-    Given the demo data has been reset
-    When the app reloads
     Then the demo banner is visible
 
   Scenario: Banner does not appear in production mode
@@ -45,7 +17,45 @@ Feature: Demo mode banner
     When the app shell loads
     Then no demo banner is visible
 
-  Scenario: Banner does not appear on fresh install
-    Given the server has not completed setup
-    When the app redirects to the setup wizard
-    Then no demo banner is visible
+  # --- Not dismissible ---
+
+  Scenario: Banner has no dismiss button
+    Given the demo banner is visible
+    Then there is no dismiss or close button on the banner
+
+  Scenario: Banner remains visible after page navigation
+    Given the demo banner is visible
+    When I navigate to the Customers page
+    Then the demo banner is still visible
+
+  Scenario: Banner remains visible after page reload
+    Given the demo banner is visible
+    When I reload the page
+    Then the demo banner is visible
+
+  # --- CTA text (context-sensitive) ---
+
+  Scenario: Banner shows "Set Up My Shop" before production is configured
+    Given the server is running in demo mode
+    And production setup has not been completed
+    When the app shell loads
+    Then the banner CTA reads "Set Up My Shop"
+
+  Scenario: Banner shows "Go to My Shop" after production is configured
+    Given the server is running in demo mode
+    And production setup has been completed
+    When the app shell loads
+    Then the banner CTA reads "Go to My Shop"
+
+  # --- CTA action ---
+
+  Scenario: Clicking the banner CTA opens the sidebar profile switcher
+    Given the demo banner is visible
+    When I click the banner CTA button
+    Then the sidebar profile switcher dropdown opens
+
+  Scenario: Banner CTA does not navigate to Settings
+    Given the demo banner is visible
+    When I click the banner CTA button
+    Then I am still on the same page
+    And I have not been navigated to Settings

--- a/services/api/src/activity/mod.rs
+++ b/services/api/src/activity/mod.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Query, State};
+use axum::extract::Query;
 use axum::routing::get;
 use axum::{Json, Router};
 use mokumo_core::activity::ActivityEntry;
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use crate::SharedState;
 use crate::error::AppError;
 use crate::pagination::PaginationParams;
+use crate::profile_db::ProfileDb;
 
 pub fn router() -> Router<SharedState> {
     Router::new().route("/", get(list_activity))
@@ -38,7 +39,7 @@ struct ListActivityQuery {
 }
 
 async fn list_activity(
-    State(state): State<SharedState>,
+    ProfileDb(db): ProfileDb,
     Query(query): Query<ListActivityQuery>,
 ) -> Result<Json<PaginatedList<ActivityEntryResponse>>, AppError> {
     let params = PaginationParams {
@@ -47,7 +48,7 @@ async fn list_activity(
     }
     .into_page_params();
 
-    let repo = SqliteActivityLogRepo::new(state.db.get_sqlite_connection_pool().clone());
+    let repo = SqliteActivityLogRepo::new(db.get_sqlite_connection_pool().clone());
     let (entries, total) = repo
         .list(
             query.entity_type.as_deref(),

--- a/services/api/src/auth/backend.rs
+++ b/services/api/src/auth/backend.rs
@@ -90,6 +90,9 @@ impl AuthnBackend for Backend {
         let Some((user, hash)) = repo.find_by_id_with_hash(&id).await? else {
             return Ok(None);
         };
+        if !user.is_active {
+            return Ok(None);
+        }
         Ok(Some(AuthenticatedUser::new(user, hash, mode)))
     }
 }

--- a/services/api/src/auth/backend.rs
+++ b/services/api/src/auth/backend.rs
@@ -119,13 +119,25 @@ mod tests {
     fn profile_user_id_roundtrip() {
         use crate::auth::user::ProfileUserId;
 
-        for original in [
-            ProfileUserId(SetupMode::Demo, 1),
-            ProfileUserId(SetupMode::Production, 99),
-        ] {
+        let cases = [
+            (ProfileUserId(SetupMode::Demo, 1), r#"["demo",1]"#),
+            (
+                ProfileUserId(SetupMode::Production, 99),
+                r#"["production",99]"#,
+            ),
+        ];
+
+        for (original, expected_json) in cases {
             let json = serde_json::to_string(&original).unwrap();
-            let restored: ProfileUserId = serde_json::from_str(&json).unwrap();
-            assert_eq!(restored, original, "roundtrip failed for {original:?}");
+            assert_eq!(
+                json, expected_json,
+                "serialization format changed for {original:?}"
+            );
+            let restored: ProfileUserId = serde_json::from_str(expected_json).unwrap();
+            assert_eq!(
+                restored, original,
+                "deserialization failed for {expected_json}"
+            );
         }
     }
 }

--- a/services/api/src/auth/backend.rs
+++ b/services/api/src/auth/backend.rs
@@ -1,11 +1,12 @@
 use axum_login::AuthnBackend;
 use mokumo_core::error::DomainError;
+use mokumo_core::setup::SetupMode;
 use mokumo_core::user::UserId;
 use mokumo_db::DatabaseConnection;
 use mokumo_db::user::password;
 use mokumo_db::user::repo::SeaOrmUserRepo;
 
-use super::user::AuthenticatedUser;
+use super::user::{AuthenticatedUser, ProfileUserId};
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct Credentials {
@@ -13,14 +14,40 @@ pub struct Credentials {
     pub password: String,
 }
 
+/// Authentication backend holding both profile databases.
+///
+/// `authenticate` uses the `active_profile` database (login form is only
+/// reachable in production mode; demo users auto-login via middleware).
+///
+/// `get_user` dispatches to the correct database by the profile discriminant
+/// in the compound user ID `(SetupMode, i64)`.
 #[derive(Clone)]
 pub struct Backend {
-    db: DatabaseConnection,
+    pub demo_db: DatabaseConnection,
+    pub production_db: DatabaseConnection,
+    /// The profile active at the time this Backend instance was created.
+    /// Used by `authenticate` to select which DB to check credentials against.
+    pub active_profile: SetupMode,
 }
 
 impl Backend {
-    pub fn new(db: DatabaseConnection) -> Self {
-        Self { db }
+    pub fn new(
+        demo_db: DatabaseConnection,
+        production_db: DatabaseConnection,
+        active_profile: SetupMode,
+    ) -> Self {
+        Self {
+            demo_db,
+            production_db,
+            active_profile,
+        }
+    }
+
+    fn db_for(&self, mode: SetupMode) -> &DatabaseConnection {
+        match mode {
+            SetupMode::Demo => &self.demo_db,
+            SetupMode::Production => &self.production_db,
+        }
     }
 }
 
@@ -33,7 +60,8 @@ impl AuthnBackend for Backend {
         &self,
         creds: Self::Credentials,
     ) -> Result<Option<Self::User>, Self::Error> {
-        let repo = SeaOrmUserRepo::new(self.db.clone());
+        let db = self.db_for(self.active_profile);
+        let repo = SeaOrmUserRepo::new(db.clone());
         let Some((user, hash)) = repo.find_by_email_with_hash(&creds.email).await? else {
             return Ok(None);
         };
@@ -44,18 +72,45 @@ impl AuthnBackend for Backend {
 
         let is_valid = password::verify_password(creds.password, hash.clone()).await?;
         if is_valid {
-            Ok(Some(AuthenticatedUser::new(user, hash)))
+            Ok(Some(AuthenticatedUser::new(
+                user,
+                hash,
+                self.active_profile,
+            )))
         } else {
             Ok(None)
         }
     }
 
-    async fn get_user(&self, user_id: &i64) -> Result<Option<Self::User>, Self::Error> {
-        let repo = SeaOrmUserRepo::new(self.db.clone());
-        let id = UserId::new(*user_id);
+    async fn get_user(&self, user_id: &ProfileUserId) -> Result<Option<Self::User>, Self::Error> {
+        let ProfileUserId(mode, raw_id) = *user_id;
+        let db = self.db_for(mode);
+        let repo = SeaOrmUserRepo::new(db.clone());
+        let id = UserId::new(raw_id);
         let Some((user, hash)) = repo.find_by_id_with_hash(&id).await? else {
             return Ok(None);
         };
-        Ok(Some(AuthenticatedUser::new(user, hash)))
+        Ok(Some(AuthenticatedUser::new(user, hash, mode)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The Backend is constructed from two DatabaseConnections and a SetupMode.
+    // Full integration tests for authenticate/get_user live in the BDD suite
+    // (demo_auth.feature, session_invalidation.feature, profile_middleware.feature).
+    // Here we just verify the constructor and db_for dispatch.
+
+    // db_for tests require real DatabaseConnection — tested via integration tests.
+    // This module primarily exercises the type-level guarantees.
+
+    #[test]
+    fn credentials_deserializes() {
+        let json = r#"{"email":"a@b.com","password":"secret"}"#;
+        let creds: Credentials = serde_json::from_str(json).unwrap();
+        assert_eq!(creds.email, "a@b.com");
+        assert_eq!(creds.password, "secret");
     }
 }

--- a/services/api/src/auth/backend.rs
+++ b/services/api/src/auth/backend.rs
@@ -16,8 +16,8 @@ pub struct Credentials {
 
 /// Authentication backend holding both profile databases.
 ///
-/// `authenticate` uses the `active_profile` database (login form is only
-/// reachable in production mode; demo users auto-login via middleware).
+/// `authenticate` always checks `production_db` — the setup wizard writes the
+/// admin account there, and demo mode auto-logins without credentials.
 ///
 /// `get_user` dispatches to the correct database by the profile discriminant
 /// in the compound user ID `(SetupMode, i64)`.
@@ -25,21 +25,13 @@ pub struct Credentials {
 pub struct Backend {
     pub demo_db: DatabaseConnection,
     pub production_db: DatabaseConnection,
-    /// The profile active at the time this Backend instance was created.
-    /// Used by `authenticate` to select which DB to check credentials against.
-    pub active_profile: SetupMode,
 }
 
 impl Backend {
-    pub fn new(
-        demo_db: DatabaseConnection,
-        production_db: DatabaseConnection,
-        active_profile: SetupMode,
-    ) -> Self {
+    pub fn new(demo_db: DatabaseConnection, production_db: DatabaseConnection) -> Self {
         Self {
             demo_db,
             production_db,
-            active_profile,
         }
     }
 
@@ -60,8 +52,11 @@ impl AuthnBackend for Backend {
         &self,
         creds: Self::Credentials,
     ) -> Result<Option<Self::User>, Self::Error> {
-        let db = self.db_for(self.active_profile);
-        let repo = SeaOrmUserRepo::new(db.clone());
+        // Credential-based login always authenticates against the production database.
+        // The setup wizard always writes the admin account to production_db, and demo
+        // mode auto-logins without credentials — so production_db is the only valid
+        // target regardless of the current active_profile.
+        let repo = SeaOrmUserRepo::new(self.production_db.clone());
         let Some((user, hash)) = repo.find_by_email_with_hash(&creds.email).await? else {
             return Ok(None);
         };
@@ -75,7 +70,7 @@ impl AuthnBackend for Backend {
             Ok(Some(AuthenticatedUser::new(
                 user,
                 hash,
-                self.active_profile,
+                SetupMode::Production,
             )))
         } else {
             Ok(None)

--- a/services/api/src/auth/backend.rs
+++ b/services/api/src/auth/backend.rs
@@ -116,4 +116,21 @@ mod tests {
         assert_eq!(creds.email, "a@b.com");
         assert_eq!(creds.password, "secret");
     }
+
+    /// Lock the serde format of ProfileUserId so accidental format changes break CI.
+    /// axum_login serialises this value into the session store — changing it
+    /// invalidates all active sessions for live users.
+    #[test]
+    fn profile_user_id_roundtrip() {
+        use crate::auth::user::ProfileUserId;
+
+        for original in [
+            ProfileUserId(SetupMode::Demo, 1),
+            ProfileUserId(SetupMode::Production, 99),
+        ] {
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: ProfileUserId = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, original, "roundtrip failed for {original:?}");
+        }
+    }
 }

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -131,7 +131,7 @@ async fn me(
     })?;
 
     let setup_complete = state.setup_completed.load(Ordering::Relaxed);
-    let repo = SeaOrmUserRepo::new((*db).clone());
+    let repo = SeaOrmUserRepo::new(db.clone());
     let recovery_codes_remaining = match repo.recovery_codes_remaining(&user.user.id).await {
         Ok(count) => count,
         Err(e) => {
@@ -173,7 +173,7 @@ pub async fn regenerate_recovery_codes(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new((*db).clone());
+    let repo = SeaOrmUserRepo::new(db.clone());
 
     // Re-fetch password hash from DB (not session cache) per AuthnBackend ADR
     let password_hash = match repo.find_by_id_with_hash(&user.user.id).await {

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -23,6 +23,7 @@ use mokumo_types::user::UserResponse;
 
 use crate::SharedState;
 use crate::error::AppError;
+use crate::profile_db::ProfileDb;
 
 use backend::{Backend, Credentials};
 
@@ -69,7 +70,7 @@ async fn login(
     mut auth_session: AuthSessionType,
     Json(req): Json<LoginRequest>,
 ) -> Result<Json<UserResponse>, AppError> {
-    let repo = SeaOrmUserRepo::new(state.db.clone());
+    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
     let creds = Credentials {
         email: req.email.clone(),
         password: req.password,
@@ -123,13 +124,14 @@ async fn logout(mut auth_session: AuthSessionType) -> Result<StatusCode, AppErro
 async fn me(
     State(state): State<SharedState>,
     auth_session: AuthSessionType,
+    ProfileDb(db): ProfileDb,
 ) -> Result<Json<MeResponse>, AppError> {
     let user = auth_session.user.as_ref().ok_or_else(|| {
         AppError::Unauthorized(ErrorCode::Unauthorized, "Not authenticated".into())
     })?;
 
     let setup_complete = state.setup_completed.load(Ordering::Relaxed);
-    let repo = SeaOrmUserRepo::new(state.db.clone());
+    let repo = SeaOrmUserRepo::new((*db).clone());
     let recovery_codes_remaining = match repo.recovery_codes_remaining(&user.user.id).await {
         Ok(count) => count,
         Err(e) => {
@@ -152,6 +154,7 @@ async fn me(
 pub async fn regenerate_recovery_codes(
     State(state): State<SharedState>,
     auth_session: AuthSessionType,
+    ProfileDb(db): ProfileDb,
     Json(req): Json<RegenerateRecoveryCodesRequest>,
 ) -> Result<Json<SetupResponse>, AppError> {
     let user = auth_session
@@ -170,7 +173,7 @@ pub async fn regenerate_recovery_codes(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new(state.db.clone());
+    let repo = SeaOrmUserRepo::new((*db).clone());
 
     // Re-fetch password hash from DB (not session cache) per AuthnBackend ADR
     let password_hash = match repo.find_by_id_with_hash(&user.user.id).await {
@@ -220,7 +223,7 @@ async fn setup(
 
     let setup_guard = SetupAttemptGuard::acquire(&state)?;
 
-    let repo = SeaOrmUserRepo::new(state.db.clone());
+    let repo = SeaOrmUserRepo::new(state.production_db.clone());
     let (user, recovery_codes) = match repo
         .create_admin_with_setup(
             &req.admin_email,
@@ -335,6 +338,7 @@ async fn auto_login(
     user: &mokumo_core::user::User,
     auth_session: &mut AuthSessionType,
 ) {
+    use mokumo_core::setup::SetupMode;
     let hash = match repo.find_by_id_with_hash(&user.id).await {
         Ok(Some((_, hash))) => hash,
         Ok(None) => return,
@@ -343,7 +347,7 @@ async fn auto_login(
             return;
         }
     };
-    let auth_user = user::AuthenticatedUser::new(user.clone(), hash);
+    let auth_user = user::AuthenticatedUser::new(user.clone(), hash, SetupMode::Production);
     if let Err(e) = auth_session.login(&auth_user).await {
         tracing::warn!("Auto-login after setup failed: {e}");
     }
@@ -369,11 +373,11 @@ pub async fn require_auth_with_demo_auto_login(
     // Demo mode auto-login: create a session for the demo admin if not authenticated.
     // Uses find_by_email_with_hash to resolve user + hash in a single DB query
     // (avoids the 2-query path through auto_login → find_by_id_with_hash).
-    if state.setup_mode == Some(SetupMode::Demo) && auth_session.user.is_none() {
-        let repo = SeaOrmUserRepo::new(state.db.clone());
+    if state.active_profile == SetupMode::Demo && auth_session.user.is_none() {
+        let repo = SeaOrmUserRepo::new(state.demo_db.clone());
         match repo.find_by_email_with_hash("admin@demo.local").await {
             Ok(Some((user, hash))) => {
-                let auth_user = user::AuthenticatedUser::new(user, hash);
+                let auth_user = user::AuthenticatedUser::new(user, hash, SetupMode::Demo);
                 if let Err(e) = auth_session.login(&auth_user).await {
                     tracing::warn!("Demo auto-login session creation failed: {e}");
                 }

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -70,7 +70,7 @@ async fn login(
     mut auth_session: AuthSessionType,
     Json(req): Json<LoginRequest>,
 ) -> Result<Json<UserResponse>, AppError> {
-    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
+    let repo = SeaOrmUserRepo::new(state.db_for(*state.active_profile.read().unwrap()).clone());
     let creds = Credentials {
         email: req.email.clone(),
         password: req.password,
@@ -245,6 +245,16 @@ async fn setup(
     };
 
     setup_guard.complete();
+
+    // Persist active_profile = "production" and update in-memory so subsequent
+    // requests (including the auto-login below) use the production database.
+    use mokumo_core::setup::SetupMode;
+    let profile_path = state.data_dir.join("active_profile");
+    if let Err(e) = tokio::fs::write(&profile_path, "production").await {
+        tracing::warn!("Failed to persist active_profile after setup: {e}");
+    }
+    *state.active_profile.write().unwrap() = SetupMode::Production;
+
     auto_login(&repo, &user, &mut auth_session).await;
 
     Ok((StatusCode::CREATED, Json(SetupResponse { recovery_codes })))
@@ -373,7 +383,7 @@ pub async fn require_auth_with_demo_auto_login(
     // Demo mode auto-login: create a session for the demo admin if not authenticated.
     // Uses find_by_email_with_hash to resolve user + hash in a single DB query
     // (avoids the 2-query path through auto_login → find_by_id_with_hash).
-    if state.active_profile == SetupMode::Demo && auth_session.user.is_none() {
+    if *state.active_profile.read().unwrap() == SetupMode::Demo && auth_session.user.is_none() {
         let repo = SeaOrmUserRepo::new(state.demo_db.clone());
         match repo.find_by_email_with_hash("admin@demo.local").await {
             Ok(Some((user, hash))) => {

--- a/services/api/src/auth/recover.rs
+++ b/services/api/src/auth/recover.rs
@@ -30,7 +30,7 @@ pub async fn recover(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new((*db).clone());
+    let repo = SeaOrmUserRepo::new(db.clone());
 
     match repo
         .verify_and_use_recovery_code(&req.email, &req.recovery_code, &req.new_password)

--- a/services/api/src/auth/recover.rs
+++ b/services/api/src/auth/recover.rs
@@ -6,9 +6,11 @@ use mokumo_types::error::ErrorCode;
 
 use crate::SharedState;
 use crate::error::AppError;
+use crate::profile_db::ProfileDb;
 
 pub async fn recover(
     State(state): State<SharedState>,
+    ProfileDb(db): ProfileDb,
     Json(req): Json<RecoverRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
     // Intentionally returns 400 (not 429) so rate-limited responses are
@@ -28,7 +30,7 @@ pub async fn recover(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
+    let repo = SeaOrmUserRepo::new((*db).clone());
 
     match repo
         .verify_and_use_recovery_code(&req.email, &req.recovery_code, &req.new_password)

--- a/services/api/src/auth/recover.rs
+++ b/services/api/src/auth/recover.rs
@@ -28,7 +28,7 @@ pub async fn recover(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new(state.db.clone());
+    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
 
     match repo
         .verify_and_use_recovery_code(&req.email, &req.recovery_code, &req.new_password)

--- a/services/api/src/auth/reset.rs
+++ b/services/api/src/auth/reset.rs
@@ -10,6 +10,7 @@ use mokumo_types::auth::{ForgotPasswordRequest, ResetPasswordRequest};
 use mokumo_types::error::ErrorCode;
 
 use crate::error::AppError;
+use crate::profile_db::ProfileDb;
 use crate::{PendingReset, SharedState};
 
 const PIN_EXPIRY: Duration = Duration::from_secs(15 * 60);
@@ -47,9 +48,10 @@ fn recovery_html(pin: &str) -> String {
 
 pub async fn forgot_password(
     State(state): State<SharedState>,
+    ProfileDb(db): ProfileDb,
     Json(req): Json<ForgotPasswordRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
+    let repo = SeaOrmUserRepo::new((*db).clone());
 
     match repo.find_by_email(&req.email).await {
         Ok(Some(_)) => {}
@@ -104,6 +106,7 @@ pub async fn forgot_password(
 
 pub async fn reset_password(
     State(state): State<SharedState>,
+    ProfileDb(db): ProfileDb,
     Json(req): Json<ResetPasswordRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
     let entry = state.reset_pins.get(&req.email).ok_or_else(|| {
@@ -137,7 +140,7 @@ pub async fn reset_password(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
+    let repo = SeaOrmUserRepo::new((*db).clone());
     let user = match repo.find_by_email(&req.email).await {
         Ok(Some(u)) => u,
         Ok(None) => {

--- a/services/api/src/auth/reset.rs
+++ b/services/api/src/auth/reset.rs
@@ -51,7 +51,7 @@ pub async fn forgot_password(
     ProfileDb(db): ProfileDb,
     Json(req): Json<ForgotPasswordRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    let repo = SeaOrmUserRepo::new((*db).clone());
+    let repo = SeaOrmUserRepo::new(db.clone());
 
     match repo.find_by_email(&req.email).await {
         Ok(Some(_)) => {}
@@ -140,7 +140,7 @@ pub async fn reset_password(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new((*db).clone());
+    let repo = SeaOrmUserRepo::new(db.clone());
     let user = match repo.find_by_email(&req.email).await {
         Ok(Some(u)) => u,
         Ok(None) => {

--- a/services/api/src/auth/reset.rs
+++ b/services/api/src/auth/reset.rs
@@ -49,7 +49,7 @@ pub async fn forgot_password(
     State(state): State<SharedState>,
     Json(req): Json<ForgotPasswordRequest>,
 ) -> Result<Json<serde_json::Value>, AppError> {
-    let repo = SeaOrmUserRepo::new(state.db.clone());
+    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
 
     match repo.find_by_email(&req.email).await {
         Ok(Some(_)) => {}
@@ -137,7 +137,7 @@ pub async fn reset_password(
         ));
     }
 
-    let repo = SeaOrmUserRepo::new(state.db.clone());
+    let repo = SeaOrmUserRepo::new(state.db_for(state.active_profile).clone());
     let user = match repo.find_by_email(&req.email).await {
         Ok(Some(u)) => u,
         Ok(None) => {

--- a/services/api/src/auth/user.rs
+++ b/services/api/src/auth/user.rs
@@ -1,26 +1,43 @@
 use axum_login::AuthUser;
+use mokumo_core::setup::SetupMode;
 use mokumo_core::user::User;
+
+/// Compound user identity: profile discriminant + database-level user ID.
+///
+/// Encodes which database the user belongs to so
+/// `axum_login::AuthnBackend::get_user` can route the lookup to the correct
+/// database without any separate session context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProfileUserId(pub SetupMode, pub i64);
+
+impl std::fmt::Display for ProfileUserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.0, self.1)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct AuthenticatedUser {
     pub user: User,
+    pub mode: SetupMode,
     password_hash_bytes: Vec<u8>,
 }
 
 impl AuthenticatedUser {
-    pub fn new(user: User, password_hash: String) -> Self {
+    pub fn new(user: User, password_hash: String, mode: SetupMode) -> Self {
         Self {
             user,
+            mode,
             password_hash_bytes: password_hash.into_bytes(),
         }
     }
 }
 
 impl AuthUser for AuthenticatedUser {
-    type Id = i64;
+    type Id = ProfileUserId;
 
     fn id(&self) -> Self::Id {
-        self.user.id.get()
+        ProfileUserId(self.mode, self.user.id.get())
     }
 
     fn session_auth_hash(&self) -> &[u8] {
@@ -31,6 +48,7 @@ impl AuthUser for AuthenticatedUser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum_login::AuthUser;
     use mokumo_core::user::{RoleId, UserId};
 
     fn test_user() -> User {
@@ -48,23 +66,39 @@ mod tests {
     }
 
     #[test]
-    fn auth_user_id_returns_inner_id() {
-        let auth_user = AuthenticatedUser::new(test_user(), "$argon2id$hash".into());
-        assert_eq!(auth_user.id(), 1);
+    fn auth_user_id_includes_mode_and_user_id() {
+        let auth_user =
+            AuthenticatedUser::new(test_user(), "$argon2id$hash".into(), SetupMode::Demo);
+        assert_eq!(auth_user.id(), ProfileUserId(SetupMode::Demo, 1_i64));
+    }
+
+    #[test]
+    fn auth_user_id_production_mode() {
+        let auth_user =
+            AuthenticatedUser::new(test_user(), "$argon2id$hash".into(), SetupMode::Production);
+        assert_eq!(auth_user.id(), ProfileUserId(SetupMode::Production, 1_i64));
     }
 
     #[test]
     fn session_auth_hash_returns_password_bytes() {
         let hash = "$argon2id$v=19$m=19456,t=2,p=1$salt$hash";
-        let auth_user = AuthenticatedUser::new(test_user(), hash.into());
+        let auth_user = AuthenticatedUser::new(test_user(), hash.into(), SetupMode::Demo);
         assert_eq!(auth_user.session_auth_hash(), hash.as_bytes());
     }
 
     #[test]
     fn different_password_hash_produces_different_session_hash() {
         let user = test_user();
-        let user1 = AuthenticatedUser::new(user.clone(), "hash_a".into());
-        let user2 = AuthenticatedUser::new(user, "hash_b".into());
+        let user1 = AuthenticatedUser::new(user.clone(), "hash_a".into(), SetupMode::Demo);
+        let user2 = AuthenticatedUser::new(user, "hash_b".into(), SetupMode::Demo);
         assert_ne!(user1.session_auth_hash(), user2.session_auth_hash());
+    }
+
+    #[test]
+    fn mode_is_accessible() {
+        let demo = AuthenticatedUser::new(test_user(), "hash".into(), SetupMode::Demo);
+        let prod = AuthenticatedUser::new(test_user(), "hash".into(), SetupMode::Production);
+        assert_eq!(demo.mode, SetupMode::Demo);
+        assert_eq!(prod.mode, SetupMode::Production);
     }
 }

--- a/services/api/src/auth/user.rs
+++ b/services/api/src/auth/user.rs
@@ -12,7 +12,14 @@ pub struct ProfileUserId(pub SetupMode, pub i64);
 
 impl std::fmt::Display for ProfileUserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.0, self.1)
+        // Use explicit literals to lock the session wire format independent of
+        // SetupMode's Display impl. A change to SetupMode::Display must not
+        // silently invalidate stored sessions.
+        let profile = match self.0 {
+            SetupMode::Demo => "demo",
+            SetupMode::Production => "production",
+        };
+        write!(f, "{}:{}", profile, self.1)
     }
 }
 
@@ -77,6 +84,17 @@ mod tests {
         let auth_user =
             AuthenticatedUser::new(test_user(), "$argon2id$hash".into(), SetupMode::Production);
         assert_eq!(auth_user.id(), ProfileUserId(SetupMode::Production, 1_i64));
+    }
+
+    /// Lock the session wire format: "demo:1" and "production:1".
+    /// Any change to this output invalidates persisted sessions for live users.
+    #[test]
+    fn profile_user_id_display_format_is_locked() {
+        assert_eq!(ProfileUserId(SetupMode::Demo, 1).to_string(), "demo:1",);
+        assert_eq!(
+            ProfileUserId(SetupMode::Production, 42).to_string(),
+            "production:42",
+        );
     }
 
     #[test]

--- a/services/api/src/customer/mod.rs
+++ b/services/api/src/customer/mod.rs
@@ -108,7 +108,7 @@ async fn create_customer(
     Json(req): Json<CreateCustomer>,
 ) -> Result<(StatusCode, Json<CustomerResponse>), AppError> {
     let actor = actor_from_session(&auth_session);
-    let svc = customer_service((*db).clone());
+    let svc = customer_service(db.clone());
     let customer = svc.create(&req, &actor).await?;
     Ok((StatusCode::CREATED, Json(to_response(customer))))
 }
@@ -120,7 +120,7 @@ async fn get_customer(
 ) -> Result<Json<CustomerResponse>, AppError> {
     let customer_id = parse_customer_id(&id)?;
 
-    let svc = customer_service((*db).clone());
+    let svc = customer_service(db.clone());
     let customer = svc
         .find_by_id(&customer_id, include_deleted_filter(query.include_deleted))
         .await?
@@ -145,7 +145,7 @@ async fn list_customers(
     }
     .into_page_params();
 
-    let svc = customer_service((*db).clone());
+    let svc = customer_service(db.clone());
     let (customers, total) = svc.list(params, filter, query.search.as_deref()).await?;
 
     let items: Vec<CustomerResponse> = customers.into_iter().map(to_response).collect();
@@ -165,7 +165,7 @@ async fn update_customer(
 ) -> Result<Json<CustomerResponse>, AppError> {
     let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
-    let svc = customer_service((*db).clone());
+    let svc = customer_service(db.clone());
     let customer = svc.update(&customer_id, &req, &actor).await?;
     Ok(Json(to_response(customer)))
 }
@@ -177,7 +177,7 @@ async fn delete_customer(
 ) -> Result<Json<CustomerResponse>, AppError> {
     let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
-    let svc = customer_service((*db).clone());
+    let svc = customer_service(db.clone());
     let customer = svc.soft_delete(&customer_id, &actor).await?;
     Ok(Json(to_response(customer)))
 }
@@ -189,7 +189,7 @@ async fn restore_customer(
 ) -> Result<Json<CustomerResponse>, AppError> {
     let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
-    let svc = customer_service((*db).clone());
+    let svc = customer_service(db.clone());
     let customer = svc.restore(&customer_id, &actor).await?;
     Ok(Json(to_response(customer)))
 }

--- a/services/api/src/customer/mod.rs
+++ b/services/api/src/customer/mod.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Path, Query, State};
+use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::routing::{get, patch};
 use axum::{Json, Router};
@@ -16,6 +16,7 @@ use crate::SharedState;
 use crate::auth::AuthSessionType;
 use crate::error::AppError;
 use crate::pagination::PaginationParams;
+use crate::profile_db::ProfileDb;
 
 pub fn router() -> Router<SharedState> {
     Router::new()
@@ -69,8 +70,8 @@ fn parse_customer_id(id: &str) -> Result<CustomerId, AppError> {
     })
 }
 
-fn customer_service(state: &SharedState) -> CustomerService<SeaOrmCustomerRepo> {
-    CustomerService::new(SeaOrmCustomerRepo::new(state.db.clone()))
+fn customer_service(db: mokumo_db::DatabaseConnection) -> CustomerService<SeaOrmCustomerRepo> {
+    CustomerService::new(SeaOrmCustomerRepo::new(db))
 }
 
 fn actor_from_session(auth_session: &AuthSessionType) -> Actor {
@@ -102,24 +103,24 @@ struct ListCustomersQuery {
 }
 
 async fn create_customer(
-    State(state): State<SharedState>,
     auth_session: AuthSessionType,
+    ProfileDb(db): ProfileDb,
     Json(req): Json<CreateCustomer>,
 ) -> Result<(StatusCode, Json<CustomerResponse>), AppError> {
     let actor = actor_from_session(&auth_session);
-    let svc = customer_service(&state);
+    let svc = customer_service((*db).clone());
     let customer = svc.create(&req, &actor).await?;
     Ok((StatusCode::CREATED, Json(to_response(customer))))
 }
 
 async fn get_customer(
-    State(state): State<SharedState>,
+    ProfileDb(db): ProfileDb,
     Path(id): Path<String>,
     Query(query): Query<IncludeDeletedQuery>,
 ) -> Result<Json<CustomerResponse>, AppError> {
     let customer_id = parse_customer_id(&id)?;
 
-    let svc = customer_service(&state);
+    let svc = customer_service((*db).clone());
     let customer = svc
         .find_by_id(&customer_id, include_deleted_filter(query.include_deleted))
         .await?
@@ -134,7 +135,7 @@ async fn get_customer(
 }
 
 async fn list_customers(
-    State(state): State<SharedState>,
+    ProfileDb(db): ProfileDb,
     Query(query): Query<ListCustomersQuery>,
 ) -> Result<Json<PaginatedList<CustomerResponse>>, AppError> {
     let filter = include_deleted_filter(query.include_deleted);
@@ -144,7 +145,7 @@ async fn list_customers(
     }
     .into_page_params();
 
-    let svc = customer_service(&state);
+    let svc = customer_service((*db).clone());
     let (customers, total) = svc.list(params, filter, query.search.as_deref()).await?;
 
     let items: Vec<CustomerResponse> = customers.into_iter().map(to_response).collect();
@@ -157,38 +158,38 @@ async fn list_customers(
 }
 
 async fn update_customer(
-    State(state): State<SharedState>,
     auth_session: AuthSessionType,
+    ProfileDb(db): ProfileDb,
     Path(id): Path<String>,
     Json(req): Json<UpdateCustomer>,
 ) -> Result<Json<CustomerResponse>, AppError> {
     let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
-    let svc = customer_service(&state);
+    let svc = customer_service((*db).clone());
     let customer = svc.update(&customer_id, &req, &actor).await?;
     Ok(Json(to_response(customer)))
 }
 
 async fn delete_customer(
-    State(state): State<SharedState>,
     auth_session: AuthSessionType,
+    ProfileDb(db): ProfileDb,
     Path(id): Path<String>,
 ) -> Result<Json<CustomerResponse>, AppError> {
     let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
-    let svc = customer_service(&state);
+    let svc = customer_service((*db).clone());
     let customer = svc.soft_delete(&customer_id, &actor).await?;
     Ok(Json(to_response(customer)))
 }
 
 async fn restore_customer(
-    State(state): State<SharedState>,
     auth_session: AuthSessionType,
+    ProfileDb(db): ProfileDb,
     Path(id): Path<String>,
 ) -> Result<Json<CustomerResponse>, AppError> {
     let actor = actor_from_session(&auth_session);
     let customer_id = parse_customer_id(&id)?;
-    let svc = customer_service(&state);
+    let svc = customer_service((*db).clone());
     let customer = svc.restore(&customer_id, &actor).await?;
     Ok(Json(to_response(customer)))
 }

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -17,7 +17,7 @@ pub async fn demo_reset(
     State(state): State<SharedState>,
 ) -> Result<Json<DemoResetResponse>, AppError> {
     // Must be demo mode
-    if state.active_profile != SetupMode::Demo {
+    if *state.active_profile.read().unwrap() != SetupMode::Demo {
         return Err(AppError::Forbidden(
             "Demo reset is only available in demo mode".into(),
         ));

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -17,16 +17,16 @@ pub async fn demo_reset(
     State(state): State<SharedState>,
 ) -> Result<Json<DemoResetResponse>, AppError> {
     // Must be demo mode
-    if state.setup_mode != Some(SetupMode::Demo) {
+    if state.active_profile != SetupMode::Demo {
         return Err(AppError::Forbidden(
             "Demo reset is only available in demo mode".into(),
         ));
     }
 
-    // Close the database connection pool before replacing the file.
+    // Close the demo database connection pool before replacing the file.
     // This releases file handles that would block std::fs::rename on Windows.
     // Other in-flight requests will get errors, but the server is about to shut down.
-    state.db.get_sqlite_connection_pool().close().await;
+    state.demo_db.get_sqlite_connection_pool().close().await;
 
     // Force-copy fresh sidecar over the demo database.
     if let Err(e) = force_copy_sidecar(&state.data_dir) {

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -351,9 +351,7 @@ pub async fn init_session_and_setup(
     session_db_path: &Path,
 ) -> Result<(SqliteStore, Arc<AtomicBool>, Option<String>), Box<dyn std::error::Error + Send + Sync>>
 {
-    let is_complete = mokumo_db::is_setup_complete(production_db)
-        .await
-        .unwrap_or(false);
+    let is_complete = mokumo_db::is_setup_complete(production_db).await?;
     let setup_completed = Arc::new(AtomicBool::new(is_complete));
     let setup_token = if is_complete {
         None
@@ -782,8 +780,9 @@ async fn health(
     ),
     error::AppError,
 > {
-    // Check the active profile database
-    mokumo_db::health_check(state.db_for(state.active_profile)).await?;
+    // Check both profile databases — either being unhealthy makes the whole instance unhealthy
+    mokumo_db::health_check(state.db_for(SetupMode::Demo)).await?;
+    mokumo_db::health_check(state.db_for(SetupMode::Production)).await?;
 
     let uptime_seconds = state.started_at.elapsed().as_secs();
 

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -508,7 +508,7 @@ fn build_app_inner(
         .with_expiry(Expiry::OnInactivity(Duration::hours(24)));
 
     // Auth backend holds both databases; dispatches by compound user ID.
-    let backend = Backend::new(demo_db.clone(), production_db.clone(), active_profile);
+    let backend = Backend::new(demo_db.clone(), production_db.clone());
     let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
 
     let state: SharedState = Arc::new(AppState {

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -5,6 +5,7 @@ pub mod demo;
 pub mod discovery;
 pub mod error;
 pub mod pagination;
+pub mod profile_db;
 pub mod rate_limit;
 pub mod server_info;
 pub mod ws;
@@ -21,6 +22,7 @@ use axum::{
     routing::{get, post},
 };
 use axum_login::AuthManagerLayerBuilder;
+use mokumo_core::setup::SetupMode;
 use mokumo_db::DatabaseConnection;
 use rust_embed::Embed;
 use time::Duration;
@@ -52,7 +54,17 @@ pub struct ServerConfig {
 }
 
 pub struct AppState {
-    pub db: DatabaseConnection,
+    /// Demo profile database connection.
+    pub demo_db: DatabaseConnection,
+    /// Production profile database connection.
+    pub production_db: DatabaseConnection,
+    /// The active profile at server startup. Controls `Backend::authenticate`
+    /// and the unauthenticated fallback in `ProfileDbMiddleware`.
+    ///
+    /// Note: this field is intentionally non-mutable in Session 1. The
+    /// profile-switch handler (Session 2) will introduce interior mutability
+    /// (e.g., `Arc<AtomicBool>`) when live switching is added.
+    pub active_profile: SetupMode,
     pub ws: Arc<ws::manager::ConnectionManager>,
     pub shutdown: CancellationToken,
     pub started_at: std::time::Instant,
@@ -61,7 +73,6 @@ pub struct AppState {
     pub setup_completed: Arc<AtomicBool>,
     pub setup_in_progress: Arc<AtomicBool>,
     pub setup_token: Option<String>,
-    pub setup_mode: Option<mokumo_core::setup::SetupMode>,
     pub data_dir: PathBuf,
     /// In-memory store for file-drop password reset PINs. Maps email → PendingReset.
     pub reset_pins: Arc<dashmap::DashMap<String, PendingReset>>,
@@ -71,6 +82,16 @@ pub struct AppState {
     pub recovery_limiter: rate_limit::RateLimiter,
     /// Rate limiter for recovery code regeneration attempts (3 per hour per user).
     pub regen_limiter: rate_limit::RateLimiter,
+}
+
+impl AppState {
+    /// Return the database connection for the given profile.
+    pub fn db_for(&self, mode: SetupMode) -> &DatabaseConnection {
+        match mode {
+            SetupMode::Demo => &self.demo_db,
+            SetupMode::Production => &self.production_db,
+        }
+    }
 }
 
 pub type SharedState = Arc<AppState>;
@@ -157,14 +178,21 @@ pub fn migrate_flat_layout(data_dir: &Path) -> Result<(), std::io::Error> {
 }
 
 /// Shared startup sequence: create directories, migrate layout, copy sidecar,
-/// resolve profile, back up and initialize the database, and run migrations on
-/// the non-active profile database (if it already exists).
+/// resolve profile, back up and initialize both databases, and run migrations on
+/// the non-active profile database.
 ///
 /// Used by both the CLI server (`main.rs`) and the desktop app (`lib.rs`).
-/// Returns `(db, profile)` on success.
+/// Returns `(demo_db, production_db, profile)` on success.
 pub async fn prepare_database(
     data_dir: &Path,
-) -> Result<(DatabaseConnection, mokumo_core::setup::SetupMode), Box<dyn std::error::Error>> {
+) -> Result<
+    (
+        DatabaseConnection,
+        DatabaseConnection,
+        mokumo_core::setup::SetupMode,
+    ),
+    Box<dyn std::error::Error>,
+> {
     use mokumo_core::setup::SetupMode;
 
     ensure_data_dirs(data_dir)?;
@@ -175,36 +203,38 @@ pub async fn prepare_database(
     }
 
     let profile = resolve_active_profile(data_dir);
-    let db_path = data_dir.join(profile.as_str()).join("mokumo.db");
 
-    // Pre-migration backup on active profile DB
-    let db_exists = db_path
+    // --- Active profile database ---
+    let active_db_path = data_dir.join(profile.as_str()).join("mokumo.db");
+    if active_db_path
         .try_exists()
-        .map_err(|e| format!("Cannot check database at {}: {e}", db_path.display()))?;
-    if db_exists {
-        mokumo_db::pre_migration_backup(&db_path)
+        .map_err(|e| format!("Cannot check database at {}: {e}", active_db_path.display()))?
+    {
+        mokumo_db::pre_migration_backup(&active_db_path)
             .await
             .map_err(|e| {
                 format!(
                     "Pre-migration backup failed for {}: {e}. \
                      Refusing to run migrations without a backup. \
                      Check disk space and permissions.",
-                    db_path.display()
+                    active_db_path.display()
                 )
             })?;
     }
+    let active_db_url = format!("sqlite:{}?mode=rwc", active_db_path.display());
+    let active_db = mokumo_db::initialize_database(&active_db_url).await?;
+    tracing::info!(
+        "Active database ({profile}) ready at {}",
+        active_db_path.display()
+    );
 
-    let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
-    let db = mokumo_db::initialize_database(&database_url).await?;
-    tracing::info!("Database ready at {}", db_path.display());
-
-    // Run startup migrations on the non-active profile database (if it exists)
+    // --- Non-active profile database ---
     let other_profile = match profile {
-        SetupMode::Demo => "production",
-        SetupMode::Production => "demo",
+        SetupMode::Demo => SetupMode::Production,
+        SetupMode::Production => SetupMode::Demo,
     };
-    let other_db_path = data_dir.join(other_profile).join("mokumo.db");
-    match other_db_path.try_exists() {
+    let other_db_path = data_dir.join(other_profile.as_str()).join("mokumo.db");
+    let other_db = match other_db_path.try_exists() {
         Ok(true) => {
             if let Err(e) = mokumo_db::pre_migration_backup(&other_db_path).await {
                 tracing::warn!(
@@ -213,22 +243,54 @@ pub async fn prepare_database(
                 );
             }
             let other_url = format!("sqlite:{}?mode=rwc", other_db_path.display());
-            if let Err(e) = mokumo_db::initialize_database(&other_url).await {
-                tracing::warn!("Failed to run migrations on {other_profile} database: {e}");
-            } else {
-                tracing::info!("Startup migrations applied to {other_profile} database");
+            match mokumo_db::initialize_database(&other_url).await {
+                Ok(db) => {
+                    tracing::info!(
+                        "Non-active database ({other_profile}) ready at {}",
+                        other_db_path.display()
+                    );
+                    db
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to open {other_profile} database: {e}");
+                    // Fall through: open a fresh empty DB at the path
+                    let url = format!("sqlite:{}?mode=rwc", other_db_path.display());
+                    mokumo_db::initialize_database(&url).await?
+                }
             }
         }
-        Ok(false) => {}
-        Err(e) => {
-            tracing::warn!(
-                "Could not check for {other_profile} database at {}: {e}",
-                other_db_path.display()
-            );
+        Ok(false) => {
+            // Other profile DB doesn't exist yet — create it fresh (migrations only)
+            let url = format!("sqlite:{}?mode=rwc", other_db_path.display());
+            match mokumo_db::initialize_database(&url).await {
+                Ok(db) => {
+                    tracing::info!(
+                        "Created {other_profile} database at {}",
+                        other_db_path.display()
+                    );
+                    db
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to create {other_profile} database: {e}");
+                    return Err(e.into());
+                }
+            }
         }
-    }
+        Err(e) => {
+            return Err(format!(
+                "Cannot check for {other_profile} database at {}: {e}",
+                other_db_path.display()
+            )
+            .into());
+        }
+    };
 
-    Ok((db, profile))
+    let (demo_db, production_db) = match profile {
+        SetupMode::Demo => (active_db, other_db),
+        SetupMode::Production => (other_db, active_db),
+    };
+
+    Ok((demo_db, production_db, profile))
 }
 
 /// Attempt to bind a TCP listener, trying ports from `port` through `port + 10`.
@@ -275,23 +337,22 @@ pub fn generate_setup_token() -> String {
 ///
 /// The session store is opened from a SEPARATE SQLite database at `session_db_path`,
 /// keeping session data independent of the active profile database.
+///
+/// `production_db` is used to check setup completion status (production setup
+/// is what the wizard populates).
 pub async fn init_session_and_setup(
-    db: &DatabaseConnection,
+    production_db: &DatabaseConnection,
     session_db_path: &Path,
-) -> (
-    SqliteStore,
-    Arc<AtomicBool>,
-    Option<String>,
-    Option<mokumo_core::setup::SetupMode>,
-) {
-    let is_complete = mokumo_db::is_setup_complete(db).await.unwrap_or(false);
+) -> (SqliteStore, Arc<AtomicBool>, Option<String>) {
+    let is_complete = mokumo_db::is_setup_complete(production_db)
+        .await
+        .unwrap_or(false);
     let setup_completed = Arc::new(AtomicBool::new(is_complete));
     let setup_token = if is_complete {
         None
     } else {
         Some(generate_setup_token())
     };
-    let setup_mode = mokumo_db::get_setup_mode(db).await.unwrap_or(None);
 
     // Open a separate SQLite pool for sessions
     let session_url = format!("sqlite:{}?mode=rwc", session_db_path.display());
@@ -304,7 +365,7 @@ pub async fn init_session_and_setup(
         .await
         .expect("session store migration failed");
 
-    (session_store, setup_completed, setup_token, setup_mode)
+    (session_store, setup_completed, setup_token)
 }
 
 /// Build the Axum router with health check, SPA fallback, and tracing.
@@ -313,24 +374,30 @@ pub async fn init_session_and_setup(
 /// task — the local IP is computed once and never updated. Use
 /// `build_app_with_shutdown` in production for graceful lifecycle control.
 #[allow(unused_variables)] // config will be used by future CORS/rate-limit settings
-pub async fn build_app(config: &ServerConfig, db: DatabaseConnection) -> (Router, Option<String>) {
+pub async fn build_app(
+    config: &ServerConfig,
+    demo_db: DatabaseConnection,
+    production_db: DatabaseConnection,
+    active_profile: SetupMode,
+) -> (Router, Option<String>) {
     let local_ip = local_ip_address::local_ip().ok();
     let (_, local_ip_rx) = tokio::sync::watch::channel(local_ip);
 
     let session_db_path = config.data_dir.join("sessions.db");
-    let (session_store, setup_completed, setup_token, setup_mode) =
-        init_session_and_setup(&db, &session_db_path).await;
+    let (session_store, setup_completed, setup_token) =
+        init_session_and_setup(&production_db, &session_db_path).await;
 
     let router = build_app_inner(
         config,
-        db,
+        demo_db,
+        production_db,
+        active_profile,
         CancellationToken::new(),
         discovery::MdnsStatus::shared(),
         local_ip_rx,
         session_store,
         setup_completed,
         setup_token.clone(),
-        setup_mode,
     );
     (router, setup_token)
 }
@@ -343,7 +410,9 @@ pub async fn build_app(config: &ServerConfig, db: DatabaseConnection) -> (Router
 #[allow(unused_variables)] // config will be used by future CORS/rate-limit settings
 pub async fn build_app_with_shutdown(
     config: &ServerConfig,
-    db: DatabaseConnection,
+    demo_db: DatabaseConnection,
+    production_db: DatabaseConnection,
+    active_profile: SetupMode,
     shutdown: CancellationToken,
     mdns_status: discovery::SharedMdnsStatus,
 ) -> (Router, Option<String>) {
@@ -374,8 +443,8 @@ pub async fn build_app_with_shutdown(
     });
 
     let session_db_path = config.data_dir.join("sessions.db");
-    let (session_store, setup_completed, setup_token, setup_mode) =
-        init_session_and_setup(&db, &session_db_path).await;
+    let (session_store, setup_completed, setup_token) =
+        init_session_and_setup(&production_db, &session_db_path).await;
 
     // Background task: delete expired sessions every 60s
     let deletion_store = session_store.clone();
@@ -393,14 +462,15 @@ pub async fn build_app_with_shutdown(
 
     let router = build_app_inner(
         config,
-        db,
+        demo_db,
+        production_db,
+        active_profile,
         shutdown,
         mdns_status,
         local_ip_rx,
         session_store,
         setup_completed,
         setup_token.clone(),
-        setup_mode,
     );
     (router, setup_token)
 }
@@ -409,14 +479,15 @@ pub async fn build_app_with_shutdown(
 #[allow(unused_variables)] // config will be used by future CORS/rate-limit settings
 fn build_app_inner(
     config: &ServerConfig,
-    db: DatabaseConnection,
+    demo_db: DatabaseConnection,
+    production_db: DatabaseConnection,
+    active_profile: SetupMode,
     shutdown: CancellationToken,
     mdns_status: discovery::SharedMdnsStatus,
     local_ip: tokio::sync::watch::Receiver<Option<std::net::IpAddr>>,
     session_store: SqliteStore,
     setup_completed: Arc<AtomicBool>,
     setup_token: Option<String>,
-    setup_mode: Option<mokumo_core::setup::SetupMode>,
 ) -> Router {
     // Session layer: SameSite=Lax, HttpOnly, no Secure for M0 (LAN HTTP)
     // Lax (not Strict) so bookmarks and mDNS links preserve the session.
@@ -426,12 +497,14 @@ fn build_app_inner(
         .with_same_site(tower_sessions::cookie::SameSite::Lax)
         .with_expiry(Expiry::OnInactivity(Duration::hours(24)));
 
-    // Auth layer
-    let backend = Backend::new(db.clone());
+    // Auth backend holds both databases; dispatches by compound user ID.
+    let backend = Backend::new(demo_db.clone(), production_db.clone(), active_profile);
     let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
 
     let state: SharedState = Arc::new(AppState {
-        db,
+        demo_db,
+        production_db,
+        active_profile,
         ws: Arc::new(ws::manager::ConnectionManager::new(64)),
         shutdown,
         started_at: std::time::Instant::now(),
@@ -440,7 +513,6 @@ fn build_app_inner(
         setup_completed,
         setup_in_progress: Arc::new(AtomicBool::new(false)),
         setup_token,
-        setup_mode,
         data_dir: config.data_dir.clone(),
         reset_pins: Arc::new(dashmap::DashMap::new()),
         recovery_dir: config.recovery_dir.clone(),
@@ -512,6 +584,12 @@ fn build_app_inner(
 
     router
         .fallback(serve_spa)
+        // ProfileDbMiddleware: innermost — runs after auth session is populated.
+        // Injects ProfileDb into request extensions for all routes.
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            profile_db::profile_db_middleware,
+        ))
         .layer(auth_layer)
         .layer(TraceLayer::new_for_http())
         .with_state(state)
@@ -560,35 +638,19 @@ pub fn resolve_recovery_dir() -> PathBuf {
 // ---------------------------------------------------------------------------
 
 /// Path to the process-level lock file within the data directory.
-///
-/// The server acquires an exclusive flock on this file at startup and holds it
-/// for its entire lifetime. `reset-db` checks this lock before deleting files —
-/// if it is held, the server is definitively running.
-///
-/// Unlike `BEGIN EXCLUSIVE` (which only detects active SQLite transactions),
-/// flock detects any process that has the lock file open, including idle servers.
-/// The OS automatically releases the lock on process exit, crash, or SIGKILL.
 pub fn lock_file_path(data_dir: &Path) -> PathBuf {
     data_dir.join("mokumo.lock")
 }
 
 /// SQLite sidecar suffixes deleted alongside the main database file.
-///
-/// Shared between the file inventory preview (main.rs) and the delete logic
-/// (cli_reset_db) so the two can never drift.
 pub const DB_SIDECAR_SUFFIXES: &[&str] = &["", "-wal", "-shm", "-journal"];
 
 /// Report from a database reset operation.
-///
-/// Partial failures (e.g. one sidecar couldn't be removed) are reported here,
-/// not as `Err`. The caller decides how to present them.
 #[derive(Debug, Default)]
 pub struct ResetReport {
     pub deleted: Vec<PathBuf>,
     pub not_found: Vec<PathBuf>,
     pub failed: Vec<(PathBuf, std::io::Error)>,
-    /// Non-fatal: recovery directory could not be scanned (e.g. EPERM on macOS).
-    /// Contains (directory path, io error) when the scan was skipped.
     pub recovery_dir_error: Option<(PathBuf, std::io::Error)>,
     /// Non-fatal: backup directory could not be scanned (only set when `include_backups` is true).
     pub backup_dir_error: Option<(PathBuf, std::io::Error)>,
@@ -660,12 +722,8 @@ pub fn cli_reset_db(
                 }
             }
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // Recovery dir doesn't exist — nothing to clean up
-        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {
-            // Non-fatal: permission errors (e.g. macOS EPERM on ~/Desktop)
-            // are recorded as a warning, not a hard failure.
             report.recovery_dir_error = Some((recovery_dir.to_path_buf(), e));
         }
     }
@@ -673,7 +731,6 @@ pub fn cli_reset_db(
     Ok(report)
 }
 
-/// Try to remove a single file, sorting the outcome into the report.
 fn delete_file(path: &Path, report: &mut ResetReport) {
     match std::fs::remove_file(path) {
         Ok(()) => report.deleted.push(path.to_path_buf()),
@@ -713,7 +770,8 @@ async fn health(
     ),
     error::AppError,
 > {
-    mokumo_db::health_check(&state.db).await?;
+    // Check the active profile database
+    mokumo_db::health_check(state.db_for(state.active_profile)).await?;
 
     let uptime_seconds = state.started_at.elapsed().as_secs();
 
@@ -734,7 +792,7 @@ async fn setup_status(State(state): State<SharedState>) -> impl IntoResponse {
         .load(std::sync::atomic::Ordering::Relaxed);
     Json(mokumo_types::setup::SetupStatusResponse {
         setup_complete,
-        setup_mode: state.setup_mode,
+        setup_mode: Some(state.active_profile),
     })
 }
 

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -58,13 +58,13 @@ pub struct AppState {
     pub demo_db: DatabaseConnection,
     /// Production profile database connection.
     pub production_db: DatabaseConnection,
-    /// The active profile at server startup. Controls `Backend::authenticate`
-    /// and the unauthenticated fallback in `ProfileDbMiddleware`.
+    /// The currently active profile. Controls the unauthenticated fallback in
+    /// `ProfileDbMiddleware` and demo auto-login detection.
     ///
-    /// Note: this field is intentionally non-mutable in Session 1. The
-    /// profile-switch handler (Session 2) will introduce interior mutability
-    /// (e.g., `Arc<AtomicBool>`) when live switching is added.
-    pub active_profile: SetupMode,
+    /// Wrapped in `RwLock` so the profile-switch handler (Session 2) can update
+    /// it in-process without a restart. Reads are always `read().unwrap()`;
+    /// writes happen only in the profile-switch handler after persisting to disk.
+    pub active_profile: std::sync::RwLock<SetupMode>,
     pub ws: Arc<ws::manager::ConnectionManager>,
     pub shutdown: CancellationToken,
     pub started_at: std::time::Instant,
@@ -514,7 +514,7 @@ fn build_app_inner(
     let state: SharedState = Arc::new(AppState {
         demo_db,
         production_db,
-        active_profile,
+        active_profile: std::sync::RwLock::new(active_profile),
         ws: Arc::new(ws::manager::ConnectionManager::new(64)),
         shutdown,
         started_at: std::time::Instant::now(),
@@ -803,7 +803,7 @@ async fn setup_status(State(state): State<SharedState>) -> impl IntoResponse {
         .load(std::sync::atomic::Ordering::Relaxed);
     Json(mokumo_types::setup::SetupStatusResponse {
         setup_complete,
-        setup_mode: Some(state.active_profile),
+        setup_mode: Some(*state.active_profile.read().unwrap()),
     })
 }
 

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -236,12 +236,15 @@ pub async fn prepare_database(
     let other_db_path = data_dir.join(other_profile.as_str()).join("mokumo.db");
     let other_db = match other_db_path.try_exists() {
         Ok(true) => {
-            if let Err(e) = mokumo_db::pre_migration_backup(&other_db_path).await {
-                tracing::warn!(
-                    "Pre-migration backup failed for {}: {e}",
-                    other_db_path.display()
-                );
-            }
+            mokumo_db::pre_migration_backup(&other_db_path)
+                .await
+                .map_err(|e| {
+                    format!(
+                        "Pre-migration backup failed for {}: {e}. \
+                         Refusing to proceed without backup to protect existing data.",
+                        other_db_path.display()
+                    )
+                })?;
             let other_url = format!("sqlite:{}?mode=rwc", other_db_path.display());
             match mokumo_db::initialize_database(&other_url).await {
                 Ok(db) => {
@@ -252,10 +255,13 @@ pub async fn prepare_database(
                     db
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to open {other_profile} database: {e}");
-                    // Fall through: open a fresh empty DB at the path
-                    let url = format!("sqlite:{}?mode=rwc", other_db_path.display());
-                    mokumo_db::initialize_database(&url).await?
+                    return Err(format!(
+                        "Failed to open {other_profile} database at {}: {e}. \
+                         Check disk space and file permissions. \
+                         Delete the database file to start fresh.",
+                        other_db_path.display()
+                    )
+                    .into());
                 }
             }
         }
@@ -343,7 +349,8 @@ pub fn generate_setup_token() -> String {
 pub async fn init_session_and_setup(
     production_db: &DatabaseConnection,
     session_db_path: &Path,
-) -> (SqliteStore, Arc<AtomicBool>, Option<String>) {
+) -> Result<(SqliteStore, Arc<AtomicBool>, Option<String>), Box<dyn std::error::Error + Send + Sync>>
+{
     let is_complete = mokumo_db::is_setup_complete(production_db)
         .await
         .unwrap_or(false);
@@ -358,14 +365,19 @@ pub async fn init_session_and_setup(
     let session_url = format!("sqlite:{}?mode=rwc", session_db_path.display());
     let session_pool = mokumo_db::open_raw_sqlite_pool(&session_url)
         .await
-        .expect("failed to open session database");
+        .map_err(|e| {
+            format!(
+                "Failed to open session database at {}: {e}",
+                session_db_path.display()
+            )
+        })?;
     let session_store = SqliteStore::new(session_pool);
     session_store
         .migrate()
         .await
-        .expect("session store migration failed");
+        .map_err(|e| format!("Session store migration failed: {e}"))?;
 
-    (session_store, setup_completed, setup_token)
+    Ok((session_store, setup_completed, setup_token))
 }
 
 /// Build the Axum router with health check, SPA fallback, and tracing.
@@ -379,13 +391,13 @@ pub async fn build_app(
     demo_db: DatabaseConnection,
     production_db: DatabaseConnection,
     active_profile: SetupMode,
-) -> (Router, Option<String>) {
+) -> Result<(Router, Option<String>), Box<dyn std::error::Error + Send + Sync>> {
     let local_ip = local_ip_address::local_ip().ok();
     let (_, local_ip_rx) = tokio::sync::watch::channel(local_ip);
 
     let session_db_path = config.data_dir.join("sessions.db");
     let (session_store, setup_completed, setup_token) =
-        init_session_and_setup(&production_db, &session_db_path).await;
+        init_session_and_setup(&production_db, &session_db_path).await?;
 
     let router = build_app_inner(
         config,
@@ -399,7 +411,7 @@ pub async fn build_app(
         setup_completed,
         setup_token.clone(),
     );
-    (router, setup_token)
+    Ok((router, setup_token))
 }
 
 /// Build the Axum router with an explicit shutdown token.
@@ -415,7 +427,7 @@ pub async fn build_app_with_shutdown(
     active_profile: SetupMode,
     shutdown: CancellationToken,
     mdns_status: discovery::SharedMdnsStatus,
-) -> (Router, Option<String>) {
+) -> Result<(Router, Option<String>), Box<dyn std::error::Error + Send + Sync>> {
     let initial_ip = local_ip_address::local_ip().ok();
     let (local_ip_tx, local_ip_rx) = tokio::sync::watch::channel(initial_ip);
 
@@ -444,7 +456,7 @@ pub async fn build_app_with_shutdown(
 
     let session_db_path = config.data_dir.join("sessions.db");
     let (session_store, setup_completed, setup_token) =
-        init_session_and_setup(&production_db, &session_db_path).await;
+        init_session_and_setup(&production_db, &session_db_path).await?;
 
     // Background task: delete expired sessions every 60s
     let deletion_store = session_store.clone();
@@ -472,7 +484,7 @@ pub async fn build_app_with_shutdown(
         setup_completed,
         setup_token.clone(),
     );
-    (router, setup_token)
+    Ok((router, setup_token))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -418,7 +418,6 @@ async fn main() {
     // a child token so individual restarts don't tear down the master signal.
     let master_shutdown = CancellationToken::new();
 
-
     // Server loop: runs once normally, restarts on demo reset.
     // Each iteration gets a fresh shutdown token, DB pool, and app state.
     {
@@ -455,7 +454,7 @@ async fn main() {
         let shutdown_token = master_shutdown.child_token();
         let mdns_status = discovery::MdnsStatus::shared();
 
-        let (app, _setup_token) = build_app_with_shutdown(
+        let (app, _setup_token) = match build_app_with_shutdown(
             &config,
             demo_db,
             production_db,
@@ -463,7 +462,14 @@ async fn main() {
             shutdown_token.clone(),
             mdns_status.clone(),
         )
-        .await;
+        .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("Failed to initialise application: {e}");
+                std::process::exit(1);
+            }
+        };
 
         // Bind to port (reuse the same port on restart)
         let port = bound_port.unwrap_or(config.port);

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -414,20 +414,10 @@ async fn main() {
         }
     };
 
-    // Shared startup: dirs, layout migration, sidecar copy, backup, DB init, non-active migration
-    let (_initial_db, profile) = match prepare_database(&config.data_dir).await {
-        Ok(result) => result,
-        Err(e) => {
-            eprintln!("Startup failed: {e}");
-            tracing::error!("Startup failed: {e}");
-            std::process::exit(1);
-        }
-    };
-    let db_path = config.data_dir.join(profile.as_str()).join("mokumo.db");
-
     // Master shutdown token — Ctrl+C cancels this once. Each loop iteration creates
     // a child token so individual restarts don't tear down the master signal.
     let master_shutdown = CancellationToken::new();
+
 
     // Server loop: runs once normally, restarts on demo reset.
     // Each iteration gets a fresh shutdown token, DB pool, and app state.
@@ -452,17 +442,12 @@ async fn main() {
     let mut bound_port: Option<u16> = None;
 
     loop {
-        // Re-open the database on each iteration (demo reset may have replaced the file)
-        let db_pool =
-            match mokumo_db::initialize_database(&format!("sqlite:{}?mode=rwc", db_path.display()))
-                .await
-            {
-                Ok(pool) => {
-                    tracing::info!("Database ready at {}", db_path.display());
-                    pool
-                }
+        // Re-initialize databases on each iteration (demo reset may have replaced the demo DB file)
+        let (demo_db, production_db, active_profile) =
+            match prepare_database(&config.data_dir).await {
+                Ok(result) => result,
                 Err(e) => {
-                    tracing::error!("Failed to initialize database: {e}");
+                    tracing::error!("Database initialization failed: {e}");
                     std::process::exit(1);
                 }
             };
@@ -472,7 +457,9 @@ async fn main() {
 
         let (app, _setup_token) = build_app_with_shutdown(
             &config,
-            db_pool,
+            demo_db,
+            production_db,
+            active_profile,
             shutdown_token.clone(),
             mdns_status.clone(),
         )

--- a/services/api/src/profile_db.rs
+++ b/services/api/src/profile_db.rs
@@ -1,0 +1,99 @@
+//! Per-request database handle, selected by session profile.
+//!
+//! `ProfileDbMiddleware` runs immediately after `AuthManagerLayer`. For
+//! authenticated requests it reads the profile discriminant from the compound
+//! user ID `(SetupMode, i64)` and inserts `ProfileDb` into request extensions.
+//! For unauthenticated requests it falls back to `AppState.active_profile`.
+//!
+//! Protected handlers extract the handle via `ProfileDb(db): ProfileDb`.
+
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::http::request::Parts;
+use axum::middleware::Next;
+use axum::response::Response;
+use axum_login::AuthSession;
+use axum_login::AuthUser;
+use mokumo_db::DatabaseConnection;
+
+use crate::SharedState;
+use crate::auth::backend::Backend;
+use crate::auth::user::ProfileUserId;
+
+/// Per-request database handle injected by `ProfileDbMiddleware`.
+///
+/// Handlers in protected routes extract this instead of going through
+/// `State<SharedState>`, ensuring each request always uses the correct
+/// profile database regardless of the current `AppState.active_profile`.
+#[derive(Clone, Debug)]
+pub struct ProfileDb(pub Arc<DatabaseConnection>);
+
+impl ProfileDb {
+    /// Borrow the inner database connection.
+    pub fn inner(&self) -> &DatabaseConnection {
+        &self.0
+    }
+}
+
+impl<S> FromRequestParts<S> for ProfileDb
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts.extensions.get::<ProfileDb>().cloned().ok_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "ProfileDb not found in request extensions — ensure ProfileDbMiddleware is wired",
+        ))
+    }
+}
+
+/// Middleware: inject `ProfileDb` into request extensions based on session profile.
+///
+/// Must be placed AFTER `AuthManagerLayer` in the layer stack (innermost) so that
+/// the auth session is already populated when this runs.
+///
+/// - Authenticated request: reads `(mode, _)` from `auth_session.user.id()`
+///   and inserts the corresponding database.
+/// - Unauthenticated request: falls back to `state.active_profile`.
+pub async fn profile_db_middleware(
+    State(state): State<SharedState>,
+    auth_session: AuthSession<Backend>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let db = if let Some(user) = &auth_session.user {
+        let ProfileUserId(mode, _) = user.id();
+        state.db_for(mode).clone()
+    } else {
+        state.db_for(state.active_profile).clone()
+    };
+
+    request.extensions_mut().insert(ProfileDb(Arc::new(db)));
+    next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ProfileDb is a thin wrapper. Verify it clones correctly.
+    // Full integration coverage is in profile_middleware.feature.
+
+    #[tokio::test]
+    async fn from_request_parts_returns_err_when_extension_absent() {
+        use axum::http::Request;
+
+        let req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        let (mut parts, _) = req.into_parts();
+
+        let result = ProfileDb::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_err());
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/services/api/src/profile_db.rs
+++ b/services/api/src/profile_db.rs
@@ -71,7 +71,7 @@ pub async fn profile_db_middleware(
         let ProfileUserId(mode, _) = user.id();
         state.db_for(mode).clone()
     } else {
-        state.db_for(state.active_profile).clone()
+        state.db_for(*state.active_profile.read().unwrap()).clone()
     };
 
     request.extensions_mut().insert(ProfileDb(db));

--- a/services/api/src/profile_db.rs
+++ b/services/api/src/profile_db.rs
@@ -9,10 +9,9 @@
 
 use axum::extract::FromRequestParts;
 use axum::extract::{Request, State};
-use axum::http::StatusCode;
 use axum::http::request::Parts;
 use axum::middleware::Next;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum_login::AuthSession;
 use axum_login::AuthUser;
 use mokumo_db::DatabaseConnection;
@@ -20,6 +19,7 @@ use mokumo_db::DatabaseConnection;
 use crate::SharedState;
 use crate::auth::backend::Backend;
 use crate::auth::user::ProfileUserId;
+use crate::error::AppError;
 
 /// Per-request database handle injected by `ProfileDbMiddleware`.
 ///
@@ -43,13 +43,13 @@ impl<S> FromRequestParts<S> for ProfileDb
 where
     S: Send + Sync,
 {
-    type Rejection = (StatusCode, &'static str);
+    type Rejection = Response;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        parts.extensions.get::<ProfileDb>().cloned().ok_or((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "ProfileDb not found in request extensions — ensure ProfileDbMiddleware is wired",
-        ))
+        parts.extensions.get::<ProfileDb>().cloned().ok_or_else(|| {
+            AppError::InternalError("ProfileDb not found in request extensions".into())
+                .into_response()
+        })
     }
 }
 
@@ -80,6 +80,8 @@ pub async fn profile_db_middleware(
 
 #[cfg(test)]
 mod tests {
+    use axum::http::StatusCode;
+
     use super::*;
 
     // ProfileDb is a thin wrapper. Verify it clones correctly.
@@ -94,7 +96,71 @@ mod tests {
 
         let result = ProfileDb::from_request_parts(&mut parts, &()).await;
         assert!(result.is_err());
-        let (status, _) = result.unwrap_err();
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            result.unwrap_err().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    /// Verify that from_request_parts returns the exact ProfileDb that was inserted,
+    /// and that two distinct databases inserted for demo vs production sessions are
+    /// correctly routed — the extracted handle queries the intended database.
+    #[tokio::test]
+    async fn routing_returns_correct_db_per_profile() {
+        use axum::http::Request;
+        use mokumo_db::DatabaseConnection;
+
+        async fn user_version(db: &DatabaseConnection) -> i64 {
+            let pool = db.get_sqlite_connection_pool();
+            sqlx::query_scalar::<_, i64>("PRAGMA user_version")
+                .fetch_one(pool)
+                .await
+                .expect("user_version query failed")
+        }
+
+        async fn set_user_version(db: &DatabaseConnection, v: i64) {
+            let pool = db.get_sqlite_connection_pool();
+            sqlx::query(&format!("PRAGMA user_version = {v}"))
+                .execute(pool)
+                .await
+                .expect("set user_version failed");
+        }
+
+        let demo_db = mokumo_db::initialize_database("sqlite::memory:?mode=rwc")
+            .await
+            .unwrap();
+        let prod_db = mokumo_db::initialize_database("sqlite::memory:?mode=rwc")
+            .await
+            .unwrap();
+
+        // Brand each DB with a distinct user_version so queries can tell them apart
+        set_user_version(&demo_db, 1).await;
+        set_user_version(&prod_db, 2).await;
+
+        // Demo session
+        let mut req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        req.extensions_mut().insert(ProfileDb(demo_db));
+        let (mut parts, _) = req.into_parts();
+        let ProfileDb(extracted) = ProfileDb::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+        assert_eq!(
+            user_version(&extracted).await,
+            1,
+            "demo session should use the demo DB"
+        );
+
+        // Production session
+        let mut req = Request::builder().body(axum::body::Body::empty()).unwrap();
+        req.extensions_mut().insert(ProfileDb(prod_db));
+        let (mut parts, _) = req.into_parts();
+        let ProfileDb(extracted) = ProfileDb::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+        assert_eq!(
+            user_version(&extracted).await,
+            2,
+            "production session should use the production DB"
+        );
     }
 }

--- a/services/api/src/profile_db.rs
+++ b/services/api/src/profile_db.rs
@@ -7,8 +7,6 @@
 //!
 //! Protected handlers extract the handle via `ProfileDb(db): ProfileDb`.
 
-use std::sync::Arc;
-
 use axum::extract::FromRequestParts;
 use axum::extract::{Request, State};
 use axum::http::StatusCode;
@@ -25,11 +23,14 @@ use crate::auth::user::ProfileUserId;
 
 /// Per-request database handle injected by `ProfileDbMiddleware`.
 ///
+/// Wraps `DatabaseConnection` directly — `sea_orm::DatabaseConnection` is
+/// already Arc-backed internally, so no additional `Arc` wrapper is needed.
+///
 /// Handlers in protected routes extract this instead of going through
 /// `State<SharedState>`, ensuring each request always uses the correct
 /// profile database regardless of the current `AppState.active_profile`.
 #[derive(Clone, Debug)]
-pub struct ProfileDb(pub Arc<DatabaseConnection>);
+pub struct ProfileDb(pub DatabaseConnection);
 
 impl ProfileDb {
     /// Borrow the inner database connection.
@@ -73,7 +74,7 @@ pub async fn profile_db_middleware(
         state.db_for(state.active_profile).clone()
     };
 
-    request.extensions_mut().insert(ProfileDb(Arc::new(db)));
+    request.extensions_mut().insert(ProfileDb(db));
     next.run(request).await
 }
 

--- a/services/api/tests/auth_reset_regressions.rs
+++ b/services/api/tests/auth_reset_regressions.rs
@@ -46,8 +46,9 @@ impl RunningServer {
             recovery_dir: recovery_dir.clone(),
         };
 
-        let (app, setup_token) =
-            build_app(&config, db.clone(), db.clone(), SetupMode::Production).await;
+        let (app, setup_token) = build_app(&config, db.clone(), db.clone(), SetupMode::Production)
+            .await
+            .unwrap();
         let server = if save_cookies {
             TestServer::builder().save_cookies().build(app).unwrap()
         } else {

--- a/services/api/tests/auth_reset_regressions.rs
+++ b/services/api/tests/auth_reset_regressions.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use axum_test::TestServer;
 use mokumo_api::auth::reset::recovery_file_path_for_email;
 use mokumo_api::{ServerConfig, build_app, ensure_data_dirs};
+use mokumo_core::setup::SetupMode;
 use mokumo_core::user::traits::UserRepository;
 use mokumo_core::user::{CreateUser, RoleId};
 use mokumo_db::DatabaseConnection;
@@ -45,7 +46,8 @@ impl RunningServer {
             recovery_dir: recovery_dir.clone(),
         };
 
-        let (app, setup_token) = build_app(&config, db.clone()).await;
+        let (app, setup_token) =
+            build_app(&config, db.clone(), db.clone(), SetupMode::Production).await;
         let server = if save_cookies {
             TestServer::builder().save_cookies().build(app).unwrap()
         } else {

--- a/services/api/tests/auth_setup_regressions.rs
+++ b/services/api/tests/auth_setup_regressions.rs
@@ -35,8 +35,9 @@ impl RunningServer {
             recovery_dir: recovery_dir.clone(),
         };
 
-        let (app, setup_token) =
-            build_app(&config, db.clone(), db.clone(), SetupMode::Production).await;
+        let (app, setup_token) = build_app(&config, db.clone(), db.clone(), SetupMode::Production)
+            .await
+            .unwrap();
         let server = TestServer::new(app).unwrap();
 
         Self {

--- a/services/api/tests/auth_setup_regressions.rs
+++ b/services/api/tests/auth_setup_regressions.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use axum_test::TestServer;
 use mokumo_api::{ServerConfig, build_app, ensure_data_dirs};
+use mokumo_core::setup::SetupMode;
 use mokumo_core::user::traits::UserRepository;
 use mokumo_db::DatabaseConnection;
 use mokumo_db::user::repo::SeaOrmUserRepo;
@@ -34,7 +35,8 @@ impl RunningServer {
             recovery_dir: recovery_dir.clone(),
         };
 
-        let (app, setup_token) = build_app(&config, db.clone()).await;
+        let (app, setup_token) =
+            build_app(&config, db.clone(), db.clone(), SetupMode::Production).await;
         let server = TestServer::new(app).unwrap();
 
         Self {

--- a/services/api/tests/bdd_world/demo_steps.rs
+++ b/services/api/tests/bdd_world/demo_steps.rs
@@ -54,9 +54,15 @@ async fn rebuild_world(w: &mut ApiWorld, cfg: &WorldConfig) {
 
     let shutdown_token = tokio_util::sync::CancellationToken::new();
     let mdns_status = mokumo_api::discovery::MdnsStatus::shared();
+    let active_profile = match cfg.profile {
+        "demo" => mokumo_core::setup::SetupMode::Demo,
+        _ => mokumo_core::setup::SetupMode::Production,
+    };
     let (app, setup_token) = mokumo_api::build_app_with_shutdown(
         &config,
         db.clone(),
+        db.clone(),
+        active_profile,
         shutdown_token.clone(),
         mdns_status.clone(),
     )

--- a/services/api/tests/bdd_world/demo_steps.rs
+++ b/services/api/tests/bdd_world/demo_steps.rs
@@ -66,7 +66,8 @@ async fn rebuild_world(w: &mut ApiWorld, cfg: &WorldConfig) {
         shutdown_token.clone(),
         mdns_status.clone(),
     )
-    .await;
+    .await
+    .unwrap();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await

--- a/services/api/tests/bdd_world/health_steps.rs
+++ b/services/api/tests/bdd_world/health_steps.rs
@@ -116,9 +116,15 @@ async fn database_unavailable(w: &mut ApiWorld) {
 
     let shutdown = tokio_util::sync::CancellationToken::new();
     let mdns_status = mokumo_api::discovery::MdnsStatus::shared();
-    let (app, _) =
-        mokumo_api::build_app_with_shutdown(&config, db.clone(), shutdown.clone(), mdns_status)
-            .await;
+    let (app, _) = mokumo_api::build_app_with_shutdown(
+        &config,
+        db.clone(),
+        db.clone(),
+        mokumo_core::setup::SetupMode::Production,
+        shutdown.clone(),
+        mdns_status,
+    )
+    .await;
 
     // NOW close the pool to simulate database failure at request time
     db.close().await.ok();

--- a/services/api/tests/bdd_world/health_steps.rs
+++ b/services/api/tests/bdd_world/health_steps.rs
@@ -124,7 +124,8 @@ async fn database_unavailable(w: &mut ApiWorld) {
         shutdown.clone(),
         mdns_status,
     )
-    .await;
+    .await
+    .unwrap();
 
     // NOW close the pool to simulate database failure at request time
     db.close().await.ok();

--- a/services/api/tests/bdd_world/mod.rs
+++ b/services/api/tests/bdd_world/mod.rs
@@ -87,6 +87,8 @@ impl ApiWorld {
         let (app, setup_token) = build_app_with_shutdown(
             &config,
             db.clone(),
+            db.clone(),
+            mokumo_core::setup::SetupMode::Production,
             shutdown_token.clone(),
             mdns_status.clone(),
         )

--- a/services/api/tests/bdd_world/mod.rs
+++ b/services/api/tests/bdd_world/mod.rs
@@ -92,7 +92,8 @@ impl ApiWorld {
             shutdown_token.clone(),
             mdns_status.clone(),
         )
-        .await;
+        .await
+        .unwrap();
 
         // Pre-bind with OS-assigned port to bypass axum-test's reserve_port
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/services/api/tests/error_handling.rs
+++ b/services/api/tests/error_handling.rs
@@ -47,7 +47,8 @@ async fn graceful_shutdown_completes_cleanly() {
         pool,
         mokumo_core::setup::SetupMode::Production,
     )
-    .await;
+    .await
+    .unwrap();
 
     // Bind to an ephemeral port
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/services/api/tests/error_handling.rs
+++ b/services/api/tests/error_handling.rs
@@ -41,7 +41,13 @@ async fn graceful_shutdown_completes_cleanly() {
         data_dir,
     };
 
-    let (app, _) = mokumo_api::build_app(&config, pool).await;
+    let (app, _) = mokumo_api::build_app(
+        &config,
+        pool.clone(),
+        pool,
+        mokumo_core::setup::SetupMode::Production,
+    )
+    .await;
 
     // Bind to an ephemeral port
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/services/api/tests/features/profile_middleware.feature
+++ b/services/api/tests/features/profile_middleware.feature
@@ -1,7 +1,8 @@
+@wip
 Feature: ProfileDbMiddleware injects correct database per session
 
-  The ProfileDbMiddleware runs after AuthManagerLayer and injects an
-  Arc<DatabaseConnection> into request extensions via the ProfileDb extractor.
+  The ProfileDbMiddleware runs after AuthManagerLayer and injects a
+  DatabaseConnection into request extensions via the ProfileDb extractor.
   For authenticated requests, it selects the database matching the user's
   profile discriminant (stored in the compound AuthUser::Id). For
   unauthenticated requests, it falls back to AppState.active_profile.

--- a/services/api/tests/features/profile_middleware.feature
+++ b/services/api/tests/features/profile_middleware.feature
@@ -1,0 +1,46 @@
+Feature: ProfileDbMiddleware injects correct database per session
+
+  The ProfileDbMiddleware runs after AuthManagerLayer and injects an
+  Arc<DatabaseConnection> into request extensions via the ProfileDb extractor.
+  For authenticated requests, it selects the database matching the user's
+  profile discriminant (stored in the compound AuthUser::Id). For
+  unauthenticated requests, it falls back to AppState.active_profile.
+
+  # --- Authenticated routing ---
+
+  Scenario: Authenticated demo user gets demo database
+    Given a running server with both demo and production databases initialised
+    And a demo user is logged in
+    When the demo user calls a protected endpoint
+    Then the request is served from the demo database
+
+  Scenario: Authenticated production user gets production database
+    Given a running server with both demo and production databases initialised
+    And a production user is logged in
+    When the production user calls a protected endpoint
+    Then the request is served from the production database
+
+  # --- Unauthenticated fallback ---
+
+  Scenario: Unauthenticated request in demo mode uses demo database
+    Given a running server with active profile set to demo
+    When an unauthenticated request reaches a protected endpoint
+    Then the request is rejected with 401 Unauthorized
+
+  Scenario: Unauthenticated request in production mode uses production database
+    Given a running server with active profile set to production
+    When an unauthenticated request reaches a protected endpoint
+    Then the request is rejected with 401 Unauthorized
+
+  # --- Hardcoded routes bypass ProfileDb ---
+
+  Scenario: demo_reset always uses demo database regardless of active profile
+    Given a running server with active profile set to production
+    And a demo user is logged in
+    When the demo user calls POST /api/demo/reset
+    Then the request is rejected with 403 Forbidden
+
+  Scenario: setup endpoint uses production database
+    Given a running server where setup is not yet complete
+    When the setup endpoint is called with valid credentials
+    Then the setup is stored in the production database

--- a/services/api/tests/server_startup.rs
+++ b/services/api/tests/server_startup.rs
@@ -4,6 +4,7 @@ use http::Request;
 use tower::ServiceExt;
 
 use mokumo_api::{ServerConfig, build_app, ensure_data_dirs};
+use mokumo_core::setup::SetupMode;
 
 /// Create a test app with a temp database. Returns the router and tempdir
 /// (tempdir must be held alive for the duration of the test).
@@ -20,7 +21,7 @@ async fn test_app(name: &str) -> (Router, tempfile::TempDir) {
         recovery_dir: data_dir.join("recovery"),
         data_dir,
     };
-    let (app, _) = build_app(&config, pool).await;
+    let (app, _) = build_app(&config, pool.clone(), pool, SetupMode::Production).await;
     (app, tmp)
 }
 
@@ -53,7 +54,7 @@ async fn full_startup_flow_with_temp_dirs() {
     let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
     let pool = mokumo_db::initialize_database(&database_url).await.unwrap();
 
-    let _app = build_app(&config, pool);
+    let _app = build_app(&config, pool.clone(), pool, SetupMode::Production);
 
     assert!(db_path.exists(), "database file should exist");
     assert!(data_dir.join("logs").exists(), "logs/ should exist");
@@ -102,7 +103,7 @@ async fn health_endpoint_returns_500_error_body_on_db_failure() {
     };
 
     // Build app while DB is alive (session store needs migration)
-    let (app, _) = build_app(&config, db.clone()).await;
+    let (app, _) = build_app(&config, db.clone(), db.clone(), SetupMode::Production).await;
 
     // Close the connection AFTER build to simulate database failure at request time
     db.close().await.ok();

--- a/services/api/tests/server_startup.rs
+++ b/services/api/tests/server_startup.rs
@@ -21,7 +21,9 @@ async fn test_app(name: &str) -> (Router, tempfile::TempDir) {
         recovery_dir: data_dir.join("recovery"),
         data_dir,
     };
-    let (app, _) = build_app(&config, pool.clone(), pool, SetupMode::Production).await;
+    let (app, _) = build_app(&config, pool.clone(), pool, SetupMode::Production)
+        .await
+        .unwrap();
     (app, tmp)
 }
 
@@ -54,7 +56,9 @@ async fn full_startup_flow_with_temp_dirs() {
     let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
     let pool = mokumo_db::initialize_database(&database_url).await.unwrap();
 
-    let _app = build_app(&config, pool.clone(), pool, SetupMode::Production);
+    let _app = build_app(&config, pool.clone(), pool, SetupMode::Production)
+        .await
+        .unwrap();
 
     assert!(db_path.exists(), "database file should exist");
     assert!(data_dir.join("logs").exists(), "logs/ should exist");
@@ -103,7 +107,9 @@ async fn health_endpoint_returns_500_error_body_on_db_failure() {
     };
 
     // Build app while DB is alive (session store needs migration)
-    let (app, _) = build_app(&config, db.clone(), db.clone(), SetupMode::Production).await;
+    let (app, _) = build_app(&config, db.clone(), db.clone(), SetupMode::Production)
+        .await
+        .unwrap();
 
     // Close the connection AFTER build to simulate database failure at request time
     db.close().await.ok();


### PR DESCRIPTION
## Summary

- Replaces `AppState.db` (single `DatabaseConnection`) with `demo_db + production_db + active_profile`
- Introduces `ProfileUserId(SetupMode, i64)` newtype as `AuthUser::Id` — compound ID lets `get_user()` route to the correct database without any separate session context
- Adds `ProfileDbMiddleware` + `ProfileDb` extractor: handlers extract the per-request DB from request extensions rather than `State<SharedState>`; authenticated requests use the DB from the session's compound user ID, unauthenticated fall back to `active_profile`

## Key decisions

- **`ProfileUserId` newtype, not bare tuple** — `axum_login::AuthUser::Id` requires `Display`, which can't be implemented on a foreign tuple. `ProfileUserId` implements `Display` as `"demo:1"` / `"production:42"`.
- **Handler dispatch**: `me`, `regenerate_recovery_codes`, customers, activity → `ProfileDb` extractor. `setup` → hardcoded `production_db`. `demo_reset` → hardcoded `demo_db`.
- **`prepare_database` returns `(demo_db, production_db, active_profile)`** — main.rs restart loop calls it on each iteration (idempotent; demo reset replaces the demo DB file).

## Session invalidation

Deploying this PR invalidates all existing sessions — `AuthUser::Id` changed from `i64` to `ProfileUserId(SetupMode, i64)`, changing session serialization. Pre-release with no active users — one-time logout. Documented in CHANGELOG.

## Test plan

- [x] `moon run api:test` — 270/270 pass
- [x] `moon run api:lint` — clean
- [x] Pre-push hook (clippy + build) — clean
- [ ] BDD spec `profile_middleware.feature` — step definitions to be wired in a follow-up (profiles are a prerequisite; middleware integration tested end-to-end via existing auth BDD specs)

Closes #276
Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Sessions are invalidated on first request after a deploy — users will be logged out once and must sign in again.
  * Health checks and setup status now reflect the currently active profile.

* **New Features**
  * Requests and authentication are profile-aware; data access is routed per-request to the appropriate profile (demo vs production).
  * Demo-mode banner is permanent, non-dismissible; its CTA opens the profile switcher with a contextual label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->