### PR TITLE
fix(api): correct compare_exchange ordering and document discard intent

### DIFF
--- a/services/api/src/profile_switch.rs
+++ b/services/api/src/profile_switch.rs
@@ -205,6 +205,9 @@ pub async fn profile_switch(
     }
 
     // Mark first-launch as done on the first successful switch.
+    // The CAS true→false is idempotent — if already false (not first launch or concurrent switch
+    // cleared it), the no-op is correct. Failure ordering is Relaxed because the failure result
+    // is discarded and no acquire fence is needed.
     let _ =
         state
             .is_first_launch

--- a/services/api/src/profile_switch.rs
+++ b/services/api/src/profile_switch.rs
@@ -205,13 +205,12 @@ pub async fn profile_switch(
     }
 
     // Mark first-launch as done on the first successful switch.
-    // The CAS true→false is idempotent — if already false (not first launch or concurrent switch
-    // cleared it), the no-op is correct. Failure ordering is Relaxed because the failure result
-    // is discarded and no acquire fence is needed.
+    // Idempotent: if already false, the CAS is a harmless no-op.
+    // Relaxed failure ordering because the result is discarded.
     let _ =
         state
             .is_first_launch
-            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed);
+            .compare_exchange(true, false, Ordering::Release, Ordering::Relaxed);
 
     Ok(Json(ProfileSwitchResponse { profile: target }))
 }


### PR DESCRIPTION
## Summary

- Documents the `compare_exchange` discard pattern in `profile_switch.rs`: the `is_first_launch` CAS result is intentionally discarded with `let _ =`, so failure ordering needs no synchronization
- Corrects success ordering from `AcqRel` to `Release` — the Acquire half was unused (no loads after the CAS need to observe prior stores from another thread); `Release` is the precisely-specified ordering for publishing the `false` write
- Simplifies the inline comment for clarity

Both commits address the same call site; no behavior change on x86/x64 (TSO architecture), removes an unnecessary load fence on ARM/Apple Silicon.

## Test plan

- [x] 296/296 tests pass (`moon run api:test`)
- [x] Clippy clean (`moon run api:lint`)
- [x] `rustfmt` clean (pre-commit hook)

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**No user-visible changes.** This release includes internal optimizations and improvements to system performance with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->