### PR TITLE
feat(web): Settings page shortcut to open profile switcher (Session 5a)

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -34,6 +34,7 @@ const appTestDir = defineBddConfig({
 	outputDir: '.features-gen/app',
 	features: [
 		'tests/features/settings/**/*.feature',
+		'!tests/features/settings/settings-profile-switch.feature',
 		'tests/features/customers/**/*.feature',
 		'tests/features/help-popover/**/*.feature',
 		'tests/features/logout/**/*.feature',
@@ -56,10 +57,12 @@ const profileTestDir = defineBddConfig({
 	features: [
 		'tests/features/demo-banner.feature',
 		'tests/features/profile-switcher.feature',
+		'tests/features/settings/settings-profile-switch.feature',
 	],
 	steps: [
 		'tests/steps/profile-shared.steps.ts',
 		'tests/steps/customer-shared.steps.ts',
+		'tests/steps/settings-profile-switch.steps.ts',
 		'tests/support/app.fixture.ts',
 	],
 	importTestFrom: 'tests/support/app.fixture.ts',

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -24,6 +24,7 @@ const storybookTestDir = defineBddConfig({
 		'!tests/steps/customer-*.steps.ts',
 		'!tests/steps/logout.steps.ts',
 		'!tests/steps/profile-shared.steps.ts',
+		'!tests/steps/settings-profile-switch.steps.ts',
 		'tests/support/storybook.fixture.ts',
 		'tests/support/storybook.helpers.ts',
 	],

--- a/apps/web/src/routes/(app)/settings/system/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/system/+page.svelte
@@ -4,8 +4,10 @@
   import EmptyState from "$lib/components/empty-state.svelte";
   import { Button } from "$lib/components/ui/button";
   import Badge from "$lib/components/ui/badge/badge.svelte";
+  import ArrowLeftRight from "@lucide/svelte/icons/arrow-left-right";
   import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
   import Server from "@lucide/svelte/icons/server";
+  import { profile } from "$lib/stores/profile.svelte";
 
   let resetDialogOpen = $state(false);
 
@@ -40,4 +42,24 @@
 
     <DemoResetDialog bind:open={resetDialogOpen} />
   {/if}
+
+  <div
+    class="mx-auto max-w-md space-y-4 rounded-lg border p-6"
+    data-testid="profile-switcher-section"
+  >
+    <div class="flex items-center gap-2">
+      <h3 class="text-lg font-semibold">Profile</h3>
+    </div>
+    <p class="text-sm text-muted-foreground">
+      Switch between the demo and production profiles.
+    </p>
+    <Button
+      variant="outline"
+      onclick={() => (profile.openProfileSwitcher = true)}
+      data-testid="open-profile-switcher-btn"
+    >
+      <ArrowLeftRight class="mr-2 h-4 w-4" />
+      Open Profile Switcher
+    </Button>
+  </div>
 </div>

--- a/apps/web/tests/features/profile-switcher.feature
+++ b/apps/web/tests/features/profile-switcher.feature
@@ -91,7 +91,3 @@ Feature: Sidebar profile switcher
     When I click the banner CTA
     Then the sidebar profile switcher dropdown opens automatically
 
-  Scenario: Settings shortcut opens the profile switcher dropdown
-    Given I am on the System Settings page
-    When I click "Open Profile Switcher"
-    Then the sidebar profile switcher dropdown opens automatically

--- a/apps/web/tests/features/profile-switcher.feature
+++ b/apps/web/tests/features/profile-switcher.feature
@@ -91,7 +91,6 @@ Feature: Sidebar profile switcher
     When I click the banner CTA
     Then the sidebar profile switcher dropdown opens automatically
 
-  @future
   Scenario: Settings shortcut opens the profile switcher dropdown
     Given I am on the System Settings page
     When I click "Open Profile Switcher"

--- a/apps/web/tests/features/settings/settings-profile-switch.feature
+++ b/apps/web/tests/features/settings/settings-profile-switch.feature
@@ -1,0 +1,40 @@
+@wip
+Feature: Profile switch shortcut in Settings
+
+  The System Settings page contains a shortcut button that opens the
+  sidebar profile switcher. This provides discoverability for users
+  who look in Settings for profile-switching controls.
+
+  # --- Button presence ---
+
+  Scenario: Profile switcher shortcut appears in demo mode
+    Given the server is running in demo mode
+    When I navigate to the System Settings page
+    Then I see an "Open Profile Switcher" button
+
+  Scenario: Profile switcher shortcut appears in production mode
+    Given the server is running in production mode
+    When I navigate to the System Settings page
+    Then I see an "Open Profile Switcher" button
+
+  # --- Button action ---
+
+  Scenario: Clicking the shortcut opens the sidebar profile switcher
+    Given I am on the System Settings page
+    When I click "Open Profile Switcher"
+    Then the sidebar profile switcher dropdown opens
+    And I remain on the System Settings page
+
+  # --- Coexistence with demo reset ---
+
+  Scenario: Demo mode shows both Reset Demo Data and profile switcher shortcut
+    Given the server is running in demo mode
+    When I navigate to the System Settings page
+    Then I see a "Reset Demo Data" button
+    And I see an "Open Profile Switcher" button
+
+  Scenario: Production mode shows only the profile switcher shortcut
+    Given the server is running in production mode
+    When I navigate to the System Settings page
+    Then I do not see a "Reset Demo Data" button
+    And I see an "Open Profile Switcher" button

--- a/apps/web/tests/features/settings/settings-profile-switch.feature
+++ b/apps/web/tests/features/settings/settings-profile-switch.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Profile switch shortcut in Settings
 
   The System Settings page contains a shortcut button that opens the

--- a/apps/web/tests/steps/settings-profile-switch.steps.ts
+++ b/apps/web/tests/steps/settings-profile-switch.steps.ts
@@ -1,0 +1,78 @@
+import { expect, type Page } from "@playwright/test";
+import { Given, When, Then } from "../support/app.fixture";
+
+const SETUP_STATUS_ROUTE = "**/api/setup-status";
+const SYSTEM_SETTINGS_PATH = "/settings/system";
+
+async function mockSetupStatus(page: Page, setupMode: "demo" | "production"): Promise<void> {
+  await page.route(SETUP_STATUS_ROUTE, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        setup_complete: true,
+        setup_mode: setupMode,
+        is_first_launch: false,
+        production_setup_complete: setupMode === "production",
+        shop_name: null,
+      }),
+    }),
+  );
+}
+
+async function navigateToSystemSettings(
+  page: Page,
+  setupMode: "demo" | "production",
+): Promise<void> {
+  await mockSetupStatus(page, setupMode);
+  await page.goto(SYSTEM_SETTINGS_PATH);
+  await page.waitForLoadState("networkidle");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Givens
+// ────────────────────────────────────────────────────────────────────────────
+
+Given("I am on the System Settings page", async ({ page }) => {
+  await navigateToSystemSettings(page, "demo");
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Whens
+// ────────────────────────────────────────────────────────────────────────────
+
+When("I navigate to the System Settings page", async ({ page }) => {
+  // setup mode was already configured by a preceding Given step in profile-shared.steps.ts;
+  // re-apply the mock using the page's already-registered route (profile-shared uses WeakMap state).
+  // We navigate directly and rely on the existing route mock registered by the profile Given steps.
+  await page.goto(SYSTEM_SETTINGS_PATH);
+  await page.waitForLoadState("networkidle");
+});
+
+When('I click "Open Profile Switcher"', async ({ page }) => {
+  await page.getByTestId("open-profile-switcher-btn").click();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Thens
+// ────────────────────────────────────────────────────────────────────────────
+
+Then('I see an "Open Profile Switcher" button', async ({ page }) => {
+  await expect(page.getByTestId("open-profile-switcher-btn")).toBeVisible();
+});
+
+Then("the sidebar profile switcher dropdown opens", async ({ page }) => {
+  await expect(page.getByTestId("profile-dropdown")).toBeVisible();
+});
+
+Then("I remain on the System Settings page", async ({ page }) => {
+  expect(page.url()).toContain(SYSTEM_SETTINGS_PATH);
+});
+
+Then('I see a "Reset Demo Data" button', async ({ page }) => {
+  await expect(page.getByRole("button", { name: "Reset Demo Data" })).toBeVisible();
+});
+
+Then('I do not see a "Reset Demo Data" button', async ({ page }) => {
+  await expect(page.getByRole("button", { name: "Reset Demo Data" })).not.toBeVisible();
+});

--- a/apps/web/tests/steps/settings-profile-switch.steps.ts
+++ b/apps/web/tests/steps/settings-profile-switch.steps.ts
@@ -61,10 +61,6 @@ Then('I see an "Open Profile Switcher" button', async ({ page }) => {
   await expect(page.getByTestId("open-profile-switcher-btn")).toBeVisible();
 });
 
-Then("the sidebar profile switcher dropdown opens", async ({ page }) => {
-  await expect(page.getByTestId("profile-dropdown")).toBeVisible();
-});
-
 Then("I remain on the System Settings page", async ({ page }) => {
   expect(page.url()).toContain(SYSTEM_SETTINGS_PATH);
 });


### PR DESCRIPTION
## Summary

- Adds an "Open Profile Switcher" button to the System Settings page (`/settings/system`) under a new "Profile" card
- Sets `profile.openProfileSwitcher = true` on click — triggers the sidebar dropdown via the existing `$effect` listener
- 5 BDD scenarios covering button visibility, click behavior, and coexistence with Reset Demo Data

## Scope

Part of pipeline `mokumo/20260329-profile-switching-ux` — Session 5a (V4).
Depends on: #297 (merged — V2+V3 sidebar profile switcher).
Session 5b (`feat/v5-unsaved-changes-guard`) depends on this branch.

## Test plan

- [ ] `pnpm exec playwright test --project profile` — all profile BDD scenarios green
- [ ] `moon run web:check` — no TypeScript errors
- [ ] Manual: navigate to System Settings in demo mode, click "Open Profile Switcher", confirm sidebar dropdown opens

Closes #262 (partial — 5a deliverable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Profile" section on the System Settings page with an "Open Profile Switcher" button to open the profile switcher UI.

* **Tests**
  * Introduced end-to-end scenarios validating the profile switcher behavior in System Settings for demo and production modes.
  * Added step definitions to drive and assert the new scenarios; removed one prior shortcut scenario from regular execution.

* **Chores**
  * Updated test configuration to include the new profile-switcher test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->