### PR TITLE
chore(security): add pnpm supply chain protections

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -123,7 +123,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -159,7 +159,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -220,7 +220,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -242,7 +242,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -267,7 +267,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
@@ -328,7 +328,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
-          version: "10.6.5"
+          version: "10.33.0"
       - uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: '10.6.5'
+          version: '10.33.0'
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 node_modules/
 .svelte-kit/
 apps/web/build/
+.pnpm-store/
 
 # Environment
 .env

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Require lockfile to be up-to-date on every install.
+# Prevents implicit dependency resolution drift — deps must be changed explicitly.
+frozen-lockfile=true

--- a/package.json
+++ b/package.json
@@ -7,5 +7,5 @@
   "devDependencies": {
     "lefthook": "^2.1.4"
   },
-  "packageManager": "pnpm@10.6.5"
+  "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
 packages:
   - 'apps/*'
   - 'tools/*'
+
+# Supply chain protection: refuse packages published less than 5 days ago.
+# Most compromised releases (e.g. the March 2026 Axios attack) are caught within hours.
+# Use minimumReleaseAgeExclude to exempt specific packages when a new release is vetted:
+#   minimumReleaseAgeExclude: ['some-package', '@myorg/*']
+minimumReleaseAge: 7200


### PR DESCRIPTION
## Summary

- `frozen-lockfile=true` in `.npmrc` — `pnpm install` fails if lockfile is out of date
- `minimumReleaseAge: 7200` (5 days) in `pnpm-workspace.yaml` — blocks packages published in the last 5 days from being resolved
- `.gitignore` — add `.pnpm-store/` exclusion

## Motivation

March 31 2026 Axios npm supply chain attack. These settings limit exposure to newly published malicious packages and prevent lockfile drift from silently pulling in untested versions.

## Notes

- Use `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` to bypass the age gate for vetted packages when needed
- Pairs with Phase 1 container isolation work (ops#243) — npm execution is now trapped inside Docker containers
- `Cargo.lock` already committed; use `cargo build --locked` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced strict dependency management to prevent unexpected version changes during installation (frozen lockfile)
  * Configured workspace release age constraint to block very recent publishes
  * Updated the pinned package manager to a newer pnpm release
  * Added a VCS ignore pattern for the local pnpm store directory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->