### PR TITLE
chore: group Dependabot updates into bundled PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "type:chore"
+    groups:
+      all-cargo:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
@@ -18,3 +22,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "type:chore"
+    groups:
+      all-npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `groups` config to both cargo and npm ecosystems in `dependabot.yml`
- All dependencies grouped with `"*"` pattern so each ecosystem produces one bundled PR per week instead of many individual ones

## Test plan
- [ ] Verify next Monday's Dependabot run produces grouped PRs
- [ ] Confirm existing open Dependabot PRs get superseded by grouped ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to enhance how updates are grouped and organized across different package ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->