### PR TITLE
chore(web): use CopyableUrl in settings shop LAN card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Settings Shop page** LAN URL and IP address display now use the shared `CopyableUrl` component, removing duplicated inline copy logic. (#162)
 - **Dashboard heading** now shows the configured shop name (falls back to "Your Shop" if none set). (#331)
 - **Dashboard Getting Started card** now differentiates demo vs. production mode: demo users see a contextual CTA to explore sample data or switch to their production shop. (#331)
 - **Shop Settings** subtitle updated to "Your shop details and network access." and now includes a read-only Shop Name card showing the mDNS slug. (#331)

--- a/apps/web/src/routes/(app)/settings/shop/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/shop/+page.svelte
@@ -7,10 +7,9 @@
   import * as Card from "$lib/components/ui/card";
   import { Badge, type BadgeVariant } from "$lib/components/ui/badge";
   import { Button } from "$lib/components/ui/button";
-  import { toast } from "$lib/components/toast";
+  import CopyableUrl from "$lib/components/copyable-url.svelte";
   import Wifi from "@lucide/svelte/icons/wifi";
   import WifiOff from "@lucide/svelte/icons/wifi-off";
-  import Copy from "@lucide/svelte/icons/copy";
 
   let serverInfo = $state<ServerInfoResponse | null>(null);
   let loading = $state(true);
@@ -70,11 +69,6 @@
     }
     loading = false;
   });
-
-  async function copyUrl(url: string) {
-    await navigator.clipboard.writeText(url);
-    toast.success("URL copied to clipboard");
-  }
 </script>
 
 <div class="space-y-6">
@@ -152,40 +146,22 @@
         {#if serverInfo.lan_url}
           <div class="space-y-1">
             <p class="text-sm font-medium">LAN URL</p>
-            <div class="flex items-center gap-2">
-              <code class="rounded bg-muted px-2 py-1 text-sm font-mono">
-                {serverInfo.lan_url}
-              </code>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Copy LAN URL to clipboard"
-                data-testid="copy-lan-url"
-                onclick={() => copyUrl(serverInfo!.lan_url!)}
-              >
-                <Copy class="size-4" />
-              </Button>
-            </div>
+            <CopyableUrl
+              url={serverInfo.lan_url}
+              label="Copy LAN URL to clipboard"
+              testId="copy-lan-url"
+            />
           </div>
         {/if}
 
         {#if serverInfo.ip_url}
           <div class="space-y-1">
             <p class="text-sm font-medium">IP Address</p>
-            <div class="flex items-center gap-2">
-              <code class="rounded bg-muted px-2 py-1 text-sm font-mono">
-                {serverInfo.ip_url}
-              </code>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Copy IP address URL to clipboard"
-                data-testid="copy-ip-url"
-                onclick={() => copyUrl(serverInfo!.ip_url!)}
-              >
-                <Copy class="size-4" />
-              </Button>
-            </div>
+            <CopyableUrl
+              url={serverInfo.ip_url}
+              label="Copy IP address URL to clipboard"
+              testId="copy-ip-url"
+            />
           </div>
 
           <p class="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- Replaces duplicated inline copy-button pattern in `settings/shop/+page.svelte` with the shared `<CopyableUrl>` component
- Removes the one-off `copyUrl` function and `Copy`/`toast` imports that duplicated logic already in the component
- Preserves `aria-label` values and `testId` props so existing BDD step definitions continue to pass without modification

## Test plan

- [ ] Existing `settings-lan-status.feature` BDD scenarios pass (copy button selectors by aria-label unchanged)
- [ ] LAN URL displays and copies to clipboard in UI
- [ ] IP address URL displays and copies to clipboard in UI
- [ ] CI checks green

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for the Settings Shop page's copy functionality for LAN URL and IP address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->