### PR TITLE
fix(api): replace std RwLock with parking_lot to prevent poisoning crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Lock poisoning crash loop**: replaced `std::sync::RwLock` with `parking_lot::RwLock` in server state to prevent cascading panics if a write-side panic poisons the lock. (#374)
 - Enter key now submits the regenerate recovery codes dialog; previously required a mouse click on the Regenerate button. (#278)
 - `GET /api/setup-status` now returns `setup_mode: null` on a fresh install (when `setup_complete` is false) instead of always returning the current profile mode. (#348)
 - `GET /api/setup-status` no longer aliases `production_setup_complete` from the active profile's setup state; it now queries the production database directly so the field is accurate when the demo profile is active. (#290)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,6 +3821,7 @@ dependencies = [
  "mokumo-core",
  "mokumo-db",
  "mokumo-types",
+ "parking_lot",
  "password-auth",
  "rand 0.9.2",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ rand = "0.9"
 # Regex
 regex = "1"
 
+# Synchronization
+parking_lot = "0.12"
+
 # Concurrent data structures
 uuid = { version = "1", features = ["v4", "serde"] }
 dashmap = "6"

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -37,6 +37,7 @@ password-auth = { workspace = true }
 rpassword = { workspace = true }
 thiserror = { workspace = true }
 fd-lock = { workspace = true }
+parking_lot = { workspace = true }
 url = "2"
 
 [features]

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -70,7 +70,7 @@ async fn login(
     mut auth_session: AuthSessionType,
     Json(req): Json<LoginRequest>,
 ) -> Result<Json<UserResponse>, AppError> {
-    let repo = SeaOrmUserRepo::new(state.db_for(*state.active_profile.read().unwrap()).clone());
+    let repo = SeaOrmUserRepo::new(state.db_for(*state.active_profile.read()).clone());
     let creds = Credentials {
         email: req.email.clone(),
         password: req.password,
@@ -253,7 +253,7 @@ async fn setup(
     if let Err(e) = tokio::fs::write(&profile_path, "production").await {
         tracing::warn!("Failed to persist active_profile after setup: {e}");
     }
-    *state.active_profile.write().unwrap() = SetupMode::Production;
+    *state.active_profile.write() = SetupMode::Production;
 
     // Clear the first-launch flag so that GET /api/setup-status returns is_first_launch: false
     // for the lifetime of this server process. The profile_switch handler does the same on a
@@ -392,7 +392,7 @@ pub async fn require_auth_with_demo_auto_login(
     // Demo mode auto-login: create a session for the demo admin if not authenticated.
     // Uses find_by_email_with_hash to resolve user + hash in a single DB query
     // (avoids the 2-query path through auto_login → find_by_id_with_hash).
-    if *state.active_profile.read().unwrap() == SetupMode::Demo && auth_session.user.is_none() {
+    if *state.active_profile.read() == SetupMode::Demo && auth_session.user.is_none() {
         let repo = SeaOrmUserRepo::new(state.demo_db.clone());
         match repo.find_by_email_with_hash("admin@demo.local").await {
             Ok(Some((user, hash))) => {

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -17,7 +17,7 @@ pub async fn demo_reset(
     State(state): State<SharedState>,
 ) -> Result<Json<DemoResetResponse>, AppError> {
     // Must be demo mode
-    if *state.active_profile.read().unwrap() != SetupMode::Demo {
+    if *state.active_profile.read() != SetupMode::Demo {
         return Err(AppError::Forbidden(
             "Demo reset is only available in demo mode".into(),
         ));

--- a/services/api/src/discovery.rs
+++ b/services/api/src/discovery.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 #[derive(Debug, Clone)]
 pub struct MdnsStatus {
@@ -72,13 +74,13 @@ impl DiscoveryService for RealDiscovery {
 }
 
 pub struct RecordingDiscovery {
-    pub calls: std::sync::Mutex<Vec<(String, u16)>>,
+    pub calls: parking_lot::Mutex<Vec<(String, u16)>>,
 }
 
 impl Default for RecordingDiscovery {
     fn default() -> Self {
         Self {
-            calls: std::sync::Mutex::new(Vec::new()),
+            calls: parking_lot::Mutex::new(Vec::new()),
         }
     }
 }
@@ -89,16 +91,13 @@ impl RecordingDiscovery {
     }
 
     pub fn call_count(&self) -> usize {
-        self.calls.lock().unwrap().len()
+        self.calls.lock().len()
     }
 }
 
 impl DiscoveryService for RecordingDiscovery {
     fn register(&self, hostname: &str, port: u16) -> Result<MdnsHandle, String> {
-        self.calls
-            .lock()
-            .unwrap()
-            .push((hostname.to_string(), port));
+        self.calls.lock().push((hostname.to_string(), port));
         Ok(MdnsHandle {
             daemon: None,
             fullname: format!("{hostname}._http._tcp.local."),
@@ -144,7 +143,7 @@ pub fn register_mdns(
     match discovery.register(hostname, port) {
         Ok(handle) => {
             {
-                let mut s = status.write().expect("MdnsStatus lock poisoned");
+                let mut s = status.write();
                 s.active = true;
                 s.hostname = Some(format!("{hostname}.local"));
                 s.port = port;
@@ -180,7 +179,7 @@ pub fn spawn_collision_monitor(
                             change.new_name
                         );
                         let hostname = change.new_name.trim_end_matches('.').to_string();
-                        let mut s = status.write().expect("MdnsStatus lock poisoned");
+                        let mut s = status.write();
                         s.hostname = Some(hostname);
                     } else {
                         tracing::debug!(
@@ -211,7 +210,7 @@ pub fn deregister_mdns(handle: MdnsHandle, status: &SharedMdnsStatus) {
         }
     }
     {
-        let mut s = status.write().expect("MdnsStatus lock poisoned");
+        let mut s = status.write();
         s.active = false;
         s.hostname = None;
     }

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -75,10 +75,10 @@ pub struct AppState {
     /// The currently active profile. Controls the unauthenticated fallback in
     /// `ProfileDbMiddleware` and demo auto-login detection.
     ///
-    /// Wrapped in `RwLock` so the profile-switch handler (Session 2) can update
-    /// it in-process without a restart. Reads are always `read().unwrap()`;
-    /// writes happen only in the profile-switch handler after persisting to disk.
-    pub active_profile: std::sync::RwLock<SetupMode>,
+    /// Wrapped in `parking_lot::RwLock` (non-poisoning) so the profile-switch
+    /// handler (Session 2) can update it in-process without a restart.
+    /// Writes happen only in the profile-switch handler after persisting to disk.
+    pub active_profile: parking_lot::RwLock<SetupMode>,
     pub ws: Arc<ws::manager::ConnectionManager>,
     pub shutdown: CancellationToken,
     pub started_at: std::time::Instant,
@@ -118,7 +118,7 @@ impl AppState {
     /// returns `true` unconditionally in demo mode. Production reads the
     /// `setup_completed` flag set when the wizard finishes.
     pub fn is_setup_complete(&self) -> bool {
-        match *self.active_profile.read().unwrap() {
+        match *self.active_profile.read() {
             SetupMode::Demo => true,
             SetupMode::Production => self
                 .setup_completed
@@ -728,7 +728,7 @@ fn build_app_inner(
     let state: SharedState = Arc::new(AppState {
         demo_db,
         production_db,
-        active_profile: std::sync::RwLock::new(active_profile),
+        active_profile: parking_lot::RwLock::new(active_profile),
         ws: Arc::new(ws::manager::ConnectionManager::new(64)),
         shutdown,
         started_at: std::time::Instant::now(),
@@ -1018,7 +1018,7 @@ async fn health(
 async fn setup_status(
     State(state): State<SharedState>,
 ) -> Result<Json<mokumo_types::setup::SetupStatusResponse>, crate::error::AppError> {
-    let active = *state.active_profile.read().unwrap();
+    let active = *state.active_profile.read();
     let setup_complete = state.is_setup_complete();
     let is_first_launch = state
         .is_first_launch

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -501,7 +501,7 @@ async fn main() {
         }
 
         {
-            let mut s = mdns_status.write().expect("MdnsStatus lock poisoned");
+            let mut s = mdns_status.write();
             s.port = actual_port;
             s.bind_host = config.host.clone();
         }

--- a/services/api/src/profile_db.rs
+++ b/services/api/src/profile_db.rs
@@ -71,7 +71,7 @@ pub async fn profile_db_middleware(
         let ProfileUserId(mode, _) = user.id();
         state.db_for(mode).clone()
     } else {
-        state.db_for(*state.active_profile.read().unwrap()).clone()
+        state.db_for(*state.active_profile.read()).clone()
     };
 
     request.extensions_mut().insert(ProfileDb(db));

--- a/services/api/src/profile_switch.rs
+++ b/services/api/src/profile_switch.rs
@@ -58,7 +58,7 @@ pub async fn profile_switch(
     }
 
     // Step 3: Origin validation — CSRF guard.
-    let port = state.mdns_status.read().unwrap().port;
+    let port = state.mdns_status.read().port;
     let origin = headers
         .get(axum::http::header::ORIGIN)
         .and_then(|v| v.to_str().ok())
@@ -151,7 +151,7 @@ pub async fn profile_switch(
     // Step 7: Update in-memory active_profile. Capture previous value for rollback if the session
     // operations below fail.
     let previous_profile = {
-        let mut guard = state.active_profile.write().unwrap();
+        let mut guard = state.active_profile.write();
         let prev = *guard;
         *guard = target;
         prev
@@ -168,7 +168,7 @@ pub async fn profile_switch(
             target = ?target,
             "Profile switch: logout failed — rolling back active_profile: {e}"
         );
-        *state.active_profile.write().unwrap() = previous_profile;
+        *state.active_profile.write() = previous_profile;
         let path = profile_path.clone();
         tokio::spawn(async move {
             let _ = tokio::fs::write(&path, previous_profile.as_str()).await;
@@ -183,7 +183,7 @@ pub async fn profile_switch(
             target = ?target,
             "Profile switch: login failed — rolling back active_profile: {e}"
         );
-        *state.active_profile.write().unwrap() = previous_profile;
+        *state.active_profile.write() = previous_profile;
         let path = profile_path.clone();
         tokio::spawn(async move {
             let _ = tokio::fs::write(&path, previous_profile.as_str()).await;

--- a/services/api/src/server_info.rs
+++ b/services/api/src/server_info.rs
@@ -13,7 +13,7 @@ fn format_host(ip: &IpAddr) -> String {
 }
 
 pub async fn handler(State(state): State<SharedState>) -> Json<ServerInfoResponse> {
-    let status = state.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = state.mdns_status.read();
     let on_loopback = crate::discovery::is_loopback(&status.bind_host);
 
     let lan_url = if status.active {

--- a/services/api/tests/bdd_world/discovery_steps.rs
+++ b/services/api/tests/bdd_world/discovery_steps.rs
@@ -9,11 +9,11 @@ use mokumo_types::ServerInfoResponse;
 async fn server_started_with(w: &mut ApiWorld, flag: String) {
     if flag == "--host 0.0.0.0" {
         w.mdns_host = "0.0.0.0".into();
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+        let mut s = w.mdns_status.write();
         s.bind_host = "0.0.0.0".into();
     } else if flag == "--host 127.0.0.1" {
         w.mdns_host = "127.0.0.1".into();
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+        let mut s = w.mdns_status.write();
         s.bind_host = "127.0.0.1".into();
     }
 }
@@ -38,7 +38,7 @@ async fn port_in_use(_w: &mut ApiWorld, _port: u16) {
 
 #[given("mDNS is registered")]
 async fn mdns_is_registered(w: &mut ApiWorld) {
-    let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    let mut s = w.mdns_status.write();
     s.active = true;
     s.hostname = Some("mokumo.local".into());
     s.port = w.server.server_address().unwrap().port().unwrap();
@@ -52,7 +52,7 @@ async fn server_starts(w: &mut ApiWorld) {
 
     // Always record the bound port (mirrors production: set before register_mdns)
     {
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+        let mut s = w.mdns_status.write();
         s.port = port;
     }
 
@@ -75,7 +75,7 @@ async fn server_starts(w: &mut ApiWorld) {
 
 #[then(expr = "mDNS is registered as {string} on the actual bound port")]
 async fn mdns_registered_as(w: &mut ApiWorld, expected_hostname: String) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(status.active, "Expected mDNS to be active");
     assert_eq!(
         status.hostname.as_deref(),
@@ -99,7 +99,7 @@ async fn service_type_is(_w: &mut ApiWorld, _expected: String) {
 
 #[then("mDNS is not registered")]
 async fn mdns_not_registered(w: &mut ApiWorld) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(!status.active, "Expected mDNS to be inactive");
 }
 
@@ -122,7 +122,7 @@ async fn server_is_running(w: &mut ApiWorld) {
 
 #[then("mDNS is registered on the actual bound port")]
 async fn mdns_registered_on_actual_port(w: &mut ApiWorld) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(status.active, "Expected mDNS to be active");
     let actual_port = w.server.server_address().unwrap().port().unwrap();
     assert_ne!(actual_port, 0, "Bound port should not be 0");
@@ -135,7 +135,7 @@ async fn mdns_registered_on_actual_port(w: &mut ApiWorld) {
 #[then("the mDNS service is deregistered")]
 async fn mdns_deregistered(w: &mut ApiWorld) {
     // After shutdown, verify mDNS status reflects deregistration
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(
         !status.active,
         "Expected mDNS to be inactive after shutdown"
@@ -147,7 +147,7 @@ async fn mdns_deregistered(w: &mut ApiWorld) {
 #[given(expr = "mDNS is registered as {string}")]
 async fn mdns_registered_as_hostname(w: &mut ApiWorld, hostname: String) {
     let port = w.server.server_address().unwrap().port().unwrap();
-    let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    let mut s = w.mdns_status.write();
     s.active = true;
     s.hostname = Some(hostname);
     s.port = port;
@@ -173,7 +173,7 @@ async fn another_device_registers_hostname(w: &mut ApiWorld) {
     // Simulate host-type collision by directly updating MdnsStatus hostname.
     // Per RFC 6762 + mdns-sd convention, host renames use "-N" suffix (e.g. mokumo-2.local),
     // NOT "(N)" which is the service-instance rename format.
-    let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    let mut s = w.mdns_status.write();
     s.hostname = Some("mokumo-2.local".into());
 }
 
@@ -250,7 +250,7 @@ async fn response_shows_mdns_not_active(w: &mut ApiWorld) {
 
 #[then(expr = "the registered hostname is no longer {string}")]
 async fn hostname_changed(w: &mut ApiWorld, original: String) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     let current = status.hostname.as_deref().unwrap_or("");
     assert_ne!(
         current, original,

--- a/services/api/tests/bdd_world/mod.rs
+++ b/services/api/tests/bdd_world/mod.rs
@@ -385,8 +385,8 @@ async fn broadcast_completes_without_error(w: &mut ApiWorld) {
 #[when("the server begins shutting down")]
 async fn server_begins_shutdown(w: &mut ApiWorld) {
     // Deregister mDNS before cancelling token (mirrors production shutdown handler)
-    if w.mdns_status.read().expect("lock").active {
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    if w.mdns_status.read().active {
+        let mut s = w.mdns_status.write();
         s.active = false;
     }
     w.shutdown_token.cancel();


### PR DESCRIPTION
## Summary

- Replace `std::sync::RwLock` with `parking_lot::RwLock` for `AppState.active_profile` and `SharedMdnsStatus` to eliminate lock poisoning crash loops
- Replace `std::sync::Mutex` with `parking_lot::Mutex` in `RecordingDiscovery` test double for consistency
- Remove all `.unwrap()` / `.expect()` calls on lock acquisitions (16 production + 13 test sites) — `parking_lot` returns guards directly, never `Result`

Closes #374

## Test plan

- [ ] `moon run api:test` — all existing tests pass unchanged (lock API is compatible)
- [ ] `moon run api:lint` — no new clippy warnings
- [ ] Verify `parking_lot` appears in `Cargo.lock` as a direct dependency
- [ ] Review: no remaining `std::sync::RwLock` or `std::sync::Mutex` in `services/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server state lock reliability by eliminating potential cascading panics caused by lock poisoning scenarios. The system now gracefully handles concurrent access failures without triggering fatal crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->