### PR TITLE
fix(web): guard vitest-setup localStorage against Node 25 built-in stub

### DIFF
--- a/apps/web/vitest-setup.ts
+++ b/apps/web/vitest-setup.ts
@@ -10,10 +10,27 @@ vi.mock('$app/navigation', () => ({
 }));
 
 beforeEach(() => {
-	if (typeof localStorage !== 'undefined') {
+	// Node 25+ ships a built-in localStorage global that exists but lacks Storage
+	// methods (getItem, setItem, clear, etc.) when --localstorage-file is not
+	// configured. vi.unstubAllGlobals() in any test's afterEach can also restore
+	// this broken stub. Re-detect and replace each time so every test starts with
+	// a functional in-memory implementation.
+	if (typeof localStorage !== 'undefined' && typeof localStorage.clear !== 'function') {
+		const store = new Map<string, string>();
+		vi.stubGlobal('localStorage', {
+			getItem: (k: string) => store.get(k) ?? null,
+			setItem: (k: string, v: string) => { store.set(k, v); },
+			removeItem: (k: string) => { store.delete(k); },
+			clear: () => { store.clear(); },
+			key: (i: number) => [...store.keys()][i] ?? null,
+			get length() { return store.size; },
+		});
+	}
+
+	if (typeof localStorage !== 'undefined' && typeof localStorage.clear === 'function') {
 		localStorage.clear();
 	}
-	if (typeof sessionStorage !== 'undefined') {
+	if (typeof sessionStorage !== 'undefined' && typeof sessionStorage.clear === 'function') {
 		sessionStorage.clear();
 	}
 });

--- a/apps/web/vitest-setup.ts
+++ b/apps/web/vitest-setup.ts
@@ -1,36 +1,49 @@
-import '@testing-library/jest-dom/vitest';
-import { vi, beforeEach } from 'vitest';
+import "@testing-library/jest-dom/vitest";
+import { vi, beforeEach } from "vitest";
 
 // Default browser: false — component test files override to true per-file
-vi.mock('$app/environment', () => ({ browser: false, dev: false, building: false }));
-vi.mock('$app/navigation', () => ({
-	goto: vi.fn(),
-	invalidate: vi.fn(),
-	invalidateAll: vi.fn()
+vi.mock("$app/environment", () => ({ browser: false, dev: false, building: false }));
+vi.mock("$app/navigation", () => ({
+  goto: vi.fn(),
+  invalidate: vi.fn(),
+  invalidateAll: vi.fn(),
 }));
 
-beforeEach(() => {
-	// Node 25+ ships a built-in localStorage global that exists but lacks Storage
-	// methods (getItem, setItem, clear, etc.) when --localstorage-file is not
-	// configured. vi.unstubAllGlobals() in any test's afterEach can also restore
-	// this broken stub. Re-detect and replace each time so every test starts with
-	// a functional in-memory implementation.
-	if (typeof localStorage !== 'undefined' && typeof localStorage.clear !== 'function') {
-		const store = new Map<string, string>();
-		vi.stubGlobal('localStorage', {
-			getItem: (k: string) => store.get(k) ?? null,
-			setItem: (k: string, v: string) => { store.set(k, v); },
-			removeItem: (k: string) => { store.delete(k); },
-			clear: () => { store.clear(); },
-			key: (i: number) => [...store.keys()][i] ?? null,
-			get length() { return store.size; },
-		});
-	}
+// Node 25+ ships built-in localStorage/sessionStorage globals that exist but
+// lack Storage methods (getItem, setItem, clear, etc.) when the backing file
+// flags are not configured. vi.unstubAllGlobals() in test afterEach blocks can
+// also restore these broken stubs. Call this helper in beforeEach so every test
+// starts with a functional in-memory implementation regardless of Node version.
+function ensureStorage(name: "localStorage" | "sessionStorage"): void {
+  if (typeof globalThis[name] !== "undefined" && typeof globalThis[name].clear !== "function") {
+    const store = new Map<string, string>();
+    vi.stubGlobal(name, {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => {
+        store.clear();
+      },
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size;
+      },
+    });
+  }
+}
 
-	if (typeof localStorage !== 'undefined' && typeof localStorage.clear === 'function') {
-		localStorage.clear();
-	}
-	if (typeof sessionStorage !== 'undefined' && typeof sessionStorage.clear === 'function') {
-		sessionStorage.clear();
-	}
+beforeEach(() => {
+  ensureStorage("localStorage");
+  ensureStorage("sessionStorage");
+
+  if (typeof localStorage !== "undefined" && typeof localStorage.clear === "function") {
+    localStorage.clear();
+  }
+  if (typeof sessionStorage !== "undefined" && typeof sessionStorage.clear === "function") {
+    sessionStorage.clear();
+  }
 });


### PR DESCRIPTION
## Summary

- Node.js 25 ships a global `localStorage` that exists but lacks Storage methods (`clear`, `getItem`, etc.) when `--localstorage-file` is unconfigured — causing all 214 Vitest tests to fail locally and in containers running Node 25
- `vi.unstubAllGlobals()` in test `afterEach` blocks can restore the broken stub mid-suite, so detection and replacement runs in `beforeEach` (not at module load time)
- CI (Node 22) was unaffected; local + container development was broken

## Test plan
- [ ] `moon run web:test` — 214 tests pass on Node 25 locally
- [ ] No regressions on Node 22 (CI)

Closes #N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test environment reliability by ensuring browser storage is initialized consistently and by adding safeguards so storage clearing runs only when supported, reducing flaky tests and improving test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->