### PR TITLE
fix(api): is_first_launch not cleared when setup wizard completes without prior profile switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `GET /api/setup-status` no longer aliases `production_setup_complete` from the active profile's setup state; it now queries the production database directly so the field is accurate when the demo profile is active. (#290)
+- `GET /api/setup-status` now correctly returns `is_first_launch: false` after the setup wizard completes, even when no profile switch occurred first (e.g. scripted onboarding or direct API use). (#291)
 - `reset-db` CLI now targets the correct profile database (`demo/mokumo.db` by default); use `--production` flag to reset the production profile with a stronger confirmation prompt (#258)
 
 ### Added

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -255,6 +255,15 @@ async fn setup(
     }
     *state.active_profile.write().unwrap() = SetupMode::Production;
 
+    // Clear the first-launch flag so that GET /api/setup-status returns is_first_launch: false
+    // for the lifetime of this server process. The profile_switch handler does the same on a
+    // successful switch, but setup may complete without going through a profile switch (e.g.
+    // scripted onboarding or direct API use that bypasses the welcome screen).
+    let _ =
+        state
+            .is_first_launch
+            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Relaxed);
+
     auto_login(&repo, &user, &mut auth_session).await;
 
     Ok((StatusCode::CREATED, Json(SetupResponse { recovery_codes })))

--- a/services/api/tests/bdd_world/auth_steps.rs
+++ b/services/api/tests/bdd_world/auth_steps.rs
@@ -342,6 +342,17 @@ async fn setup_status_is_first_launch_false(w: &mut ApiWorld) {
     );
 }
 
+#[then("GET /api/setup-status returns is_first_launch as true")]
+async fn setup_status_is_first_launch_true(w: &mut ApiWorld) {
+    let resp = w.server.get("/api/setup-status").await;
+    assert_eq!(resp.status_code(), 200);
+    let body: serde_json::Value = resp.json();
+    assert_eq!(
+        body["is_first_launch"], true,
+        "Expected is_first_launch: true when setup has not completed, got: {body}"
+    );
+}
+
 // ---- Session Login steps ----
 
 #[given("an admin user exists")]

--- a/services/api/tests/bdd_world/auth_steps.rs
+++ b/services/api/tests/bdd_world/auth_steps.rs
@@ -303,6 +303,45 @@ async fn request_rejected(w: &mut ApiWorld) {
     );
 }
 
+// ---- is_first_launch / setup-status steps ----
+
+#[when("the shop owner completes the setup wizard via the HTTP API")]
+async fn complete_setup_wizard_via_api(w: &mut ApiWorld) {
+    let token = w
+        .setup_token
+        .as_ref()
+        .expect("setup_token should be set for fresh server")
+        .clone();
+    let resp = w
+        .server
+        .post("/api/setup")
+        .json(&serde_json::json!({
+            "shop_name": "Test Shop",
+            "admin_name": "Admin",
+            "admin_email": "admin@test.local",
+            "admin_password": "testpassword123",
+            "setup_token": token
+        }))
+        .await;
+    assert_eq!(
+        resp.status_code(),
+        201,
+        "Setup wizard should succeed: {}",
+        resp.text()
+    );
+}
+
+#[then("GET /api/setup-status returns is_first_launch as false")]
+async fn setup_status_is_first_launch_false(w: &mut ApiWorld) {
+    let resp = w.server.get("/api/setup-status").await;
+    assert_eq!(resp.status_code(), 200);
+    let body: serde_json::Value = resp.json();
+    assert_eq!(
+        body["is_first_launch"], false,
+        "Expected is_first_launch: false after setup wizard completion, got: {body}"
+    );
+}
+
 // ---- Session Login steps ----
 
 #[given("an admin user exists")]

--- a/services/api/tests/features/setup_wizard.feature
+++ b/services/api/tests/features/setup_wizard.feature
@@ -61,3 +61,8 @@ Feature: Setup Wizard
     When someone submits the setup wizard with an incorrect token
     Then the request is rejected
     And no user account is created
+
+  Scenario: Setup wizard completion clears is_first_launch without a prior profile switch
+    Given a freshly started server with no users
+    When the shop owner completes the setup wizard via the HTTP API
+    Then GET /api/setup-status returns is_first_launch as false

--- a/services/api/tests/features/setup_wizard.feature
+++ b/services/api/tests/features/setup_wizard.feature
@@ -66,3 +66,9 @@ Feature: Setup Wizard
     Given a freshly started server with no users
     When the shop owner completes the setup wizard via the HTTP API
     Then GET /api/setup-status returns is_first_launch as false
+
+  Scenario: Failed setup wizard does not clear is_first_launch
+    Given a freshly started server with no users
+    When someone submits the setup wizard with an incorrect token
+    Then the request is rejected
+    And GET /api/setup-status returns is_first_launch as true


### PR DESCRIPTION
## Summary

- `is_first_launch: Arc<AtomicBool>` was only cleared by `profile_switch.rs` via `compare_exchange`. The setup wizard handler wrote `active_profile` to disk and updated in-memory state but never cleared the flag, leaving `is_first_launch: true` for the process lifetime when setup completed without going through the welcome screen's profile switch path (scripted onboarding, direct API use).
- Adds `compare_exchange(true, false, AcqRel, Relaxed)` in the setup handler after `active_profile` is written — mirrors the identical pattern already in `profile_switch.rs:210`.
- Adds two BDD scenarios: one asserting `is_first_launch: false` after successful setup via the real HTTP API, one asserting it stays `true` after a rejected setup attempt (pins the invariant).

## Test Plan

- [x] `moon run api:test` — 296/296 pass
- [x] BDD: "Setup wizard completion clears is_first_launch without a prior profile switch" — GREEN
- [x] BDD: "Failed setup wizard does not clear is_first_launch" — GREEN (invariant pinned)

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the setup wizard status was not properly reflected as complete after completion in certain scenarios.

* **Tests**
  * Added test coverage for setup wizard completion and setup status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->