### PR TITLE
fix(ui): Enter key submits regenerate recovery codes dialog (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Enter key now submits the regenerate recovery codes dialog; previously required a mouse click on the Regenerate button. (#278)
 - `GET /api/setup-status` now returns `setup_mode: null` on a fresh install (when `setup_complete` is false) instead of always returning the current profile mode. (#348)
 - `GET /api/setup-status` no longer aliases `production_setup_complete` from the active profile's setup state; it now queries the production database directly so the field is accurate when the demo profile is active. (#290)
 - `GET /api/setup-status` now correctly returns `is_first_launch: false` after the setup wizard completes, even when no profile switch occurred first (e.g. scripted onboarding or direct API use). (#291)

--- a/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
+++ b/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
@@ -51,9 +51,10 @@
       <AlertDialog.Description>{description}</AlertDialog.Description>
     </AlertDialog.Header>
     <form
+      id="regen-form"
       onsubmit={(e) => {
         e.preventDefault();
-        if (!loading && password) handleConfirm();
+        handleConfirm();
       }}
       class="space-y-2"
     >
@@ -80,9 +81,10 @@
       <AlertDialog.Cancel disabled={loading}>Cancel</AlertDialog.Cancel>
       <button
         data-slot="alert-dialog-action"
+        form="regen-form"
+        type="submit"
         class={cn(buttonVariants({ variant: "destructive" }), "gap-2")}
         disabled={loading || !password}
-        onclick={handleConfirm}
       >
         {#if loading}
           <Loader2 class="h-4 w-4 animate-spin" />

--- a/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
+++ b/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.svelte
@@ -18,6 +18,8 @@
     onConfirm,
   }: Props = $props();
 
+  const formId = `regen-form-${Math.random().toString(36).slice(2, 8)}`;
+
   let password = $state("");
   let loading = $state(false);
   let error = $state<string | null>(null);
@@ -51,7 +53,7 @@
       <AlertDialog.Description>{description}</AlertDialog.Description>
     </AlertDialog.Header>
     <form
-      id="regen-form"
+      id={formId}
       onsubmit={(e) => {
         e.preventDefault();
         handleConfirm();
@@ -81,7 +83,7 @@
       <AlertDialog.Cancel disabled={loading}>Cancel</AlertDialog.Cancel>
       <button
         data-slot="alert-dialog-action"
-        form="regen-form"
+        form={formId}
         type="submit"
         class={cn(buttonVariants({ variant: "destructive" }), "gap-2")}
         disabled={loading || !password}

--- a/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.test.ts
+++ b/apps/web/src/lib/components/confirm-dialog/confirm-regen-dialog.test.ts
@@ -3,7 +3,7 @@
 import { render, screen, waitFor } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect, beforeEach, type Mock } from "vitest";
-import ConfirmRegenDialog from "./confirm-dialog/confirm-regen-dialog.svelte";
+import ConfirmRegenDialog from "./confirm-regen-dialog.svelte";
 
 const DEFAULT_PROPS = {
   open: true,

--- a/apps/web/src/lib/components/confirm-regen-dialog.test.ts
+++ b/apps/web/src/lib/components/confirm-regen-dialog.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import ConfirmRegenDialog from "./confirm-dialog/confirm-regen-dialog.svelte";
+
+const DEFAULT_PROPS = {
+  open: true,
+  title: "Regenerate Recovery Codes",
+  description: "Enter your password to confirm.",
+};
+
+describe("ConfirmRegenDialog", () => {
+  let onConfirm: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onConfirm = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it("pressing Enter in the password field submits the form", async () => {
+    render(ConfirmRegenDialog, { ...DEFAULT_PROPS, onConfirm });
+    const user = userEvent.setup();
+
+    const input = screen.getByLabelText(/current password/i);
+    await user.type(input, "correct-password");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith("correct-password");
+    });
+  });
+
+  it("clicking the Regenerate button submits the form", async () => {
+    render(ConfirmRegenDialog, { ...DEFAULT_PROPS, onConfirm });
+    const user = userEvent.setup();
+
+    const input = screen.getByLabelText(/current password/i);
+    await user.type(input, "correct-password");
+    await user.click(screen.getByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith("correct-password");
+    });
+  });
+
+  it("does not submit when password field is empty", async () => {
+    render(ConfirmRegenDialog, { ...DEFAULT_PROPS, onConfirm });
+    const user = userEvent.setup();
+
+    const input = screen.getByLabelText(/current password/i);
+    await user.click(input);
+    await user.keyboard("{Enter}");
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("Regenerate button is disabled when password is empty", () => {
+    render(ConfirmRegenDialog, { ...DEFAULT_PROPS, onConfirm });
+
+    expect(screen.getByRole("button", { name: /regenerate/i })).toBeDisabled();
+  });
+
+  it("shows error message on failed confirmation", async () => {
+    onConfirm.mockRejectedValue(new Error("Incorrect password"));
+    render(ConfirmRegenDialog, { ...DEFAULT_PROPS, onConfirm });
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/current password/i), "wrong");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByText(/incorrect password/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/lib/components/confirm-regen-dialog.test.ts
+++ b/apps/web/src/lib/components/confirm-regen-dialog.test.ts
@@ -2,7 +2,7 @@
 
 import { render, screen, waitFor } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, type Mock } from "vitest";
 import ConfirmRegenDialog from "./confirm-dialog/confirm-regen-dialog.svelte";
 
 const DEFAULT_PROPS = {
@@ -12,10 +12,10 @@ const DEFAULT_PROPS = {
 };
 
 describe("ConfirmRegenDialog", () => {
-  let onConfirm: ReturnType<typeof vi.fn>;
+  let onConfirm: Mock<(password: string) => Promise<void>>;
 
   beforeEach(() => {
-    onConfirm = vi.fn().mockResolvedValue(undefined);
+    onConfirm = vi.fn<(password: string) => Promise<void>>().mockResolvedValue(undefined);
   });
 
   it("pressing Enter in the password field submits the form", async () => {

--- a/apps/web/tests/features/settings/settings-account-regen.feature
+++ b/apps/web/tests/features/settings/settings-account-regen.feature
@@ -56,3 +56,11 @@ Feature: Recovery code regeneration from Settings
     When the admin clicks "Done"
     Then the page returns to the default view
     And the recovery code count shows 10 of 10
+
+  # --- Keyboard interaction ---
+
+  Scenario: Pressing Enter in the password field submits the dialog
+    Given the confirmation dialog is open
+    When the admin types the correct password and presses Enter
+    Then the dialog closes
+    And the page displays 10 new recovery codes


### PR DESCRIPTION
## Summary

- Adds `id="regen-form"` to the password `<form>` and associates the Regenerate button via `form="regen-form" type="submit"`, enabling native HTML implicit form submission on Enter key press
- Removes the redundant `onsubmit` guard (the `handleConfirm` function already bails early on loading/empty password)
- Adds 5 Vitest unit tests covering Enter key submission, button click, empty-password guard, disabled state, and error display
- Adds BDD scenario for keyboard submission to `settings-account-regen.feature`

Closes #278

## Root Cause

The Regenerate button was rendered inside `AlertDialog.Footer` (outside the `<form>`) and used `onclick={handleConfirm}` instead of `type="submit"`. Without an associated submit button, pressing Enter triggered the form's `onsubmit` handler inconsistently across browsers and Tauri's WebView. The `form` attribute pattern (HTML spec) associates an external button with a form by ID without restructuring the component.

## Test Plan

- [x] 5 Vitest unit tests pass (`confirm-regen-dialog.test.ts`)
- [x] Full frontend test suite passes (219 tests)
- [x] Pre-commit hooks pass (oxlint, prettier, story-colocation)
- [ ] Manual: open Settings → Account, click Regenerate Recovery Codes, type password, press Enter → dialog submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now press Enter to submit the recovery code regeneration confirmation dialog, eliminating the need to click the Regenerate button for keyboard navigation efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->