### PR TITLE
feat(web): demo banner overhaul + sidebar profile switcher (#262 Session 4)

### DIFF
--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -122,7 +122,7 @@ tasks:
     - '@group(tests)'
     - .storybook/**/*
   test-e2e:
-    script: pnpm exec bddgen && pnpm exec playwright test --project app
+    script: pnpm exec bddgen && pnpm exec playwright test --project app --project profile
     deps:
     - ~:build
     - api:build

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -37,8 +37,6 @@ const appTestDir = defineBddConfig({
 		'tests/features/customers/**/*.feature',
 		'tests/features/help-popover/**/*.feature',
 		'tests/features/logout/**/*.feature',
-		'tests/features/demo-banner.feature',
-		'tests/features/profile-switcher.feature',
 	],
 	steps: [
 		'tests/steps/settings-lan.steps.ts',
@@ -46,7 +44,22 @@ const appTestDir = defineBddConfig({
 		'tests/steps/customer-*.steps.ts',
 		'tests/steps/help-popover.steps.ts',
 		'tests/steps/logout.steps.ts',
+		'tests/support/app.fixture.ts',
+	],
+	importTestFrom: 'tests/support/app.fixture.ts',
+	tags: 'not @wip and not @future',
+	disableWarnings: { importTestFrom: true },
+});
+
+const profileTestDir = defineBddConfig({
+	outputDir: '.features-gen/profile',
+	features: [
+		'tests/features/demo-banner.feature',
+		'tests/features/profile-switcher.feature',
+	],
+	steps: [
 		'tests/steps/profile-shared.steps.ts',
+		'tests/steps/customer-shared.steps.ts',
 		'tests/support/app.fixture.ts',
 	],
 	importTestFrom: 'tests/support/app.fixture.ts',
@@ -82,6 +95,11 @@ export default defineConfig({
 		{
 			name: 'app',
 			testDir: appTestDir,
+			use: { browserName: 'chromium' },
+		},
+		{
+			name: 'profile',
+			testDir: profileTestDir,
 			use: { browserName: 'chromium' },
 		},
 		{

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -11,6 +11,8 @@ const storybookTestDir = defineBddConfig({
 		'!tests/features/setup-wizard.feature',
 		'!tests/features/help-popover/**/*.feature',
 		'!tests/features/logout/**/*.feature',
+		'!tests/features/demo-banner.feature',
+		'!tests/features/profile-switcher.feature',
 	],
 	steps: [
 		'tests/steps/*.ts',
@@ -21,6 +23,7 @@ const storybookTestDir = defineBddConfig({
 		'!tests/steps/help-popover.steps.ts',
 		'!tests/steps/customer-*.steps.ts',
 		'!tests/steps/logout.steps.ts',
+		'!tests/steps/profile-shared.steps.ts',
 		'tests/support/storybook.fixture.ts',
 		'tests/support/storybook.helpers.ts',
 	],
@@ -34,6 +37,8 @@ const appTestDir = defineBddConfig({
 		'tests/features/customers/**/*.feature',
 		'tests/features/help-popover/**/*.feature',
 		'tests/features/logout/**/*.feature',
+		'tests/features/demo-banner.feature',
+		'tests/features/profile-switcher.feature',
 	],
 	steps: [
 		'tests/steps/settings-lan.steps.ts',
@@ -41,6 +46,7 @@ const appTestDir = defineBddConfig({
 		'tests/steps/customer-*.steps.ts',
 		'tests/steps/help-popover.steps.ts',
 		'tests/steps/logout.steps.ts',
+		'tests/steps/profile-shared.steps.ts',
 		'tests/support/app.fixture.ts',
 	],
 	importTestFrom: 'tests/support/app.fixture.ts',

--- a/apps/web/src/lib/components/app-sidebar.stories.svelte
+++ b/apps/web/src/lib/components/app-sidebar.stories.svelte
@@ -14,7 +14,11 @@
 
 <Story name="Default">
   <Sidebar.Provider>
-    <AppSidebar />
+    <AppSidebar
+      setupMode="demo"
+      productionSetupComplete={false}
+      shopName={null}
+    />
     <Sidebar.Inset>
       <header
         class="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12"

--- a/apps/web/src/lib/components/app-sidebar.svelte
+++ b/apps/web/src/lib/components/app-sidebar.svelte
@@ -2,9 +2,12 @@
   import { untrack } from "svelte";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import { profile } from "$lib/stores/profile.svelte";
   import { navItems } from "$lib/config/nav-items";
   import { isActive } from "$lib/config/nav-utils";
   import * as Avatar from "$lib/components/ui/avatar";
+  import { Badge } from "$lib/components/ui/badge";
+  import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import * as Popover from "$lib/components/ui/popover";
   import * as Sidebar from "$lib/components/ui/sidebar";
   import { useSidebar } from "$lib/components/ui/sidebar";
@@ -12,11 +15,23 @@
   import { toast } from "$lib/components/toast";
   import { apiFetch } from "$lib/api";
   import { DEMO_GUIDE_URL } from "$lib/config/constants";
+  import type { ProfileSwitchResponse } from "$lib/types/ProfileSwitchResponse";
+  import Check from "@lucide/svelte/icons/check";
+  import ChevronDown from "@lucide/svelte/icons/chevron-down";
   import CircleHelp from "@lucide/svelte/icons/circle-help";
+  import Loader2 from "@lucide/svelte/icons/loader-2";
   import LogOut from "@lucide/svelte/icons/log-out";
   import Moon from "@lucide/svelte/icons/moon";
   import Sun from "@lucide/svelte/icons/sun";
   import UserRound from "@lucide/svelte/icons/user-round";
+
+  interface Props {
+    setupMode: "demo" | "production" | null;
+    productionSetupComplete: boolean;
+    shopName: string | null;
+  }
+
+  let { setupMode, productionSetupComplete, shopName }: Props = $props();
 
   const visibleItems = navItems.filter((item) => !item.hidden);
 
@@ -75,7 +90,6 @@
     localStorage.setItem("mokumo-theme", value);
   }
 
-  // Apply saved theme on mount
   $effect(() => {
     applyTheme(activeTheme);
   });
@@ -114,29 +128,133 @@
       }
     });
   });
+
+  // ─── Profile switcher ──────────────────────────────────────────────────────
+
+  let switcherOpen = $state(false);
+  let switching = $state(false);
+
+  let activeProfileName = $derived(
+    setupMode === "demo" ? "Mokumo Software" : (shopName ?? "Set Up My Shop"),
+  );
+
+  // Open the dropdown when an external trigger sets the flag (banner CTA, settings)
+  $effect(() => {
+    if (profile.openProfileSwitcher) {
+      switcherOpen = true;
+      profile.openProfileSwitcher = false;
+    }
+  });
+
+  async function handleProfileSwitch(target: "demo" | "production") {
+    if (target === setupMode || switching) return;
+    if (profile.dirtyForms.size > 0) {
+      // Session 5b: dirty-form guard opens confirmation dialog
+      profile.switchTarget = target;
+      return;
+    }
+    switching = true;
+    const result = await apiFetch<ProfileSwitchResponse>(
+      "/api/profile/switch",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ profile: target }),
+      },
+    );
+    if (!result.ok) {
+      switching = false;
+      toast.error("Failed to switch profile. Please try again.");
+      return;
+    }
+    switcherOpen = false;
+    await goto("/");
+  }
 </script>
 
 <Sidebar.Sidebar variant="sidebar" collapsible="icon">
   <Sidebar.SidebarHeader>
-    <div
-      class="flex items-center gap-2 px-1 py-1.5 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
-      role="none"
-      oncontextmenu={(e) => e.preventDefault()}
-    >
-      <img
-        src="/mokumo-cloud.png"
-        alt="Mokumo"
-        class="h-8 w-auto shrink-0 dark:invert group-data-[collapsible=icon]:h-6 select-none"
-        draggable="false"
-      />
-      <img
-        src="/mokumo-name.png"
-        alt="Mokumo Software"
-        class="h-6 w-auto dark:invert group-data-[collapsible=icon]:hidden select-none"
-        draggable="false"
-      />
-    </div>
+    <DropdownMenu.Root bind:open={switcherOpen}>
+      <DropdownMenu.Trigger
+        class="flex w-full items-center gap-2 rounded-md px-1 py-1.5 hover:bg-sidebar-accent group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+        data-testid="profile-switcher-trigger"
+        aria-label="Switch profile"
+      >
+        <img
+          src="/mokumo-cloud.png"
+          alt="Mokumo"
+          class="h-8 w-auto shrink-0 dark:invert group-data-[collapsible=icon]:h-6 select-none"
+          draggable="false"
+        />
+        <span
+          class="flex-1 truncate text-left text-sm font-semibold group-data-[collapsible=icon]:hidden"
+          data-testid="profile-switcher-text"
+        >
+          {activeProfileName}
+        </span>
+        <ChevronDown
+          class="ml-auto size-4 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden"
+          data-testid="profile-switcher-chevron"
+        />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content
+        align="start"
+        class="w-60"
+        data-testid="profile-dropdown"
+      >
+        <!-- Demo profile entry -->
+        <DropdownMenu.Item
+          onclick={() => handleProfileSwitch("demo")}
+          disabled={switching}
+          class="gap-2 py-2"
+          data-testid="profile-entry-demo"
+        >
+          <img
+            src="/mokumo-cloud.png"
+            alt=""
+            class="h-5 w-auto shrink-0 dark:invert"
+            draggable="false"
+          />
+          <span class="flex-1 truncate">Mokumo Software</span>
+          <Badge variant="secondary" data-testid="demo-badge">DEMO</Badge>
+          {#if switching && setupMode !== "demo"}
+            <Loader2
+              class="size-4 animate-spin"
+              data-testid="profile-switch-spinner"
+            />
+          {:else if setupMode === "demo"}
+            <Check class="size-4" data-testid="profile-entry-checkmark-demo" />
+          {/if}
+        </DropdownMenu.Item>
+
+        <!-- Production profile entry -->
+        <DropdownMenu.Item
+          onclick={() => handleProfileSwitch("production")}
+          disabled={switching}
+          class="gap-2 py-2"
+          data-testid="profile-entry-production"
+        >
+          <span class="flex-1 truncate">
+            {productionSetupComplete
+              ? (shopName ?? "Production")
+              : "Set Up My Shop"}
+          </span>
+          {#if switching && setupMode !== "production"}
+            <Loader2
+              class="size-4 animate-spin"
+              data-testid="profile-switch-spinner"
+            />
+          {:else if setupMode === "production"}
+            <Check
+              class="size-4"
+              data-testid="profile-entry-checkmark-production"
+            />
+          {/if}
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
   </Sidebar.SidebarHeader>
+
   <Sidebar.SidebarContent>
     <Sidebar.SidebarGroup>
       <Sidebar.SidebarMenu>
@@ -158,6 +276,7 @@
       </Sidebar.SidebarMenu>
     </Sidebar.SidebarGroup>
   </Sidebar.SidebarContent>
+
   <Sidebar.SidebarFooter>
     <Sidebar.SidebarMenu>
       <Sidebar.SidebarMenuItem>

--- a/apps/web/src/lib/components/app-sidebar.svelte
+++ b/apps/web/src/lib/components/app-sidebar.svelte
@@ -141,13 +141,25 @@
   // Open the dropdown when an external trigger sets the flag (banner CTA, settings)
   $effect(() => {
     if (profile.openProfileSwitcher) {
+      if (sidebar.isMobile) {
+        sidebar.setOpenMobile(true);
+      }
       switcherOpen = true;
       profile.openProfileSwitcher = false;
     }
   });
 
   async function handleProfileSwitch(target: "demo" | "production") {
-    if (target === setupMode || switching) return;
+    if (switching) return;
+    if (target === setupMode) {
+      switcherOpen = false;
+      return;
+    }
+    if (target === "production" && !productionSetupComplete) {
+      switcherOpen = false;
+      await goto("/setup");
+      return;
+    }
     if (profile.dirtyForms.size > 0) {
       // Session 5b: dirty-form guard opens confirmation dialog
       profile.switchTarget = target;
@@ -205,6 +217,7 @@
         <!-- Demo profile entry -->
         <DropdownMenu.Item
           onclick={() => handleProfileSwitch("demo")}
+          closeOnSelect={false}
           disabled={switching}
           class="gap-2 py-2"
           data-testid="profile-entry-demo"
@@ -230,6 +243,7 @@
         <!-- Production profile entry -->
         <DropdownMenu.Item
           onclick={() => handleProfileSwitch("production")}
+          closeOnSelect={false}
           disabled={switching}
           class="gap-2 py-2"
           data-testid="profile-entry-production"

--- a/apps/web/src/lib/components/app-sidebar.svelte
+++ b/apps/web/src/lib/components/app-sidebar.svelte
@@ -135,7 +135,11 @@
   let switching = $state(false);
 
   let activeProfileName = $derived(
-    setupMode === "demo" ? "Mokumo Software" : (shopName ?? "Set Up My Shop"),
+    setupMode === "demo"
+      ? "Mokumo Software"
+      : productionSetupComplete
+        ? (shopName ?? "Production")
+        : "Set Up My Shop",
   );
 
   // Open the dropdown when an external trigger sets the flag (banner CTA, settings)
@@ -179,6 +183,7 @@
       toast.error("Failed to switch profile. Please try again.");
       return;
     }
+    switching = false;
     switcherOpen = false;
     await goto("/");
   }

--- a/apps/web/src/lib/components/demo-banner.svelte
+++ b/apps/web/src/lib/components/demo-banner.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
-  import { browser } from "$app/environment";
-  import X from "@lucide/svelte/icons/x";
+  import { profile } from "$lib/stores/profile.svelte";
 
   interface Props {
-    setupMode: string | null;
+    setupMode: "demo" | "production" | null;
+    hasProductionShop: boolean;
   }
 
-  let { setupMode }: Props = $props();
+  let { setupMode, hasProductionShop }: Props = $props();
 
-  const STORAGE_KEY = "demo_banner_dismissed";
+  let visible = $derived(setupMode === "demo");
 
-  let dismissed = $state(
-    browser && localStorage.getItem(STORAGE_KEY) === "true",
-  );
-
-  let visible = $derived(setupMode === "demo" && !dismissed);
-
-  function dismiss() {
-    localStorage.setItem(STORAGE_KEY, "true");
-    dismissed = true;
+  function openSwitcher() {
+    profile.openProfileSwitcher = true;
   }
 </script>
 
@@ -28,23 +21,13 @@
     role="status"
     data-testid="demo-banner"
   >
-    <div class="flex items-center gap-2">
-      <span>
-        You're exploring demo data.
-        <a
-          href="/settings/system"
-          class="font-medium underline underline-offset-4 hover:no-underline"
-        >
-          Go to Settings
-        </a>
-      </span>
-    </div>
+    <span>You're exploring demo data.</span>
     <button
-      onclick={dismiss}
-      class="ml-2 rounded-sm p-0.5 hover:bg-blue-200/50 dark:hover:bg-blue-800/50"
-      aria-label="Dismiss demo banner"
+      onclick={openSwitcher}
+      class="ml-4 rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600"
+      data-testid="demo-banner-cta"
     >
-      <X class="h-4 w-4" />
+      {hasProductionShop ? "Go to My Shop" : "Set Up My Shop"}
     </button>
   </div>
 {/if}

--- a/apps/web/src/lib/components/demo-banner.test.ts
+++ b/apps/web/src/lib/components/demo-banner.test.ts
@@ -4,33 +4,41 @@ import { render, screen } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect } from "vitest";
 import DemoBanner from "./demo-banner.svelte";
+import { profile } from "$lib/stores/profile.svelte";
 
-// browser: true required — demo-banner reads `browser && localStorage.getItem(...)` on mount.
-// Without this override, `dismissed` always initializes to false regardless of localStorage.
 vi.mock("$app/environment", () => ({ browser: true, dev: false, building: false }));
 
 describe("DemoBanner", () => {
   it('shows banner when setupMode is "demo"', () => {
-    render(DemoBanner, { setupMode: "demo" });
+    render(DemoBanner, { setupMode: "demo", hasProductionShop: false });
     expect(screen.getByTestId("demo-banner")).toBeInTheDocument();
   });
 
   it('hides banner when setupMode is not "demo"', () => {
-    render(DemoBanner, { setupMode: null });
+    render(DemoBanner, { setupMode: null, hasProductionShop: false });
     expect(screen.queryByTestId("demo-banner")).not.toBeInTheDocument();
   });
 
-  it("persists dismiss to localStorage and hides banner", async () => {
-    render(DemoBanner, { setupMode: "demo" });
+  it('shows "Set Up My Shop" CTA when production is not configured', () => {
+    render(DemoBanner, { setupMode: "demo", hasProductionShop: false });
+    expect(screen.getByTestId("demo-banner-cta")).toHaveTextContent("Set Up My Shop");
+  });
+
+  it('shows "Go to My Shop" CTA when production is configured', () => {
+    render(DemoBanner, { setupMode: "demo", hasProductionShop: true });
+    expect(screen.getByTestId("demo-banner-cta")).toHaveTextContent("Go to My Shop");
+  });
+
+  it("has no dismiss button", () => {
+    render(DemoBanner, { setupMode: "demo", hasProductionShop: false });
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it("clicking CTA sets profile.openProfileSwitcher to true", async () => {
+    profile.openProfileSwitcher = false;
+    render(DemoBanner, { setupMode: "demo", hasProductionShop: false });
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: /dismiss/i }));
-    expect(localStorage.getItem("demo_banner_dismissed")).toBe("true");
-    expect(screen.queryByTestId("demo-banner")).not.toBeInTheDocument();
-  });
-
-  it("hides banner on mount when already dismissed", () => {
-    localStorage.setItem("demo_banner_dismissed", "true"); // set before render
-    render(DemoBanner, { setupMode: "demo" });
-    expect(screen.queryByTestId("demo-banner")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("demo-banner-cta"));
+    expect(profile.openProfileSwitcher).toBe(true);
   });
 });

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -24,10 +24,17 @@
 </script>
 
 <SidebarProvider open={sidebarOpen} onOpenChange={handleOpenChange}>
-  <AppSidebar />
+  <AppSidebar
+    setupMode={data.setup_mode}
+    productionSetupComplete={data.production_setup_complete}
+    shopName={data.shop_name ?? null}
+  />
   <SidebarInset>
     <AppTopbar />
-    <DemoBanner setupMode={data.setup_mode} />
+    <DemoBanner
+      setupMode={data.setup_mode}
+      hasProductionShop={data.production_setup_complete}
+    />
     <RecoveryCodeWarning count={data.recovery_codes_remaining} />
     <main class="flex-1 p-4">
       {@render children()}

--- a/apps/web/tests/features/demo-banner.feature
+++ b/apps/web/tests/features/demo-banner.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Demo mode banner
 
   When Mokumo is running with demo data, a permanent banner tells the

--- a/apps/web/tests/features/profile-switcher.feature
+++ b/apps/web/tests/features/profile-switcher.feature
@@ -1,0 +1,97 @@
+Feature: Sidebar profile switcher
+
+  The top-left sidebar header contains a profile switcher. Clicking the
+  shop name / wordmark opens a dropdown with both profiles listed. The
+  active profile has a checkmark. Selecting the inactive profile calls
+  POST /api/profile/switch and reloads the app shell.
+
+  # --- Trigger ---
+
+  Scenario: Sidebar header shows the active profile name
+    Given I am on the demo profile
+    When the app shell loads
+    Then the sidebar header shows "Mokumo Software"
+
+  Scenario: Sidebar header shows shop name on production profile
+    Given I am on the production profile with shop name "Gary's Printing Co"
+    When the app shell loads
+    Then the sidebar header shows "Gary's Printing Co"
+
+  Scenario: Clicking the sidebar header opens the profile dropdown
+    Given the app shell is loaded
+    When I click the sidebar header trigger
+    Then the profile dropdown opens
+
+  Scenario: Clicking the sidebar header again closes the dropdown
+    Given the profile dropdown is open
+    When I click the sidebar header trigger
+    Then the profile dropdown closes
+
+  Scenario: Collapsed sidebar does not show the switcher trigger
+    Given the sidebar is in collapsed/icon-only mode
+    Then the profile switcher trigger text and chevron are hidden
+    And only the logo icon is visible
+
+  # --- Dropdown content ---
+
+  Scenario: Dropdown lists demo profile entry with DEMO badge
+    Given the profile dropdown is open
+    Then I see an entry for "Mokumo Software"
+    And that entry has a "DEMO" badge
+
+  Scenario: Dropdown lists production profile entry when set up
+    Given the profile dropdown is open
+    And production setup has been completed with shop name "Gary's Printing Co"
+    Then I see an entry for "Gary's Printing Co"
+    And that entry has no badge
+
+  Scenario: Dropdown shows "Set Up My Shop" when production is not yet configured
+    Given the profile dropdown is open
+    And production setup has not been completed
+    Then I see a "Set Up My Shop" entry instead of a production shop name
+
+  Scenario: Active profile entry has a checkmark
+    Given I am on the demo profile
+    And the profile dropdown is open
+    Then the "Mokumo Software" entry has a checkmark indicator
+    And the production entry has no checkmark
+
+  # --- Switching profiles ---
+
+  Scenario: Selecting the inactive profile triggers a switch
+    Given I am on the demo profile
+    And the profile dropdown is open
+    When I click the "Gary's Printing Co" production entry
+    Then a profile switch request is sent for the production profile
+    And the app reloads to "/"
+    And the sidebar header now shows "Gary's Printing Co"
+
+  Scenario: Selecting the active profile does nothing
+    Given I am on the demo profile
+    And the profile dropdown is open
+    When I click the "Mokumo Software" demo entry
+    Then no profile switch request is sent
+    And the dropdown closes
+
+  Scenario: Loading indicator appears on the entry while switch is in flight
+    Given the profile dropdown is open
+    When I click a profile entry
+    Then a spinner appears on that entry
+    And both entries are disabled
+
+  Scenario: Dropdown closes after a successful switch
+    Given I triggered a profile switch from the dropdown
+    When the switch completes successfully
+    Then the dropdown is closed
+
+  # --- Opened by external triggers ---
+
+  Scenario: Demo banner CTA opens the profile switcher dropdown
+    Given the demo banner is visible
+    When I click the banner CTA
+    Then the sidebar profile switcher dropdown opens automatically
+
+  Scenario: Settings shortcut opens the profile switcher dropdown
+    Given I am on the System Settings page
+    When I click "Open Profile Switcher"
+    Then the sidebar profile switcher dropdown opens automatically

--- a/apps/web/tests/features/profile-switcher.feature
+++ b/apps/web/tests/features/profile-switcher.feature
@@ -91,6 +91,7 @@ Feature: Sidebar profile switcher
     When I click the banner CTA
     Then the sidebar profile switcher dropdown opens automatically
 
+  @future
   Scenario: Settings shortcut opens the profile switcher dropdown
     Given I am on the System Settings page
     When I click "Open Profile Switcher"

--- a/apps/web/tests/steps/profile-shared.steps.ts
+++ b/apps/web/tests/steps/profile-shared.steps.ts
@@ -231,10 +231,6 @@ When("I click the banner CTA", async ({ page }) => {
 // Thens — banner
 // ────────────────────────────────────────────────────────────────────────────
 
-Then("the demo banner is visible", async ({ page }) => {
-  await expect(page.getByTestId("demo-banner")).toBeVisible();
-});
-
 Then("no demo banner is visible", async ({ page }) => {
   await expect(page.getByTestId("demo-banner")).not.toBeVisible();
 });

--- a/apps/web/tests/steps/profile-shared.steps.ts
+++ b/apps/web/tests/steps/profile-shared.steps.ts
@@ -1,0 +1,368 @@
+import { expect, type Page } from "@playwright/test";
+import { Given, When, Then } from "../support/app.fixture";
+
+const SETUP_STATUS_ROUTE = "**/api/setup-status";
+const PROFILE_SWITCH_ROUTE = "**/api/profile/switch";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Per-test state
+// ────────────────────────────────────────────────────────────────────────────
+
+type ProfileTestState = {
+  setupMode: "demo" | "production";
+  productionSetupComplete: boolean;
+  shopName: string | null;
+  urlBeforeClick: string | null;
+};
+
+const testState = new WeakMap<Page, ProfileTestState>();
+
+function getState(page: Page): ProfileTestState {
+  if (!testState.has(page)) {
+    testState.set(page, {
+      setupMode: "demo",
+      productionSetupComplete: false,
+      shopName: null,
+      urlBeforeClick: null,
+    });
+  }
+  return testState.get(page)!;
+}
+
+function makeSetupStatusBody(s: ProfileTestState): string {
+  return JSON.stringify({
+    setup_complete: true,
+    setup_mode: s.setupMode,
+    is_first_launch: false,
+    production_setup_complete: s.productionSetupComplete,
+    shop_name: s.shopName,
+  });
+}
+
+async function applySetupStatusMock(page: Page): Promise<void> {
+  const s = getState(page);
+  await page.route(SETUP_STATUS_ROUTE, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: makeSetupStatusBody(s),
+    }),
+  );
+}
+
+async function navigateToApp(page: Page): Promise<void> {
+  await applySetupStatusMock(page);
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Givens — profile state
+// ────────────────────────────────────────────────────────────────────────────
+
+Given("the server is running in demo mode", async ({ page }) => {
+  getState(page).setupMode = "demo";
+});
+
+Given("the server is running in production mode", async ({ page }) => {
+  getState(page).setupMode = "production";
+});
+
+Given("I am on the demo profile", async ({ page }) => {
+  const s = getState(page);
+  s.setupMode = "demo";
+  s.productionSetupComplete = false;
+});
+
+Given(
+  "I am on the production profile with shop name {string}",
+  async ({ page }, shopName: string) => {
+    const s = getState(page);
+    s.setupMode = "production";
+    s.productionSetupComplete = true;
+    s.shopName = shopName;
+  },
+);
+
+Given("production setup has not been completed", async ({ page }) => {
+  getState(page).productionSetupComplete = false;
+});
+
+Given("production setup has been completed", async ({ page }) => {
+  getState(page).productionSetupComplete = true;
+});
+
+Given(
+  "production setup has been completed with shop name {string}",
+  async ({ page }, shopName: string) => {
+    const s = getState(page);
+    s.productionSetupComplete = true;
+    s.shopName = shopName;
+  },
+);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Givens — navigation state
+// ────────────────────────────────────────────────────────────────────────────
+
+Given("the app shell is loaded", async ({ page }) => {
+  await navigateToApp(page);
+  await expect(page.getByTestId("profile-switcher-trigger")).toBeVisible();
+});
+
+Given("the demo banner is visible", async ({ page }) => {
+  const s = getState(page);
+  s.setupMode = "demo";
+  await navigateToApp(page);
+  await expect(page.getByTestId("demo-banner")).toBeVisible();
+});
+
+Given("the profile dropdown is open", async ({ page }) => {
+  await navigateToApp(page);
+  await page.getByTestId("profile-switcher-trigger").click();
+  await expect(page.getByTestId("profile-dropdown")).toBeVisible();
+});
+
+Given("the sidebar is in collapsed/icon-only mode", async ({ page }) => {
+  await navigateToApp(page);
+  const trigger = page.getByRole("button", { name: /toggle sidebar/i });
+  if (await trigger.isVisible()) {
+    await trigger.click();
+    await page.waitForTimeout(300);
+  }
+});
+
+Given("I triggered a profile switch from the dropdown", async ({ page }) => {
+  const s = getState(page);
+  s.setupMode = "demo";
+  await applySetupStatusMock(page);
+  await page.route(PROFILE_SWITCH_ROUTE, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ profile: "production" }),
+    });
+  });
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.getByTestId("profile-switcher-trigger").click();
+  await expect(page.getByTestId("profile-dropdown")).toBeVisible();
+  // Click production entry to trigger switch
+  s.setupMode = "production";
+  s.productionSetupComplete = true;
+  await applySetupStatusMock(page);
+  await page.getByTestId("profile-entry-production").click();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Whens
+// ────────────────────────────────────────────────────────────────────────────
+
+When("the app shell loads", async ({ page }) => {
+  await navigateToApp(page);
+});
+
+When("I click the sidebar header trigger", async ({ page }) => {
+  await page.getByTestId("profile-switcher-trigger").click();
+});
+
+When("I click the {string} production entry", async ({ page }, _label: string) => {
+  // Set up switch response and update mock for post-switch load
+  await page.route(PROFILE_SWITCH_ROUTE, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ profile: "production" }),
+    }),
+  );
+  const s = getState(page);
+  s.setupMode = "production";
+  s.productionSetupComplete = true;
+  s.shopName = s.shopName ?? "Gary's Printing Co";
+  await applySetupStatusMock(page);
+  await page.getByTestId("profile-entry-production").click();
+});
+
+When("I click the {string} demo entry", async ({ page }, _label: string) => {
+  await page.getByTestId("profile-entry-demo").click();
+});
+
+When("I click a profile entry", async ({ page }) => {
+  // Click the inactive profile entry and intercept the switch to observe spinner
+  const s = getState(page);
+  const targetId = s.setupMode === "demo" ? "profile-entry-production" : "profile-entry-demo";
+  await page.route(PROFILE_SWITCH_ROUTE, async (route) => {
+    // Delay to let spinner appear before resolving
+    await new Promise<void>((r) => setTimeout(r, 1000));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ profile: "production" }),
+    });
+  });
+  await page.getByTestId(targetId).click();
+});
+
+When("the switch completes successfully", async ({ page }) => {
+  await page.waitForLoadState("networkidle");
+});
+
+When("I navigate to the Customers page", async ({ page }) => {
+  await page.goto("/customers");
+  await page.waitForLoadState("networkidle");
+});
+
+When("I reload the page", async ({ page }) => {
+  await applySetupStatusMock(page);
+  await page.reload();
+  await page.waitForLoadState("networkidle");
+});
+
+When("I click the banner CTA button", async ({ page }) => {
+  getState(page).urlBeforeClick = page.url();
+  await page.getByTestId("demo-banner-cta").click();
+});
+
+When("I click the banner CTA", async ({ page }) => {
+  await page.getByTestId("demo-banner-cta").click();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Thens — banner
+// ────────────────────────────────────────────────────────────────────────────
+
+Then("the demo banner is visible", async ({ page }) => {
+  await expect(page.getByTestId("demo-banner")).toBeVisible();
+});
+
+Then("no demo banner is visible", async ({ page }) => {
+  await expect(page.getByTestId("demo-banner")).not.toBeVisible();
+});
+
+Then("there is no dismiss or close button on the banner", async ({ page }) => {
+  const banner = page.getByTestId("demo-banner");
+  await expect(
+    banner.locator('button[aria-label*="ismiss"], button[aria-label*="lose"]'),
+  ).not.toBeAttached();
+});
+
+Then("the demo banner is still visible", async ({ page }) => {
+  await expect(page.getByTestId("demo-banner")).toBeVisible();
+});
+
+Then("the banner CTA reads {string}", async ({ page }, text: string) => {
+  await expect(page.getByTestId("demo-banner-cta")).toHaveText(text);
+});
+
+Then("I am still on the same page", async ({ page }) => {
+  const { urlBeforeClick } = getState(page);
+  if (urlBeforeClick) {
+    expect(page.url()).toBe(urlBeforeClick);
+  }
+});
+
+Then("I have not been navigated to Settings", async ({ page }) => {
+  expect(page.url()).not.toContain("/settings");
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Thens — profile switcher
+// ────────────────────────────────────────────────────────────────────────────
+
+Then("the sidebar header shows {string}", async ({ page }, text: string) => {
+  await expect(page.getByTestId("profile-switcher-text")).toHaveText(text);
+});
+
+Then("the sidebar header now shows {string}", async ({ page }, text: string) => {
+  await expect(page.getByTestId("profile-switcher-text")).toHaveText(text);
+});
+
+Then("the profile dropdown opens", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).toBeVisible();
+});
+
+Then("the profile dropdown closes", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).not.toBeVisible();
+});
+
+Then("the sidebar profile switcher dropdown opens", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).toBeVisible();
+});
+
+Then("the sidebar profile switcher dropdown opens automatically", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).toBeVisible();
+});
+
+Then("the profile switcher trigger text and chevron are hidden", async ({ page }) => {
+  await expect(page.getByTestId("profile-switcher-text")).not.toBeVisible();
+  await expect(page.getByTestId("profile-switcher-chevron")).not.toBeVisible();
+});
+
+Then("only the logo icon is visible", async ({ page }) => {
+  await expect(page.getByTestId("profile-switcher-trigger").locator("img").first()).toBeVisible();
+});
+
+Then("I see an entry for {string}", async ({ page }, name: string) => {
+  const entry =
+    name.toLowerCase().includes("mokumo") || name === "Mokumo Software"
+      ? page.getByTestId("profile-entry-demo")
+      : page.getByTestId("profile-entry-production");
+  await expect(entry).toBeVisible();
+  await expect(entry).toContainText(name);
+});
+
+Then("that entry has a {string} badge", async ({ page }, _text: string) => {
+  await expect(page.getByTestId("demo-badge")).toBeVisible();
+});
+
+Then("that entry has no badge", async ({ page }) => {
+  await expect(
+    page.getByTestId("profile-entry-production").getByTestId("demo-badge"),
+  ).not.toBeAttached();
+});
+
+Then("I see a {string} entry instead of a production shop name", async ({ page }, text: string) => {
+  await expect(page.getByTestId("profile-entry-production")).toContainText(text);
+});
+
+Then("the {string} entry has a checkmark indicator", async ({ page }, entryName: string) => {
+  const testId = entryName.toLowerCase().includes("mokumo")
+    ? "profile-entry-checkmark-demo"
+    : "profile-entry-checkmark-production";
+  await expect(page.getByTestId(testId)).toBeVisible();
+});
+
+Then("the production entry has no checkmark", async ({ page }) => {
+  await expect(page.getByTestId("profile-entry-checkmark-production")).not.toBeAttached();
+});
+
+Then("a profile switch request is sent for the production profile", async ({ page }) => {
+  await page.waitForURL(/\/$/, { timeout: 5000 });
+});
+
+Then("the app reloads to {string}", async ({ page }, path: string) => {
+  await page.waitForURL(new RegExp(`${path.replace("/", "\\/")}$`), {
+    timeout: 5000,
+  });
+});
+
+Then("no profile switch request is sent", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).not.toBeVisible();
+});
+
+Then("the dropdown closes", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).not.toBeVisible();
+});
+
+Then("a spinner appears on that entry", async ({ page }) => {
+  await expect(page.getByTestId("profile-switch-spinner")).toBeVisible();
+});
+
+Then("both entries are disabled", async ({ page }) => {
+  await expect(page.getByTestId("profile-entry-demo")).toHaveAttribute("data-disabled", "");
+  await expect(page.getByTestId("profile-entry-production")).toHaveAttribute("data-disabled", "");
+});
+
+Then("the dropdown is closed", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).not.toBeVisible();
+});

--- a/apps/web/tests/steps/profile-shared.steps.ts
+++ b/apps/web/tests/steps/profile-shared.steps.ts
@@ -13,7 +13,7 @@ type ProfileTestState = {
   productionSetupComplete: boolean;
   shopName: string | null;
   urlBeforeClick: string | null;
-  switchRequests: Array<{ profile: string }>;
+  switchRequests: Array<unknown>;
 };
 
 const testState = new WeakMap<Page, ProfileTestState>();
@@ -38,8 +38,7 @@ async function interceptSwitchRoute(
   delayMs = 0,
 ): Promise<void> {
   await page.route(PROFILE_SWITCH_ROUTE, async (route) => {
-    const body = route.request().postDataJSON() as { profile: string } | null;
-    state.switchRequests.push({ profile: body?.profile ?? responseProfile });
+    state.switchRequests.push(route.request().postDataJSON() as unknown);
     if (delayMs > 0) await new Promise<void>((r) => setTimeout(r, delayMs));
     await route.fulfill({
       status: 200,
@@ -143,7 +142,7 @@ Given("the profile dropdown is open", async ({ page }) => {
   await expect(page.getByTestId("profile-dropdown")).toBeVisible();
 });
 
-Given("the sidebar is in collapsed/icon-only mode", async ({ page }) => {
+Given(/^the sidebar is in collapsed\/icon-only mode$/, async ({ page }) => {
   await navigateToApp(page);
   const trigger = page.getByRole("button", { name: /toggle sidebar/i });
   if (await trigger.isVisible()) {
@@ -191,6 +190,16 @@ When("I click the {string} production entry", async ({ page }, _label: string) =
 });
 
 When("I click the {string} demo entry", async ({ page }, _label: string) => {
+  const s = getState(page);
+  // Record any unexpected switch POST — clicking the active demo entry should not fire one
+  await page.route(PROFILE_SWITCH_ROUTE, async (route) => {
+    s.switchRequests.push(route.request().postDataJSON() as unknown);
+    await route.fulfill({
+      status: 403,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "unexpected" }),
+    });
+  });
   await page.getByTestId("profile-entry-demo").click();
 });
 
@@ -207,11 +216,6 @@ When("I click a profile entry", async ({ page }) => {
 });
 
 When("the switch completes successfully", async ({ page }) => {
-  await page.waitForLoadState("networkidle");
-});
-
-When("I navigate to the Customers page", async ({ page }) => {
-  await page.goto("/customers");
   await page.waitForLoadState("networkidle");
 });
 
@@ -338,7 +342,7 @@ Then("the production entry has no checkmark", async ({ page }) => {
 Then("a profile switch request is sent for the production profile", async ({ page }) => {
   const s = getState(page);
   expect(s.switchRequests).toHaveLength(1);
-  expect(s.switchRequests[0].profile).toBe("production");
+  expect((s.switchRequests[0] as { profile?: unknown })?.profile).toBe("production");
   await page.waitForURL((url) => url.pathname === "/", { timeout: 5000 });
 });
 

--- a/apps/web/tests/steps/profile-shared.steps.ts
+++ b/apps/web/tests/steps/profile-shared.steps.ts
@@ -13,6 +13,7 @@ type ProfileTestState = {
   productionSetupComplete: boolean;
   shopName: string | null;
   urlBeforeClick: string | null;
+  switchRequests: Array<{ profile: string }>;
 };
 
 const testState = new WeakMap<Page, ProfileTestState>();
@@ -24,9 +25,28 @@ function getState(page: Page): ProfileTestState {
       productionSetupComplete: false,
       shopName: null,
       urlBeforeClick: null,
+      switchRequests: [],
     });
   }
   return testState.get(page)!;
+}
+
+async function interceptSwitchRoute(
+  page: Page,
+  state: ProfileTestState,
+  responseProfile: "demo" | "production",
+  delayMs = 0,
+): Promise<void> {
+  await page.route(PROFILE_SWITCH_ROUTE, async (route) => {
+    const body = route.request().postDataJSON() as { profile: string } | null;
+    state.switchRequests.push({ profile: body?.profile ?? responseProfile });
+    if (delayMs > 0) await new Promise<void>((r) => setTimeout(r, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ profile: responseProfile }),
+    });
+  });
 }
 
 function makeSetupStatusBody(s: ProfileTestState): string {
@@ -128,28 +148,22 @@ Given("the sidebar is in collapsed/icon-only mode", async ({ page }) => {
   const trigger = page.getByRole("button", { name: /toggle sidebar/i });
   if (await trigger.isVisible()) {
     await trigger.click();
-    await page.waitForTimeout(300);
+    await expect(page.getByTestId("profile-switcher-text")).not.toBeVisible();
   }
 });
 
 Given("I triggered a profile switch from the dropdown", async ({ page }) => {
   const s = getState(page);
   s.setupMode = "demo";
+  s.productionSetupComplete = true;
   await applySetupStatusMock(page);
-  await page.route(PROFILE_SWITCH_ROUTE, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ profile: "production" }),
-    });
-  });
+  await interceptSwitchRoute(page, s, "production");
   await page.goto("/");
   await page.waitForLoadState("networkidle");
   await page.getByTestId("profile-switcher-trigger").click();
   await expect(page.getByTestId("profile-dropdown")).toBeVisible();
   // Click production entry to trigger switch
   s.setupMode = "production";
-  s.productionSetupComplete = true;
   await applySetupStatusMock(page);
   await page.getByTestId("profile-entry-production").click();
 });
@@ -167,15 +181,8 @@ When("I click the sidebar header trigger", async ({ page }) => {
 });
 
 When("I click the {string} production entry", async ({ page }, _label: string) => {
-  // Set up switch response and update mock for post-switch load
-  await page.route(PROFILE_SWITCH_ROUTE, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ profile: "production" }),
-    }),
-  );
   const s = getState(page);
+  await interceptSwitchRoute(page, s, "production");
   s.setupMode = "production";
   s.productionSetupComplete = true;
   s.shopName = s.shopName ?? "Gary's Printing Co";
@@ -191,15 +198,11 @@ When("I click a profile entry", async ({ page }) => {
   // Click the inactive profile entry and intercept the switch to observe spinner
   const s = getState(page);
   const targetId = s.setupMode === "demo" ? "profile-entry-production" : "profile-entry-demo";
-  await page.route(PROFILE_SWITCH_ROUTE, async (route) => {
-    // Delay to let spinner appear before resolving
-    await new Promise<void>((r) => setTimeout(r, 1000));
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ profile: "production" }),
-    });
-  });
+  if (targetId === "profile-entry-production") {
+    s.productionSetupComplete = true;
+    await applySetupStatusMock(page);
+  }
+  await interceptSwitchRoute(page, s, "production", 1000);
   await page.getByTestId(targetId).click();
 });
 
@@ -333,16 +336,19 @@ Then("the production entry has no checkmark", async ({ page }) => {
 });
 
 Then("a profile switch request is sent for the production profile", async ({ page }) => {
-  await page.waitForURL(/\/$/, { timeout: 5000 });
+  const s = getState(page);
+  expect(s.switchRequests).toHaveLength(1);
+  expect(s.switchRequests[0].profile).toBe("production");
+  await page.waitForURL((url) => url.pathname === "/", { timeout: 5000 });
 });
 
 Then("the app reloads to {string}", async ({ page }, path: string) => {
-  await page.waitForURL(new RegExp(`${path.replace("/", "\\/")}$`), {
-    timeout: 5000,
-  });
+  await page.waitForURL((url) => url.pathname === path, { timeout: 5000 });
 });
 
 Then("no profile switch request is sent", async ({ page }) => {
+  const s = getState(page);
+  expect(s.switchRequests).toHaveLength(0);
   await expect(page.getByTestId("profile-dropdown")).not.toBeVisible();
 });
 


### PR DESCRIPTION
## Summary

Session 4 of #262 — demo banner + sidebar profile switcher.

- **demo-banner.svelte**: Permanent banner (no dismiss). CTA is context-sensitive ("Set Up My Shop" / "Go to My Shop") and opens the sidebar switcher instead of navigating to Settings.
- **app-sidebar.svelte**: Static logo header replaced with interactive `DropdownMenu` profile switcher. Lists demo (DEMO badge) and production entries, active entry has checkmark, loading spinner during switch flight. Wires `profile.openProfileSwitcher` `$effect` so banner CTA (and future Settings shortcut) can trigger it remotely. Collapsed sidebar hides text/chevron, shows only logo icon.
- **+layout.svelte**: Passes `setupMode`, `productionSetupComplete`, `shopName` to both `AppSidebar` and `DemoBanner`.
- **Tests**: 9 demo-banner scenarios + 15 profile-switcher scenarios (BDD) + 6 updated unit tests.

## Test plan

- [ ] `moon run web:test` — 214 unit tests pass
- [ ] `moon run web:check` — 0 type errors
- [ ] CI: demo-banner BDD scenarios green
- [ ] CI: profile-switcher BDD scenarios green
- [ ] Demo: in demo mode, banner appears with "Set Up My Shop"; after production setup, CTA reads "Go to My Shop"
- [ ] Demo: clicking CTA opens the sidebar dropdown
- [ ] Demo: dropdown lists both profiles with correct badge and checkmark
- [ ] Demo: switching profiles reloads app shell with new profile active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar header now includes a profile-switcher dropdown (DEMO badge, checkmarks, loading states); layout provides setup/shop state to components. Demo banner simplified—not dismissible; CTA opens the profile switcher and swaps label based on production shop presence.

* **Tests**
  * New end-to-end feature suite, shared step definitions, and updated Playwright config covering profile-switcher and demo-banner flows, UI states, switching behavior, and CTA interactions.

* **Chores**
  * Test task updated to run the new Playwright profile project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->