### PR TITLE
test(db,api): verify SQLite works with spaces in data directory path

### DIFF
--- a/crates/db/tests/startup_guards.rs
+++ b/crates/db/tests/startup_guards.rs
@@ -246,6 +246,41 @@ async fn application_id_is_mkmo_after_full_migration() {
     );
 }
 
+// ─── Space-safe path handling (#134) ─────────────────────────────────────────
+
+#[tokio::test]
+async fn initialize_database_works_with_spaces_in_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("Application Support").join("mokumo.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+    let result = initialize_database(&url).await;
+    assert!(
+        result.is_ok(),
+        "initialize_database must succeed when path contains spaces: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn migrations_run_successfully_with_spaces_in_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("Application Support").join("mokumo.db");
+    std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+    let url = format!("sqlite:{}?mode=rwc", db_path.display());
+    let db = initialize_database(&url).await.unwrap();
+    // If initialize_database succeeded, migrations ran. Confirm by querying the migrations table.
+    use sea_orm::ConnectionTrait as _;
+    let result = db
+        .execute_unprepared("SELECT COUNT(*) FROM seaql_migrations")
+        .await;
+    assert!(
+        result.is_ok(),
+        "seaql_migrations table must exist after migrations with spaces in path: {:?}",
+        result.err()
+    );
+}
+
 // ─── Migration quality assertions ──────────────────────────────��─────────────
 
 #[test]

--- a/services/api/tests/auth_reset_regressions.rs
+++ b/services/api/tests/auth_reset_regressions.rs
@@ -395,3 +395,51 @@ async fn sessions_survive_recovery_code_regeneration() {
         "session should remain valid after recovery code regeneration"
     );
 }
+
+#[tokio::test]
+async fn file_drop_recovery_works_with_spaces_in_recovery_dir() {
+    // macOS resolves Tauri's app_data_dir() to ~/Library/Application Support/...
+    // Both the data dir and recovery dir may contain spaces — verify the full
+    // forgot-password flow succeeds and creates the recovery file when they do.
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().join("Application Support");
+    let recovery_dir = tmp.path().join("Recovery Files");
+    ensure_data_dirs(&data_dir).unwrap();
+    std::fs::create_dir_all(&recovery_dir).unwrap();
+
+    let db_path = data_dir.join("mokumo.db");
+    let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    let db = mokumo_db::initialize_database(&database_url).await.unwrap();
+
+    let config = ServerConfig {
+        port: 0,
+        host: "127.0.0.1".into(),
+        data_dir,
+        recovery_dir: recovery_dir.clone(),
+    };
+    let (app, _setup_token) = build_app(&config, db.clone(), db.clone(), SetupMode::Production)
+        .await
+        .unwrap();
+
+    let repo = SeaOrmUserRepo::new(db.clone());
+    repo.create_admin_with_setup("admin@shop.local", "Admin", "password123", "Test Shop")
+        .await
+        .unwrap();
+
+    let server = TestServer::new(app).unwrap();
+    let response = server
+        .post("/api/auth/forgot-password")
+        .json(&json!({ "email": "admin@shop.local" }))
+        .await;
+    assert_eq!(
+        response.status_code(),
+        http::StatusCode::OK,
+        "forgot-password must succeed when recovery_dir contains spaces"
+    );
+
+    let recovery_file = recovery_file_path_for_email(&recovery_dir, "admin@shop.local");
+    assert!(
+        recovery_file.exists(),
+        "recovery file must be created when recovery_dir contains spaces"
+    );
+}

--- a/services/api/tests/cli_reset_password.rs
+++ b/services/api/tests/cli_reset_password.rs
@@ -87,3 +87,32 @@ async fn reset_password_rejects_missing_database() {
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("Cannot open database"));
 }
+
+#[tokio::test]
+async fn reset_password_works_with_spaces_in_db_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().join("Application Support");
+    ensure_data_dirs(&data_dir).unwrap();
+    let db_path = data_dir.join("mokumo.db");
+    let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    let pool = mokumo_db::initialize_database(&database_url).await.unwrap();
+
+    let repo = mokumo_db::user::repo::SeaOrmUserRepo::new(pool.clone());
+    use mokumo_core::user::traits::UserRepository;
+    use mokumo_core::user::{CreateUser, RoleId};
+    repo.create(&CreateUser {
+        email: "admin@shop.local".into(),
+        name: "Admin".into(),
+        password: "old-password-123".into(),
+        role_id: RoleId::ADMIN,
+    })
+    .await
+    .unwrap();
+
+    let result = cli_reset_password(&db_path, "admin@shop.local", "new-password-456");
+    assert!(
+        result.is_ok(),
+        "CLI reset-password must succeed when db_path contains spaces: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Summary

Closes #134

Adds integration tests confirming all four acceptance criteria from the issue:

- **DB initialization** — `initialize_database()` succeeds when the path contains spaces (e.g. macOS `~/Library/Application Support/com.breezybayslabs.mokumo/`)
- **Migrations** — SeaORM migrations apply correctly with a space-containing DB path  
- **CLI reset-password** — `cli_reset_password()` succeeds when `db_path` contains spaces
- **File-drop recovery** — `forgot_password` handler creates the recovery HTML file when `recovery_dir` contains spaces

All four tests pass with SQLx 0.8.6: the `sqlite:` URL format and `tokio::fs` path APIs both handle spaces without percent-encoding. The code was already space-safe; these tests lock in that guarantee.

## Test plan

- [x] `initialize_database_works_with_spaces_in_path` — new in `crates/db/tests/startup_guards.rs`
- [x] `migrations_run_successfully_with_spaces_in_path` — new in `crates/db/tests/startup_guards.rs`
- [x] `reset_password_works_with_spaces_in_db_path` — new in `services/api/tests/cli_reset_password.rs`
- [x] `file_drop_recovery_works_with_spaces_in_recovery_dir` — new in `services/api/tests/auth_reset_regressions.rs`
- [x] All existing tests in the same files continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests validating system behavior with file paths containing special characters (spaces).
  * Expanded test coverage for database initialization, authentication workflows, and CLI operations across edge-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->