### PR TITLE
test(bdd): fix valid_setup_token step — assert rather than overwrite

### DIFF
--- a/services/api/tests/bdd_world/auth_steps.rs
+++ b/services/api/tests/bdd_world/auth_steps.rs
@@ -12,11 +12,11 @@ async fn fresh_server(_w: &mut ApiWorld) {
 
 #[given("a valid setup token")]
 async fn valid_setup_token(w: &mut ApiWorld) {
-    // No-op: ApiWorld::new() populates setup_token from build_app_with_shutdown().
-    // This step verifies the precondition holds — it must not overwrite the real token.
+    // Verify that ApiWorld::new() populated the setup_token.
+    // This step ensures the precondition holds without overwriting the real token.
     assert!(
-        w.setup_token.is_some(),
-        "setup_token should be set by ApiWorld::new() via build_app_with_shutdown"
+        w.setup_token.as_ref().is_some_and(|t| !t.is_empty()),
+        "setup_token should be set and non-empty by ApiWorld::new()"
     );
 }
 

--- a/services/api/tests/bdd_world/auth_steps.rs
+++ b/services/api/tests/bdd_world/auth_steps.rs
@@ -12,20 +12,12 @@ async fn fresh_server(_w: &mut ApiWorld) {
 
 #[given("a valid setup token")]
 async fn valid_setup_token(w: &mut ApiWorld) {
-    // Read the setup token from the app by checking GET /api/auth/me
-    // The setup token is not directly exposed via API, so we need to
-    // obtain it from the server logs or bypass it.
-    // For BDD tests, we use direct DB setup via ensure_auth when needed,
-    // or we need to expose the token differently.
-    //
-    // WORKAROUND: We read the setup token from the server's startup logs.
-    // Since we can't do that easily, we'll use a different approach:
-    // We'll query the server's internal state or use a test endpoint.
-    //
-    // For now, we store a placeholder. The setup handler will be tested
-    // with the actual token by rebuilding with a known token.
-    // Actually: we bypass by doing setup via DB directly.
-    w.setup_token = Some("test-token-placeholder".into());
+    // No-op: ApiWorld::new() populates setup_token from build_app_with_shutdown().
+    // This step verifies the precondition holds — it must not overwrite the real token.
+    assert!(
+        w.setup_token.is_some(),
+        "setup_token should be set by ApiWorld::new() via build_app_with_shutdown"
+    );
 }
 
 #[when("the shop owner submits the setup wizard with shop name, admin credentials, and token")]


### PR DESCRIPTION
## Summary

- Fix `Given a valid setup token` BDD step that was overwriting `w.setup_token` with a hardcoded `"test-token-placeholder"`, corrupting the real UUID token already set by `ApiWorld::new()` via `build_app_with_shutdown()`
- Converted to a no-op assertion matching the existing `fresh_server` pattern — verifies the precondition holds without mutating world state
- Any scenario using this step before an HTTP `POST /api/setup` would previously fail with 401

Closes #341

## Test plan

- [ ] All 4 scenarios in `setup_wizard.feature` using `And a valid setup token` still pass
- [ ] The assertion fires if `ApiWorld::new()` ever stops populating `setup_token`
- [ ] CI quality gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test setup reliability by ensuring authentication tokens are validated at runtime and preserved if already initialized, preventing tests from overwriting real token values with placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->