### PR TITLE
feat(web): add branded error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+- **Branded error page** shows the Mokumo logo, status code, and human-readable message for 400/401/403/404/5xx errors with navigation back to the dashboard.
+
 ### Changed
 
 - **Settings Shop page** LAN URL and IP address display now use the shared `CopyableUrl` component, removing duplicated inline copy logic. (#162)

--- a/apps/web/src/routes/+error.svelte
+++ b/apps/web/src/routes/+error.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { Button } from "$lib/components/ui/button";
+
+  const STATUS_MESSAGES: Record<
+    number,
+    { title: string; description: string }
+  > = {
+    400: {
+      title: "Bad request",
+      description:
+        "The request could not be understood. Please check the URL and try again.",
+    },
+    401: {
+      title: "Not authorized",
+      description: "You need to sign in to access this page.",
+    },
+    403: {
+      title: "Access denied",
+      description: "You do not have permission to view this page.",
+    },
+    404: {
+      title: "Page not found",
+      description:
+        "The page you are looking for does not exist or has been moved.",
+    },
+    500: {
+      title: "Something went wrong",
+      description:
+        "An unexpected error occurred. Please try again or return to the dashboard.",
+    },
+    502: {
+      title: "Server unavailable",
+      description:
+        "The server is temporarily unreachable. Please try again in a moment.",
+    },
+    503: {
+      title: "Service unavailable",
+      description:
+        "Mokumo is temporarily unavailable. Please try again shortly.",
+    },
+  };
+
+  let info = $derived(
+    STATUS_MESSAGES[page.status] ?? {
+      title: page.status >= 500 ? "Server error" : "Something went wrong",
+      description:
+        page.error?.message ||
+        "An unexpected error occurred. Please try again or return to the dashboard.",
+    },
+  );
+</script>
+
+<div class="flex min-h-screen items-center justify-center bg-background p-4">
+  <div class="w-full max-w-md space-y-8 text-center">
+    <div class="flex flex-col items-center gap-2">
+      <img
+        src="/mokumo-cloud.png"
+        alt="Mokumo"
+        class="h-16 dark:invert select-none"
+        draggable="false"
+        oncontextmenu={(e) => e.preventDefault()}
+      />
+      <span class="text-lg font-semibold tracking-tight">Mokumo Print</span>
+    </div>
+
+    <div class="space-y-3">
+      <p class="text-7xl font-bold tracking-tighter text-muted-foreground/25">
+        {page.status}
+      </p>
+      <h1 class="text-2xl font-bold text-foreground">
+        {info.title}
+      </h1>
+      <p class="text-sm text-muted-foreground leading-relaxed">
+        {info.description}
+      </p>
+    </div>
+
+    <div class="flex flex-col items-center gap-3 pt-2">
+      <Button href="/" size="lg" class="w-full max-w-xs">
+        Return to Dashboard
+      </Button>
+      <button
+        class="text-sm text-muted-foreground hover:text-foreground underline-offset-4 hover:underline transition-colors"
+        onclick={() => history.back()}
+      >
+        Go back
+      </button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Adds a branded `+error.svelte` page replacing SvelteKit's default error handling
- Shows Mokumo cloud logo, HTTP status code, human-readable title/description, and navigation (dashboard link + go back)
- Covers 400, 401, 403, 404, 500, 502, 503 with fallback for other codes

## Test plan
- [ ] Navigate to a non-existent route (e.g. `/nonexistent`) — should show 404 page with Mokumo branding
- [ ] Verify logo renders correctly in both light and dark mode (`dark:invert`)
- [ ] Verify "Return to Dashboard" links to `/`
- [ ] Verify "Go back" calls `history.back()`
- [ ] Check responsive layout at mobile viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced branded error pages for HTTP error responses (400, 401, 403, 404, and 5xx status codes), featuring the Mokumo logo, status code display, descriptive error messages, and navigation controls to return to the dashboard or go back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->