### PR TITLE
feat(frontend): auth/setup continuity (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Dashboard heading** now shows the configured shop name (falls back to "Your Shop" if none set). (#331)
+- **Dashboard Getting Started card** now differentiates demo vs. production mode: demo users see a contextual CTA to explore sample data or switch to their production shop. (#331)
+- **Shop Settings** subtitle updated to "Your shop details and network access." and now includes a read-only Shop Name card showing the mDNS slug. (#331)
+- **System Settings** replaces the placeholder EmptyState with a plain h1 + subtitle: "Demo mode and profile switching." (#331)
 - **Session invalidation on deploy**: `AuthUser::Id` changed from `i64` to `ProfileUserId(SetupMode, i64)` (compound user ID for dual-DB routing). Any sessions created before this deploy are invalidated on first request. Pre-release with no active users — one-time logout only. (#276)
 
 ### Fixed

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,133 +1,133 @@
-import { defineConfig } from '@playwright/test';
-import { defineBddConfig } from 'playwright-bdd';
+import { defineConfig } from "@playwright/test";
+import { defineBddConfig } from "playwright-bdd";
 
 const storybookTestDir = defineBddConfig({
-	outputDir: '.features-gen/storybook',
-	features: [
-		'tests/features/**/*.feature',
-		'!tests/features/settings/**/*.feature',
-		'!tests/features/customers/**/*.feature',
-		'!tests/features/dashboard.feature',
-		'!tests/features/setup-wizard.feature',
-		'!tests/features/help-popover/**/*.feature',
-		'!tests/features/logout/**/*.feature',
-		'!tests/features/demo-banner.feature',
-		'!tests/features/profile-switcher.feature',
-		'!tests/features/profile-switch-dirty-forms.feature',
-	],
-	steps: [
-		'tests/steps/*.ts',
-		'!tests/steps/shared-steps.ts',
-		'!tests/steps/settings-lan.steps.ts',
-		'!tests/steps/shared-lan.steps.ts',
-		'!tests/steps/dashboard.steps.ts',
-		'!tests/steps/setup-wizard.steps.ts',
-		'!tests/steps/help-popover.steps.ts',
-		'!tests/steps/customer-*.steps.ts',
-		'!tests/steps/logout.steps.ts',
-		'!tests/steps/profile-shared.steps.ts',
-		'!tests/steps/settings-profile-switch.steps.ts',
-		'!tests/steps/profile-switch-dirty-forms.steps.ts',
-		'tests/support/storybook.fixture.ts',
-		'tests/support/storybook.helpers.ts',
-	],
-	tags: 'not @wip and not @future',
+  outputDir: ".features-gen/storybook",
+  features: [
+    "tests/features/**/*.feature",
+    "!tests/features/settings/**/*.feature",
+    "!tests/features/customers/**/*.feature",
+    "!tests/features/dashboard.feature",
+    "!tests/features/setup-wizard.feature",
+    "!tests/features/help-popover/**/*.feature",
+    "!tests/features/logout/**/*.feature",
+    "!tests/features/demo-banner.feature",
+    "!tests/features/profile-switcher.feature",
+    "!tests/features/profile-switch-dirty-forms.feature",
+  ],
+  steps: [
+    "tests/steps/*.ts",
+    "!tests/steps/shared-steps.ts",
+    "!tests/steps/settings-lan.steps.ts",
+    "!tests/steps/shared-lan.steps.ts",
+    "!tests/steps/dashboard.steps.ts",
+    "!tests/steps/setup-wizard.steps.ts",
+    "!tests/steps/help-popover.steps.ts",
+    "!tests/steps/customer-*.steps.ts",
+    "!tests/steps/logout.steps.ts",
+    "!tests/steps/profile-shared.steps.ts",
+    "!tests/steps/settings-profile-switch.steps.ts",
+    "!tests/steps/profile-switch-dirty-forms.steps.ts",
+    "tests/support/storybook.fixture.ts",
+    "tests/support/storybook.helpers.ts",
+  ],
+  tags: "not @wip and not @future",
 });
 
 const appTestDir = defineBddConfig({
-	outputDir: '.features-gen/app',
-	features: [
-		'tests/features/settings/**/*.feature',
-		'!tests/features/settings/settings-profile-switch.feature',
-		'tests/features/customers/**/*.feature',
-		'tests/features/help-popover/**/*.feature',
-		'tests/features/logout/**/*.feature',
-	],
-	steps: [
-		'tests/steps/shared-steps.ts',
-		'tests/steps/settings-lan.steps.ts',
-		'tests/steps/shared-lan.steps.ts',
-		'tests/steps/customer-*.steps.ts',
-		'tests/steps/help-popover.steps.ts',
-		'tests/steps/logout.steps.ts',
-		'tests/support/app.fixture.ts',
-	],
-	importTestFrom: 'tests/support/app.fixture.ts',
-	tags: 'not @wip and not @future',
-	disableWarnings: { importTestFrom: true },
+  outputDir: ".features-gen/app",
+  features: [
+    "tests/features/settings/**/*.feature",
+    "!tests/features/settings/settings-profile-switch.feature",
+    "tests/features/customers/**/*.feature",
+    "tests/features/help-popover/**/*.feature",
+    "tests/features/logout/**/*.feature",
+  ],
+  steps: [
+    "tests/steps/shared-steps.ts",
+    "tests/steps/settings-lan.steps.ts",
+    "tests/steps/shared-lan.steps.ts",
+    "tests/steps/customer-*.steps.ts",
+    "tests/steps/help-popover.steps.ts",
+    "tests/steps/logout.steps.ts",
+    "tests/support/app.fixture.ts",
+  ],
+  importTestFrom: "tests/support/app.fixture.ts",
+  tags: "not @wip and not @future",
+  disableWarnings: { importTestFrom: true },
 });
 
 const profileTestDir = defineBddConfig({
-	outputDir: '.features-gen/profile',
-	features: [
-		'tests/features/demo-banner.feature',
-		'tests/features/profile-switcher.feature',
-		'tests/features/settings/settings-profile-switch.feature',
-		'tests/features/profile-switch-dirty-forms.feature',
-	],
-	steps: [
-		'tests/steps/profile-shared.steps.ts',
-		'tests/steps/profile-switch-dirty-forms.steps.ts',
-		'tests/steps/customer-shared.steps.ts',
-		'tests/steps/settings-profile-switch.steps.ts',
-		'tests/support/app.fixture.ts',
-	],
-	importTestFrom: 'tests/support/app.fixture.ts',
-	tags: 'not @wip and not @future',
-	disableWarnings: { importTestFrom: true },
+  outputDir: ".features-gen/profile",
+  features: [
+    "tests/features/demo-banner.feature",
+    "tests/features/profile-switcher.feature",
+    "tests/features/settings/settings-profile-switch.feature",
+    "tests/features/profile-switch-dirty-forms.feature",
+  ],
+  steps: [
+    "tests/steps/profile-shared.steps.ts",
+    "tests/steps/profile-switch-dirty-forms.steps.ts",
+    "tests/steps/customer-shared.steps.ts",
+    "tests/steps/settings-profile-switch.steps.ts",
+    "tests/support/app.fixture.ts",
+  ],
+  importTestFrom: "tests/support/app.fixture.ts",
+  tags: "not @wip and not @future",
+  disableWarnings: { importTestFrom: true },
 });
 
 const onboardingTestDir = defineBddConfig({
-	outputDir: '.features-gen/onboarding',
-	features: [
-		'tests/features/dashboard.feature',
-		'tests/features/setup-wizard.feature',
-	],
-	steps: [
-		'tests/steps/shared-steps.ts',
-		'tests/steps/dashboard.steps.ts',
-		'tests/steps/setup-wizard.steps.ts',
-		'tests/steps/shared-lan.steps.ts',
-		'tests/support/app.fixture.ts',
-	],
-	importTestFrom: 'tests/support/app.fixture.ts',
-	tags: 'not @wip and not @future',
-	disableWarnings: { importTestFrom: true },
+  outputDir: ".features-gen/onboarding",
+  features: [
+    "tests/features/dashboard.feature",
+    "tests/features/setup-wizard.feature",
+  ],
+  steps: [
+    "tests/steps/shared-steps.ts",
+    "tests/steps/dashboard.steps.ts",
+    "tests/steps/setup-wizard.steps.ts",
+    "tests/steps/shared-lan.steps.ts",
+    "tests/support/app.fixture.ts",
+  ],
+  importTestFrom: "tests/support/app.fixture.ts",
+  tags: "not @wip and not @future",
+  disableWarnings: { importTestFrom: true },
 });
 
 export default defineConfig({
-	workers: 2,
-	projects: [
-		{
-			name: 'storybook',
-			testDir: storybookTestDir,
-			use: { browserName: 'chromium' },
-		},
-		{
-			name: 'app',
-			testDir: appTestDir,
-			use: { browserName: 'chromium' },
-		},
-		{
-			name: 'profile',
-			testDir: profileTestDir,
-			use: { browserName: 'chromium' },
-		},
-		{
-			name: 'onboarding',
-			testDir: onboardingTestDir,
-			use: { browserName: 'chromium' },
-		},
-		{
-			name: 'demo-captures',
-			testDir: 'tests/demo-captures',
-			use: {
-				browserName: 'chromium',
-				screenshot: 'only-on-failure',
-				trace: 'retain-on-failure',
-			},
-		},
-	],
-	reporter: 'html',
-	timeout: 30_000,
+  workers: 2,
+  projects: [
+    {
+      name: "storybook",
+      testDir: storybookTestDir,
+      use: { browserName: "chromium" },
+    },
+    {
+      name: "app",
+      testDir: appTestDir,
+      use: { browserName: "chromium" },
+    },
+    {
+      name: "profile",
+      testDir: profileTestDir,
+      use: { browserName: "chromium" },
+    },
+    {
+      name: "onboarding",
+      testDir: onboardingTestDir,
+      use: { browserName: "chromium" },
+    },
+    {
+      name: "demo-captures",
+      testDir: "tests/demo-captures",
+      use: {
+        browserName: "chromium",
+        screenshot: "only-on-failure",
+        trace: "retain-on-failure",
+      },
+    },
+  ],
+  reporter: "html",
+  timeout: 30_000,
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -17,6 +17,7 @@ const storybookTestDir = defineBddConfig({
 	],
 	steps: [
 		'tests/steps/*.ts',
+		'!tests/steps/shared-steps.ts',
 		'!tests/steps/settings-lan.steps.ts',
 		'!tests/steps/shared-lan.steps.ts',
 		'!tests/steps/dashboard.steps.ts',
@@ -43,6 +44,7 @@ const appTestDir = defineBddConfig({
 		'tests/features/logout/**/*.feature',
 	],
 	steps: [
+		'tests/steps/shared-steps.ts',
 		'tests/steps/settings-lan.steps.ts',
 		'tests/steps/shared-lan.steps.ts',
 		'tests/steps/customer-*.steps.ts',
@@ -82,6 +84,7 @@ const onboardingTestDir = defineBddConfig({
 		'tests/features/setup-wizard.feature',
 	],
 	steps: [
+		'tests/steps/shared-steps.ts',
 		'tests/steps/dashboard.steps.ts',
 		'tests/steps/setup-wizard.steps.ts',
 		'tests/steps/shared-lan.steps.ts',

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -94,42 +94,36 @@
     </Card.Card>
   {/if}
 
-  {#if page.data.setup_mode === "demo"}
-    <Card.Card>
-      <Card.CardHeader>
-        <Card.CardTitle>Getting Started</Card.CardTitle>
-        <Card.CardDescription>Explore what Mokumo can do</Card.CardDescription>
-      </Card.CardHeader>
-      <Card.CardContent>
-        {#if page.data.production_setup_complete}
-          <p class="text-sm text-muted-foreground">
-            You're exploring demo data.
-          </p>
-          <Button
-            variant="outline"
-            class="mt-3"
-            onclick={() => (profile.openProfileSwitcher = true)}
-          >
-            Switch to My Shop
-          </Button>
+  <Card.Card>
+    <Card.CardHeader>
+      <Card.CardTitle>Getting Started</Card.CardTitle>
+      <Card.CardDescription>
+        {#if page.data.setup_mode === "demo"}
+          Explore what Mokumo can do
         {:else}
-          <a href="/customers" class="text-sm text-primary hover:underline">
-            Explore sample customers &rarr;
-          </a>
+          Start building your shop
         {/if}
-      </Card.CardContent>
-    </Card.Card>
-  {:else}
-    <Card.Card>
-      <Card.CardHeader>
-        <Card.CardTitle>Getting Started</Card.CardTitle>
-        <Card.CardDescription>Start building your shop</Card.CardDescription>
-      </Card.CardHeader>
-      <Card.CardContent>
+      </Card.CardDescription>
+    </Card.CardHeader>
+    <Card.CardContent>
+      {#if page.data.setup_mode === "demo" && page.data.production_setup_complete}
+        <p class="text-sm text-muted-foreground">You're exploring demo data.</p>
+        <Button
+          variant="outline"
+          class="mt-3"
+          onclick={() => (profile.openProfileSwitcher = true)}
+        >
+          Switch to My Shop
+        </Button>
+      {:else if page.data.setup_mode === "demo"}
+        <a href="/customers" class="text-sm text-primary hover:underline">
+          Explore sample customers &rarr;
+        </a>
+      {:else}
         <a href="/customers" class="text-sm text-primary hover:underline">
           Create your first customer &rarr;
         </a>
-      </Card.CardContent>
-    </Card.Card>
-  {/if}
+      {/if}
+    </Card.CardContent>
+  </Card.Card>
 </div>

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -38,7 +38,9 @@
 
 <div class="space-y-6">
   <div>
-    <h1 class="text-2xl font-bold">{page.data.shop_name?.trim() || "Your Shop"}</h1>
+    <h1 class="text-2xl font-bold">
+      {page.data.shop_name?.trim() || "Your Shop"}
+    </h1>
     <p class="text-sm text-muted-foreground">Powered by Mokumo</p>
   </div>
 

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -5,6 +5,9 @@
   import type { ServerInfoResponse } from "$lib/types/ServerInfoResponse";
   import * as Card from "$lib/components/ui/card";
   import CopyableUrl from "$lib/components/copyable-url.svelte";
+  import { page } from "$app/state";
+  import { profile } from "$lib/stores/profile.svelte";
+  import { Button } from "$lib/components/ui/button";
 
   let healthy = $state<boolean | null>(null);
   let version = $state("");
@@ -35,7 +38,7 @@
 
 <div class="space-y-6">
   <div>
-    <h1 class="text-2xl font-bold">Your Shop</h1>
+    <h1 class="text-2xl font-bold">{page.data.shop_name ?? "Your Shop"}</h1>
     <p class="text-sm text-muted-foreground">Powered by Mokumo</p>
   </div>
 
@@ -91,15 +94,42 @@
     </Card.Card>
   {/if}
 
-  <Card.Card>
-    <Card.CardHeader>
-      <Card.CardTitle>Getting Started</Card.CardTitle>
-      <Card.CardDescription>Start building your shop</Card.CardDescription>
-    </Card.CardHeader>
-    <Card.CardContent>
-      <a href="/customers" class="text-sm text-primary hover:underline">
-        Create your first customer &rarr;
-      </a>
-    </Card.CardContent>
-  </Card.Card>
+  {#if page.data.setup_mode === "demo"}
+    <Card.Card>
+      <Card.CardHeader>
+        <Card.CardTitle>Getting Started</Card.CardTitle>
+        <Card.CardDescription>Explore what Mokumo can do</Card.CardDescription>
+      </Card.CardHeader>
+      <Card.CardContent>
+        {#if page.data.production_setup_complete}
+          <p class="text-sm text-muted-foreground">
+            You're exploring demo data.
+          </p>
+          <Button
+            variant="outline"
+            class="mt-3"
+            onclick={() => (profile.openProfileSwitcher = true)}
+          >
+            Switch to My Shop
+          </Button>
+        {:else}
+          <a href="/customers" class="text-sm text-primary hover:underline">
+            Explore sample customers &rarr;
+          </a>
+        {/if}
+      </Card.CardContent>
+    </Card.Card>
+  {:else}
+    <Card.Card>
+      <Card.CardHeader>
+        <Card.CardTitle>Getting Started</Card.CardTitle>
+        <Card.CardDescription>Start building your shop</Card.CardDescription>
+      </Card.CardHeader>
+      <Card.CardContent>
+        <a href="/customers" class="text-sm text-primary hover:underline">
+          Create your first customer &rarr;
+        </a>
+      </Card.CardContent>
+    </Card.Card>
+  {/if}
 </div>

--- a/apps/web/src/routes/(app)/+page.svelte
+++ b/apps/web/src/routes/(app)/+page.svelte
@@ -38,7 +38,7 @@
 
 <div class="space-y-6">
   <div>
-    <h1 class="text-2xl font-bold">{page.data.shop_name ?? "Your Shop"}</h1>
+    <h1 class="text-2xl font-bold">{page.data.shop_name?.trim() || "Your Shop"}</h1>
     <p class="text-sm text-muted-foreground">Powered by Mokumo</p>
   </div>
 

--- a/apps/web/src/routes/(app)/settings/shop/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/shop/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { page } from "$app/state";
+  import { apiFetch } from "$lib/api";
   import type { ServerInfoResponse } from "$lib/types/ServerInfoResponse";
+  import { profile } from "$lib/stores/profile.svelte";
   import * as Card from "$lib/components/ui/card";
   import { Badge, type BadgeVariant } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
@@ -57,15 +60,13 @@
   });
 
   onMount(async () => {
-    try {
-      const res = await fetch("/api/server-info");
-      if (!res.ok) throw new Error(`Server returned ${res.status}`);
-      serverInfo = await res.json();
-    } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to load";
-    } finally {
-      loading = false;
+    const result = await apiFetch<ServerInfoResponse>("/api/server-info");
+    if (!result.ok) {
+      error = result.error.message;
+    } else if ("data" in result) {
+      serverInfo = result.data;
     }
+    loading = false;
   });
 
   async function copyUrl(url: string) {
@@ -78,9 +79,34 @@
   <div>
     <h1 class="text-2xl font-bold">Shop Settings</h1>
     <p class="text-sm text-muted-foreground">
-      Configure your shop name, address, and branding.
+      Your shop details and network access.
     </p>
   </div>
+
+  <Card.Card>
+    <Card.CardHeader>
+      <Card.CardTitle>Shop Name</Card.CardTitle>
+    </Card.CardHeader>
+    <Card.CardContent>
+      {#if page.data.shop_name}
+        {@const slug = page.data.shop_name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-|-$/g, "")}
+        <p class="text-sm font-medium">{page.data.shop_name}</p>
+        <p class="text-sm text-muted-foreground font-mono">{slug}.local</p>
+      {:else}
+        <p class="text-sm text-muted-foreground">No shop name set yet.</p>
+        <Button
+          variant="outline"
+          class="mt-3"
+          onclick={() => (profile.openProfileSwitcher = true)}
+        >
+          Switch to My Shop
+        </Button>
+      {/if}
+    </Card.CardContent>
+  </Card.Card>
 
   <Card.Card>
     <Card.CardHeader>

--- a/apps/web/src/routes/(app)/settings/shop/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/shop/+page.svelte
@@ -96,7 +96,9 @@
           .replace(/[^a-z0-9]+/g, "-")
           .replace(/^-|-$/g, "")}
         <p class="text-sm font-medium">{page.data.shop_name}</p>
-        <p class="text-sm text-muted-foreground font-mono">{slug || "shop"}.local</p>
+        <p class="text-sm text-muted-foreground font-mono">
+          {slug || "shop"}.local
+        </p>
       {:else}
         <p class="text-sm text-muted-foreground">No shop name set yet.</p>
         <Button

--- a/apps/web/src/routes/(app)/settings/shop/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/shop/+page.svelte
@@ -65,6 +65,8 @@
       error = result.error.message;
     } else if ("data" in result) {
       serverInfo = result.data;
+    } else {
+      error = "Unexpected response from server. Please reload.";
     }
     loading = false;
   });

--- a/apps/web/src/routes/(app)/settings/shop/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/shop/+page.svelte
@@ -96,7 +96,7 @@
           .replace(/[^a-z0-9]+/g, "-")
           .replace(/^-|-$/g, "")}
         <p class="text-sm font-medium">{page.data.shop_name}</p>
-        <p class="text-sm text-muted-foreground font-mono">{slug}.local</p>
+        <p class="text-sm text-muted-foreground font-mono">{slug || "shop"}.local</p>
       {:else}
         <p class="text-sm text-muted-foreground">No shop name set yet.</p>
         <Button

--- a/apps/web/src/routes/(app)/settings/system/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/system/+page.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
   import { page } from "$app/state";
   import DemoResetDialog from "$lib/components/demo-reset-dialog.svelte";
-  import EmptyState from "$lib/components/empty-state.svelte";
   import { Button } from "$lib/components/ui/button";
   import Badge from "$lib/components/ui/badge/badge.svelte";
   import ArrowLeftRight from "@lucide/svelte/icons/arrow-left-right";
   import RotateCcw from "@lucide/svelte/icons/rotate-ccw";
-  import Server from "@lucide/svelte/icons/server";
   import { profile } from "$lib/stores/profile.svelte";
 
   let resetDialogOpen = $state(false);
@@ -15,11 +13,12 @@
 </script>
 
 <div class="space-y-6">
-  <EmptyState
-    icon={Server}
-    title="System Settings"
-    subtitle="Server configuration, backups, and system maintenance."
-  />
+  <div>
+    <h1 class="text-2xl font-bold">System Settings</h1>
+    <p class="text-sm text-muted-foreground">
+      Demo mode and profile switching.
+    </p>
+  </div>
 
   {#if isDemo}
     <div

--- a/apps/web/tests/features/dashboard.feature
+++ b/apps/web/tests/features/dashboard.feature
@@ -53,3 +53,34 @@ Feature: Dashboard displays LAN connection information
     Given the server is healthy
     When I navigate to the dashboard
     Then I see the server status as "Online"
+
+  # --- Shop name heading ---
+
+  Scenario: Production mode shows shop name in dashboard heading
+    Given the app is running in production mode with shop name "Stitch & Screen"
+    And the server has mDNS active with hostname "mokumo.local" on port 3000
+    When I navigate to the dashboard
+    Then I see the heading "Stitch & Screen"
+
+  Scenario: Dashboard shows fallback heading when shop name is not set
+    Given the app is running in production mode with no shop name
+    And the server has mDNS active with hostname "mokumo.local" on port 3000
+    When I navigate to the dashboard
+    Then I see the heading "Your Shop"
+
+  # --- Demo Getting Started card ---
+
+  Scenario: Demo mode without production setup shows "Explore sample customers" link
+    Given the app is running in demo mode with production setup incomplete
+    And the server has mDNS active with hostname "mokumo.local" on port 3000
+    When I navigate to the dashboard
+    Then I see the heading "Your Shop"
+    And I see "Explore sample customers →"
+
+  Scenario: Demo mode with production setup complete shows "Switch to My Shop" button
+    Given the app is running in demo mode with production setup complete
+    And the server has mDNS active with hostname "mokumo.local" on port 3000
+    When I navigate to the dashboard
+    Then I see the heading "Your Shop"
+    And I see "You're exploring demo data."
+    And I see a "Switch to My Shop" button

--- a/apps/web/tests/features/settings/settings-headers.feature
+++ b/apps/web/tests/features/settings/settings-headers.feature
@@ -21,3 +21,22 @@ Feature: Settings page headers reflect actual page content
     Given the server-info API returns LAN status
     When I navigate to the Shop settings page
     Then I see the "Shop Name" card
+
+  Scenario: Shop name card shows name and mDNS slug when shop name is set
+    Given the server-info API returns LAN status
+    And the shop name is "Stitch & Screen"
+    When I navigate to the Shop settings page
+    Then I see "Stitch & Screen"
+    And I see "stitch-screen.local"
+
+  Scenario: Shop name card shows placeholder when no shop name is configured
+    Given the server-info API returns LAN status
+    And no shop name is configured
+    When I navigate to the Shop settings page
+    Then I see "No shop name set yet."
+    And I see a "Switch to My Shop" button
+
+  Scenario: Shop settings LAN card shows error when server-info API fails
+    Given the server-info API returns an error
+    When I navigate to the Shop settings page
+    Then I see "Unable to fetch server info"

--- a/apps/web/tests/features/settings/settings-headers.feature
+++ b/apps/web/tests/features/settings/settings-headers.feature
@@ -1,0 +1,23 @@
+Feature: Settings page headers reflect actual page content
+
+  System Settings and Shop Settings should have accurate, plain headers
+  instead of placeholder EmptyState components or aspirational subtitles.
+
+  # --- System Settings ---
+
+  Scenario: System settings shows correct subtitle after EmptyState removal
+    When I navigate to the System settings page
+    Then I see "Demo mode and profile switching."
+    And I do not see "Server configuration, backups, and system maintenance."
+
+  # --- Shop Settings ---
+
+  Scenario: Shop settings shows updated subtitle
+    Given the server-info API returns LAN status
+    When I navigate to the Shop settings page
+    Then I see "Your shop details and network access."
+
+  Scenario: Shop settings shows read-only shop name card
+    Given the server-info API returns LAN status
+    When I navigate to the Shop settings page
+    Then I see the "Shop Name" card

--- a/apps/web/tests/steps/dashboard.steps.ts
+++ b/apps/web/tests/steps/dashboard.steps.ts
@@ -110,4 +110,3 @@ Then("I see the server status as {string}", async ({ page }, status: string) => 
 Then("I see the heading {string}", async ({ page }, text: string) => {
   await expect(page.getByRole("heading", { name: text, level: 1 })).toBeVisible();
 });
-

--- a/apps/web/tests/steps/dashboard.steps.ts
+++ b/apps/web/tests/steps/dashboard.steps.ts
@@ -95,14 +95,6 @@ Given("the app is running in production mode with no shop name", async ({ page }
   });
 });
 
-Then("I see the {string} card", async ({ page }, cardTitle: string) => {
-  await expect(page.getByText(cardTitle)).toBeVisible();
-});
-
-Then("I see {string}", async ({ page }, text: string) => {
-  await expect(page.getByText(text)).toBeVisible();
-});
-
 Then("I do not see the {string} card", async ({ page }, cardTitle: string) => {
   await expect(page.getByText(cardTitle)).not.toBeVisible();
 });
@@ -119,6 +111,3 @@ Then("I see the heading {string}", async ({ page }, text: string) => {
   await expect(page.getByRole("heading", { name: text, level: 1 })).toBeVisible();
 });
 
-Then("I see a {string} button", async ({ page }, text: string) => {
-  await expect(page.getByRole("button", { name: text })).toBeVisible();
-});

--- a/apps/web/tests/steps/dashboard.steps.ts
+++ b/apps/web/tests/steps/dashboard.steps.ts
@@ -2,6 +2,7 @@ import { expect } from "@playwright/test";
 import { Given, Then, When } from "../support/app.fixture";
 import { buildHttpUrl } from "../support/local-server";
 import { buildServerInfo, mockHealth, mockServerInfo } from "../support/server-info.helpers";
+import { mockSetupStatus } from "../support/setup-status.helpers";
 
 Given(
   "the server has mDNS active with hostname {string} on port {int}",
@@ -51,12 +52,47 @@ Given("the server is healthy", async ({ page }) => {
 
 Given("I am on the dashboard", async ({ page, appUrl }) => {
   await page.goto(new URL("/", appUrl).toString());
-  await expect(page.getByRole("heading", { name: "Your Shop" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
 });
 
 When("I navigate to the dashboard", async ({ page, appUrl }) => {
   await page.goto(new URL("/", appUrl).toString());
-  await expect(page.getByRole("heading", { name: "Your Shop" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+});
+
+Given("the app is running in demo mode with production setup incomplete", async ({ page }) => {
+  await mockSetupStatus(page, {
+    setup_mode: "demo",
+    production_setup_complete: false,
+    shop_name: null,
+  });
+});
+
+Given("the app is running in demo mode with production setup complete", async ({ page }) => {
+  await mockSetupStatus(page, {
+    setup_mode: "demo",
+    production_setup_complete: true,
+    shop_name: null,
+  });
+});
+
+Given(
+  "the app is running in production mode with shop name {string}",
+  async ({ page }, shopName: string) => {
+    await mockSetupStatus(page, {
+      setup_mode: "production",
+      production_setup_complete: true,
+      shop_name: shopName,
+    });
+  },
+);
+
+Given("the app is running in production mode with no shop name", async ({ page }) => {
+  await mockSetupStatus(page, {
+    setup_mode: "production",
+    production_setup_complete: true,
+    shop_name: null,
+  });
 });
 
 Then("I see the {string} card", async ({ page }, cardTitle: string) => {
@@ -77,4 +113,12 @@ Then("the clipboard contains {string}", async ({ page }, expected: string) => {
 
 Then("I see the server status as {string}", async ({ page }, status: string) => {
   await expect(page.getByText(status)).toBeVisible();
+});
+
+Then("I see the heading {string}", async ({ page }, text: string) => {
+  await expect(page.getByRole("heading", { name: text, level: 1 })).toBeVisible();
+});
+
+Then("I see a {string} button", async ({ page }, text: string) => {
+  await expect(page.getByRole("button", { name: text })).toBeVisible();
 });

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -1,6 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 import type { ServerInfoResponse } from "../../src/lib/types/ServerInfoResponse";
 import { Given, Then, When } from "../support/app.fixture";
+import { mockSetupStatus } from "../support/setup-status.helpers";
 import { buildHttpUrl, TEST_SERVER_HOST } from "../support/local-server";
 
 const SHOP_SETTINGS_PATH = "/settings/shop";
@@ -89,6 +90,28 @@ Given("the server-info API returns LAN status", async ({ lanTestState, page }) =
   await mockServerInfo(page, ACTIVE_SERVER_INFO);
 });
 
+Given("the server-info API returns an error", async ({ page }) => {
+  await page.route(SERVER_INFO_ROUTE, async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: "server_error",
+        message: "Unable to fetch server info",
+        details: null,
+      }),
+    });
+  });
+});
+
+Given("the shop name is {string}", async ({ page }, shopName: string) => {
+  await mockSetupStatus(page, { shop_name: shopName });
+});
+
+Given("no shop name is configured", async ({ page }) => {
+  await mockSetupStatus(page, { shop_name: null });
+});
+
 Given("the server-info API returns mDNS inactive", async ({ lanTestState, page }) => {
   lanTestState.serverInfo = UNAVAILABLE_SERVER_INFO;
   await mockServerInfo(page, UNAVAILABLE_SERVER_INFO);
@@ -138,6 +161,10 @@ Then("I see {string}", async ({ page }, text: string) => {
 
 Then("I do not see {string}", async ({ page }, text: string) => {
   await expect(page.getByText(text)).not.toBeVisible();
+});
+
+Then("I see a {string} button", async ({ page }, text: string) => {
+  await expect(page.getByRole("button", { name: text })).toBeVisible();
 });
 
 Then("I see an {string} status badge", async ({ page }, status: string) => {

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -123,8 +123,21 @@ When("I navigate to the Shop settings page", async ({ page, appUrl }) => {
   await expect(page.getByText("LAN Access")).toBeVisible();
 });
 
+When("I navigate to the System settings page", async ({ page, appUrl }) => {
+  await page.goto(new URL("/settings/system", appUrl).toString());
+  await page.waitForLoadState("networkidle");
+});
+
 Then("I see the {string} card", async ({ page }, cardTitle: string) => {
   await expect(page.getByText(cardTitle)).toBeVisible();
+});
+
+Then("I see {string}", async ({ page }, text: string) => {
+  await expect(page.getByText(text)).toBeVisible();
+});
+
+Then("I do not see {string}", async ({ page }, text: string) => {
+  await expect(page.getByText(text)).not.toBeVisible();
 });
 
 Then("I see an {string} status badge", async ({ page }, status: string) => {

--- a/apps/web/tests/steps/settings-lan.steps.ts
+++ b/apps/web/tests/steps/settings-lan.steps.ts
@@ -151,20 +151,8 @@ When("I navigate to the System settings page", async ({ page, appUrl }) => {
   await page.waitForLoadState("networkidle");
 });
 
-Then("I see the {string} card", async ({ page }, cardTitle: string) => {
-  await expect(page.getByText(cardTitle)).toBeVisible();
-});
-
-Then("I see {string}", async ({ page }, text: string) => {
-  await expect(page.getByText(text)).toBeVisible();
-});
-
 Then("I do not see {string}", async ({ page }, text: string) => {
   await expect(page.getByText(text)).not.toBeVisible();
-});
-
-Then("I see a {string} button", async ({ page }, text: string) => {
-  await expect(page.getByRole("button", { name: text })).toBeVisible();
 });
 
 Then("I see an {string} status badge", async ({ page }, status: string) => {

--- a/apps/web/tests/steps/shared-steps.ts
+++ b/apps/web/tests/steps/shared-steps.ts
@@ -1,0 +1,14 @@
+import { expect } from "@playwright/test";
+import { Then } from "../support/app.fixture";
+
+Then("I see the {string} card", async ({ page }, cardTitle: string) => {
+  await expect(page.getByText(cardTitle)).toBeVisible();
+});
+
+Then("I see {string}", async ({ page }, text: string) => {
+  await expect(page.getByText(text)).toBeVisible();
+});
+
+Then("I see a {string} button", async ({ page }, text: string) => {
+  await expect(page.getByRole("button", { name: text })).toBeVisible();
+});

--- a/apps/web/tests/support/app.fixture.ts
+++ b/apps/web/tests/support/app.fixture.ts
@@ -73,7 +73,13 @@ async function mockAuthenticatedAppShell(page: Page): Promise<void> {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ setup_complete: true }),
+      body: JSON.stringify({
+        setup_complete: true,
+        setup_mode: "production",
+        is_first_launch: false,
+        production_setup_complete: false,
+        shop_name: null,
+      }),
     });
   });
 

--- a/apps/web/tests/support/setup-status.helpers.ts
+++ b/apps/web/tests/support/setup-status.helpers.ts
@@ -1,0 +1,31 @@
+import type { Page } from "@playwright/test";
+import type { SetupStatusResponse } from "../../src/lib/types/SetupStatusResponse";
+
+const SETUP_STATUS_ROUTE = "**/api/setup-status";
+
+export function buildSetupStatus(
+  overrides: Partial<SetupStatusResponse> = {},
+): SetupStatusResponse {
+  return {
+    setup_complete: true,
+    setup_mode: "production",
+    is_first_launch: false,
+    production_setup_complete: true,
+    shop_name: null,
+    ...overrides,
+  };
+}
+
+export async function mockSetupStatus(
+  page: Page,
+  overrides: Partial<SetupStatusResponse> = {},
+): Promise<void> {
+  const status = buildSetupStatus(overrides);
+  await page.route(SETUP_STATUS_ROUTE, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(status),
+    });
+  });
+}

--- a/apps/web/tests/support/setup-status.helpers.ts
+++ b/apps/web/tests/support/setup-status.helpers.ts
@@ -21,6 +21,7 @@ export async function mockSetupStatus(
   overrides: Partial<SetupStatusResponse> = {},
 ): Promise<void> {
   const status = buildSetupStatus(overrides);
+  await page.unroute(SETUP_STATUS_ROUTE).catch(() => {});
   await page.route(SETUP_STATUS_ROUTE, async (route) => {
     await route.fulfill({
       status: 200,

--- a/apps/web/tests/support/setup-status.helpers.ts
+++ b/apps/web/tests/support/setup-status.helpers.ts
@@ -10,7 +10,7 @@ export function buildSetupStatus(
     setup_complete: true,
     setup_mode: "production",
     is_first_launch: false,
-    production_setup_complete: true,
+    production_setup_complete: false,
     shop_name: null,
     ...overrides,
   };


### PR DESCRIPTION
## Summary

- Dashboard heading now shows configured shop name (fallback: "Your Shop")
- Getting Started card differentiates demo vs. production mode with contextual CTAs
- Shop Settings: updated subtitle, read-only Shop Name card with mDNS slug
- System Settings: replaced placeholder EmptyState with accurate h1 + subtitle
- Migrated raw `fetch` to `apiFetch` in shop settings

## Test plan
- [ ] `moon run web:test` — 214 Vitest tests pass
- [ ] BDD fixtures generated cleanly (bddgen exit 0, 6 scenarios in settings-headers)
- [ ] Type check: 0 errors across 1790 files

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard heading shows configured shop name with fallback to "Your Shop."
  * Getting Started card CTA and customer links adapt for demo vs production (includes demo-data status and "Switch to My Shop" flow and "Explore sample customers" where applicable).
  * Shop Settings shows a read-only Shop Name card with mDNS slug when available.
  * System Settings presents a clear title and subtitle instead of a placeholder empty state.

* **Tests**
  * Added end-to-end scenarios and shared test steps covering shop-name-dependent UI and settings headers.

* **Documentation**
  * Updated CHANGELOG with these UI/wording changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->