### PR TITLE
feat(desktop): handle server-error Tauri event in root layout

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -2,8 +2,42 @@
   import "../app.css";
   import { ModeWatcher, mode } from "mode-watcher";
   import { Toaster, toastClasses } from "$lib/components/toast";
+  import { toast } from "svelte-sonner";
+  import { onMount } from "svelte";
+  import type { ServerStartupError } from "$lib/types/ServerStartupError";
 
   let { children } = $props();
+
+  onMount(() => {
+    if (!("__TAURI_INTERNALS__" in window)) return;
+
+    let unlisten: (() => void) | undefined;
+
+    import("@tauri-apps/api/event").then(({ listen }) => {
+      listen<ServerStartupError>("server-error", ({ payload }) => {
+        toast.error("Server failed to restart", {
+          description: formatStartupError(payload),
+          duration: Infinity,
+        });
+      }).then((fn) => {
+        unlisten = fn;
+      });
+    });
+
+    return () => {
+      unlisten?.();
+    };
+  });
+
+  function formatStartupError(err: ServerStartupError): string {
+    if (err.code === "migration_failed") {
+      return `Migration failed (${err.path}): ${err.message}`;
+    }
+    if (err.code === "schema_incompatible") {
+      return `Database is newer than this version of Mokumo (${err.path}). Upgrade Mokumo or restore from backup.`;
+    }
+    return `File at ${err.path} is not a Mokumo database. Check your data directory.`;
+  }
 </script>
 
 <ModeWatcher defaultMode="system" />

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import "../app.css";
   import { ModeWatcher, mode } from "mode-watcher";
-  import { Toaster, toastClasses } from "$lib/components/toast";
-  import { toast } from "svelte-sonner";
+  import { Toaster, toastClasses, toast } from "$lib/components/toast";
   import { onMount } from "svelte";
   import type { ServerStartupError } from "$lib/types/ServerStartupError";
 
@@ -11,7 +10,7 @@
   onMount(() => {
     if (!("__TAURI_INTERNALS__" in window)) return;
 
-    let unlisten: (() => void) | undefined;
+    let mounted = true;
 
     import("@tauri-apps/api/event").then(({ listen }) => {
       listen<ServerStartupError>("server-error", ({ payload }) => {
@@ -20,23 +19,35 @@
           duration: Infinity,
         });
       }).then((fn) => {
-        unlisten = fn;
+        if (mounted) {
+          unlisten = fn;
+        } else {
+          fn();
+        }
       });
     });
 
+    let unlisten: (() => void) | undefined;
+
     return () => {
+      mounted = false;
       unlisten?.();
     };
   });
 
   function formatStartupError(err: ServerStartupError): string {
-    if (err.code === "migration_failed") {
-      return `Migration failed (${err.path}): ${err.message}`;
+    switch (err.code) {
+      case "migration_failed":
+        return `Migration failed (${err.path}): ${err.message}`;
+      case "schema_incompatible":
+        return `Database is newer than this version of Mokumo (${err.path}). Upgrade Mokumo or restore from backup.`;
+      case "not_mokumo_database":
+        return `File at ${err.path} is not a Mokumo database. Check your data directory.`;
+      default: {
+        const _exhaustive: never = err;
+        return `Unexpected server error. Check the logs for details.`;
+      }
     }
-    if (err.code === "schema_incompatible") {
-      return `Database is newer than this version of Mokumo (${err.path}). Upgrade Mokumo or restore from backup.`;
-    }
-    return `File at ${err.path} is not a Mokumo database. Check your data directory.`;
   }
 </script>
 


### PR DESCRIPTION
## Summary

- Add `"server-error"` Tauri event listener to the root `+layout.svelte`
- Guard with `"__TAURI_INTERNALS__" in window` — no-op in browser/LAN context
- On receipt, show a persistent error toast with human-readable message derived from the `ServerStartupError` payload variant (`migration_failed` / `schema_incompatible` / `not_mokumo_database`)

## Context

The restart loop in `apps/desktop/src/lib.rs` emits a typed `"server-error"` event when demo reset fails to reinitialize the server. The event was added in PR #353 but had no frontend consumer — operators would see the server stop with no visible UI feedback.

The `ServerStartupError` type and `apps/web/src/lib/types/ServerStartupError.ts` binding were also added in #353.

## Test plan

- [x] `moon run web:check` — 0 errors, 0 warnings
- [x] `oxlint` + `prettier` clean via pre-commit hook
- [ ] Manual: trigger a demo reset with a poisoned database to verify toast appears

Closes the follow-up deferred in pipeline `mokumo/20260404-startup-safety-guards`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app now shows persistent error notifications when the server fails to restart, with clearer, formatted descriptions to help users understand the issue and take action. Notifications remain until dismissed and appear immediately when the failure is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->