### PR TITLE
fix(api): setup_mode null on fresh install + atomic ordering (#348, #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `GET /api/setup-status` now returns `setup_mode: null` on a fresh install (when `setup_complete` is false) instead of always returning the current profile mode. (#348)
 - `GET /api/setup-status` no longer aliases `production_setup_complete` from the active profile's setup state; it now queries the production database directly so the field is accurate when the demo profile is active. (#290)
 - `GET /api/setup-status` now correctly returns `is_first_launch: false` after the setup wizard completes, even when no profile switch occurred first (e.g. scripted onboarding or direct API use). (#291)
 - `reset-db` CLI now targets the correct profile database (`demo/mokumo.db` by default); use `--production` flag to reset the production profile with a stronger confirmation prompt (#258)

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -130,7 +130,7 @@ async fn me(
         AppError::Unauthorized(ErrorCode::Unauthorized, "Not authenticated".into())
     })?;
 
-    let setup_complete = state.setup_completed.load(Ordering::Acquire);
+    let setup_complete = state.is_setup_complete();
     let repo = SeaOrmUserRepo::new(db.clone());
     let recovery_codes_remaining = match repo.recovery_codes_remaining(&user.user.id).await {
         Ok(count) => count,

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -130,7 +130,7 @@ async fn me(
         AppError::Unauthorized(ErrorCode::Unauthorized, "Not authenticated".into())
     })?;
 
-    let setup_complete = state.setup_completed.load(Ordering::Relaxed);
+    let setup_complete = state.setup_completed.load(Ordering::Acquire);
     let repo = SeaOrmUserRepo::new(db.clone());
     let recovery_codes_remaining = match repo.recovery_codes_remaining(&user.user.id).await {
         Ok(count) => count,
@@ -319,7 +319,7 @@ impl Drop for SetupAttemptGuard {
 }
 
 fn validate_setup_request(state: &SharedState, req: &SetupRequest) -> Result<(), AppError> {
-    if state.setup_completed.load(Ordering::Relaxed) {
+    if state.setup_completed.load(Ordering::Acquire) {
         return Err(AppError::Forbidden("Setup already completed".into()));
     }
 

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -956,11 +956,11 @@ async fn setup_status(
         mokumo_core::setup::SetupMode::Demo => true,
         mokumo_core::setup::SetupMode::Production => state
             .setup_completed
-            .load(std::sync::atomic::Ordering::Relaxed),
+            .load(std::sync::atomic::Ordering::Acquire),
     };
     let is_first_launch = state
         .is_first_launch
-        .load(std::sync::atomic::Ordering::Relaxed);
+        .load(std::sync::atomic::Ordering::Acquire);
 
     let shop_name = mokumo_db::get_shop_name(&state.production_db)
         .await

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -980,7 +980,7 @@ async fn setup_status(
 
     Ok(Json(mokumo_types::setup::SetupStatusResponse {
         setup_complete,
-        setup_mode: Some(*state.active_profile.read().unwrap()),
+        setup_mode: setup_complete.then_some(active),
         is_first_launch,
         production_setup_complete,
         shop_name,

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -98,6 +98,20 @@ impl AppState {
             SetupMode::Production => &self.production_db,
         }
     }
+
+    /// Whether setup is complete for the currently active profile.
+    ///
+    /// Demo is always pre-seeded and never requires the setup wizard, so this
+    /// returns `true` unconditionally in demo mode. Production reads the
+    /// `setup_completed` flag set when the wizard finishes.
+    pub fn is_setup_complete(&self) -> bool {
+        match *self.active_profile.read().unwrap() {
+            SetupMode::Demo => true,
+            SetupMode::Production => self
+                .setup_completed
+                .load(std::sync::atomic::Ordering::Acquire),
+        }
+    }
 }
 
 pub type SharedState = Arc<AppState>;
@@ -950,14 +964,7 @@ async fn setup_status(
     State(state): State<SharedState>,
 ) -> Result<Json<mokumo_types::setup::SetupStatusResponse>, crate::error::AppError> {
     let active = *state.active_profile.read().unwrap();
-    // Demo is always pre-seeded — never needs the setup wizard.
-    // Production uses the AtomicBool that is set when the wizard completes.
-    let setup_complete = match active {
-        mokumo_core::setup::SetupMode::Demo => true,
-        mokumo_core::setup::SetupMode::Production => state
-            .setup_completed
-            .load(std::sync::atomic::Ordering::Acquire),
-    };
+    let setup_complete = state.is_setup_complete();
     let is_first_launch = state
         .is_first_launch
         .load(std::sync::atomic::Ordering::Acquire);


### PR DESCRIPTION
## Summary

  - `GET /api/setup-status` always returned `setup_mode: "production"` on a fresh install — the field is
  `Option<SetupMode>` but `None` was never returned. Fixed by making `setup_mode` conditional on
  `setup_complete` using `then_some(active)`. (#348)
  - `setup_complete` already correctly returns `true` for demo mode — no backend change needed for that
  half of #296. (#296)
  - Four `Relaxed` atomic loads on `setup_completed` and `is_first_launch` paired with `Release` stores —
   corrected to `Acquire` for ARM visibility guarantees. Caught during review.

  ## Commits

  1. `fix(api)`: `setup_mode: setup_complete.then_some(active)` — eliminates redundant lock
  re-acquisition and returns `null` on fresh install
  2. `fix(api)`: `Relaxed` → `Acquire` on all `setup_completed` and `is_first_launch` loads in `lib.rs`
  and `auth/mod.rs`

  ## Test plan

  - [ ] `moon run api:test-bdd` — BDD scenario "Setup status reports fresh install" now passes
  (`setup_mode: null`, `setup_complete: false`)
  - [ ] BDD scenario "Setup status reports demo mode" passes (`setup_complete: true`, `setup_mode:
  "demo"`)
  - [ ] BDD scenario "Setup status reports production mode" passes
  - [ ] `profile_switch.feature` scenarios still pass
  - [ ] CI quality gate green

  Closes #348
  Closes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed setup status API endpoint to correctly return null for setup mode during initial setup on fresh installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->