### PR TITLE
feat(api): add HTTP security headers middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **HTTP security headers**: every response now includes `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 0`, and `Referrer-Policy: strict-origin-when-cross-origin`. `Strict-Transport-Security` is set conditionally when behind Cloudflare Tunnel. (#380)
 - **Branded error page** shows the Mokumo logo, status code, and human-readable message for 400/401/403/404/5xx errors with navigation back to the dashboard.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Lock poisoning crash loop**: replaced `std::sync::RwLock` with `parking_lot::RwLock` in server state to prevent cascading panics if a write-side panic poisons the lock. (#374)
 - Enter key now submits the regenerate recovery codes dialog; previously required a mouse click on the Regenerate button. (#278)
 - `GET /api/setup-status` now returns `setup_mode: null` on a fresh install (when `setup_complete` is false) instead of always returning the current profile mode. (#348)
 - `GET /api/setup-status` no longer aliases `production_setup_complete` from the active profile's setup state; it now queries the production database directly so the field is accurate when the demo profile is active. (#290)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,6 +3821,7 @@ dependencies = [
  "mokumo-core",
  "mokumo-db",
  "mokumo-types",
+ "parking_lot",
  "password-auth",
  "rand 0.9.2",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ rand = "0.9"
 # Regex
 regex = "1"
 
+# Synchronization
+parking_lot = "0.12"
+
 # Concurrent data structures
 uuid = { version = "1", features = ["v4", "serde"] }
 dashmap = "6"

--- a/docs/adr/adr-security-headers.md
+++ b/docs/adr/adr-security-headers.md
@@ -35,6 +35,7 @@ script-src 'self' 'unsafe-inline';
 style-src 'self' 'unsafe-inline';
 img-src 'self' data:;
 connect-src 'self' ws: wss:;
+object-src 'none';
 frame-ancestors 'none'
 ```
 

--- a/docs/adr/adr-security-headers.md
+++ b/docs/adr/adr-security-headers.md
@@ -1,0 +1,83 @@
+# ADR: HTTP Security Headers
+
+**Status**: Accepted
+**Date**: 2026-04-09
+**Issue**: #380
+
+## Context
+
+Mokumo serves a SvelteKit SPA from an Axum backend. The Cloudflare Tunnel
+feature (M4) makes the server internet-facing. Without security headers, XSS
+vulnerabilities allow full database access, and the app can be clickjacked via
+iframes.
+
+## Decision
+
+Add a Tower middleware (`axum::middleware::from_fn`) that sets security headers
+on every HTTP response. The middleware is the outermost layer so it covers all
+routes including SPA fallback, auth errors, and health checks.
+
+### Headers (always set)
+
+| Header | Value | Rationale |
+|--------|-------|-----------|
+| `Content-Security-Policy` | See below | Primary XSS defense |
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME sniffing |
+| `X-Frame-Options` | `DENY` | Clickjacking protection (legacy browsers) |
+| `X-XSS-Protection` | `0` | Disable legacy XSS filter (causes more harm than good; rely on CSP) |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limit referrer leakage |
+
+### Content-Security-Policy
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline';
+style-src 'self' 'unsafe-inline';
+img-src 'self' data:;
+connect-src 'self' ws: wss:;
+frame-ancestors 'none'
+```
+
+**Why `script-src 'unsafe-inline'`**: SvelteKit adapter-static emits an inline
+bootstrap `<script>` in `index.html` that initializes the SPA. Without
+`'unsafe-inline'`, the app will not load. Nonce-based CSP is not feasible
+because the HTML is served from rust-embed (static bytes) with no per-request
+rewriting.
+
+**Why `style-src 'unsafe-inline'`**: SvelteKit inlines scoped component styles
+and the root `<div style="display: contents">`. This is a known SvelteKit
+limitation (sveltejs/kit#11747).
+
+**Tightening roadmap**: When SvelteKit moves to external stylesheets or the Web
+Animations API, `'unsafe-inline'` can be removed. For `script-src`, a future
+enhancement could compute the SHA-256 hash of the inline bootstrap script at
+server startup and include it in the CSP header, allowing removal of
+`'unsafe-inline'` for scripts.
+
+### Conditional HSTS
+
+`Strict-Transport-Security: max-age=63072000; includeSubDomains` is set **only**
+when the request arrives through Cloudflare Tunnel, detected by the presence of
+the `cf-connecting-ip` header. LAN-only HTTP deployments would break with
+unconditional HSTS.
+
+No `preload` directive: self-hosted domains vary per shop and should never join
+the browser HSTS preload list.
+
+## Alternatives Considered
+
+1. **`tower-http::SetResponseHeaderLayer`** — one layer per header, verbose for
+   6+ headers. No request access for conditional HSTS.
+2. **`axum-helmet` crate** — helmet.js port. Adds a dependency for what is 30
+   lines of code. Preset CSP doesn't match SvelteKit needs.
+3. **CSP via `<meta>` tag in HTML** — cannot set `frame-ancestors` via meta tag
+   (spec limitation). Also doesn't cover non-HTML responses.
+
+## Consequences
+
+- Every response from the Axum server includes defensive security headers.
+- CSP with `'unsafe-inline'` is not ideal but is the pragmatic starting point
+  given SvelteKit's current constraints.
+- HSTS is safe for Tunnel users and does not affect LAN-only deployments.
+- Future work: OWASP recommends additional headers (Permissions-Policy, COOP,
+  CORP, COEP) which can be added incrementally.

--- a/docs/adr/adr-security-headers.md
+++ b/docs/adr/adr-security-headers.md
@@ -29,12 +29,12 @@ routes including SPA fallback, auth errors, and health checks.
 
 ### Content-Security-Policy
 
-```
+```text
 default-src 'self';
 script-src 'self' 'unsafe-inline';
 style-src 'self' 'unsafe-inline';
 img-src 'self' data:;
-connect-src 'self' ws: wss:;
+connect-src 'self';
 object-src 'none';
 frame-ancestors 'none'
 ```

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -37,6 +37,7 @@ password-auth = { workspace = true }
 rpassword = { workspace = true }
 thiserror = { workspace = true }
 fd-lock = { workspace = true }
+parking_lot = { workspace = true }
 url = "2"
 
 [features]

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -70,7 +70,7 @@ async fn login(
     mut auth_session: AuthSessionType,
     Json(req): Json<LoginRequest>,
 ) -> Result<Json<UserResponse>, AppError> {
-    let repo = SeaOrmUserRepo::new(state.db_for(*state.active_profile.read().unwrap()).clone());
+    let repo = SeaOrmUserRepo::new(state.db_for(*state.active_profile.read()).clone());
     let creds = Credentials {
         email: req.email.clone(),
         password: req.password,
@@ -253,7 +253,7 @@ async fn setup(
     if let Err(e) = tokio::fs::write(&profile_path, "production").await {
         tracing::warn!("Failed to persist active_profile after setup: {e}");
     }
-    *state.active_profile.write().unwrap() = SetupMode::Production;
+    *state.active_profile.write() = SetupMode::Production;
 
     // Clear the first-launch flag so that GET /api/setup-status returns is_first_launch: false
     // for the lifetime of this server process. The profile_switch handler does the same on a
@@ -392,7 +392,7 @@ pub async fn require_auth_with_demo_auto_login(
     // Demo mode auto-login: create a session for the demo admin if not authenticated.
     // Uses find_by_email_with_hash to resolve user + hash in a single DB query
     // (avoids the 2-query path through auto_login → find_by_id_with_hash).
-    if *state.active_profile.read().unwrap() == SetupMode::Demo && auth_session.user.is_none() {
+    if *state.active_profile.read() == SetupMode::Demo && auth_session.user.is_none() {
         let repo = SeaOrmUserRepo::new(state.demo_db.clone());
         match repo.find_by_email_with_hash("admin@demo.local").await {
             Ok(Some((user, hash))) => {

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -17,7 +17,7 @@ pub async fn demo_reset(
     State(state): State<SharedState>,
 ) -> Result<Json<DemoResetResponse>, AppError> {
     // Must be demo mode
-    if *state.active_profile.read().unwrap() != SetupMode::Demo {
+    if *state.active_profile.read() != SetupMode::Demo {
         return Err(AppError::Forbidden(
             "Demo reset is only available in demo mode".into(),
         ));

--- a/services/api/src/discovery.rs
+++ b/services/api/src/discovery.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 #[derive(Debug, Clone)]
 pub struct MdnsStatus {
@@ -72,13 +74,13 @@ impl DiscoveryService for RealDiscovery {
 }
 
 pub struct RecordingDiscovery {
-    pub calls: std::sync::Mutex<Vec<(String, u16)>>,
+    pub calls: parking_lot::Mutex<Vec<(String, u16)>>,
 }
 
 impl Default for RecordingDiscovery {
     fn default() -> Self {
         Self {
-            calls: std::sync::Mutex::new(Vec::new()),
+            calls: parking_lot::Mutex::new(Vec::new()),
         }
     }
 }
@@ -89,16 +91,13 @@ impl RecordingDiscovery {
     }
 
     pub fn call_count(&self) -> usize {
-        self.calls.lock().unwrap().len()
+        self.calls.lock().len()
     }
 }
 
 impl DiscoveryService for RecordingDiscovery {
     fn register(&self, hostname: &str, port: u16) -> Result<MdnsHandle, String> {
-        self.calls
-            .lock()
-            .unwrap()
-            .push((hostname.to_string(), port));
+        self.calls.lock().push((hostname.to_string(), port));
         Ok(MdnsHandle {
             daemon: None,
             fullname: format!("{hostname}._http._tcp.local."),
@@ -144,7 +143,7 @@ pub fn register_mdns(
     match discovery.register(hostname, port) {
         Ok(handle) => {
             {
-                let mut s = status.write().expect("MdnsStatus lock poisoned");
+                let mut s = status.write();
                 s.active = true;
                 s.hostname = Some(format!("{hostname}.local"));
                 s.port = port;
@@ -180,7 +179,7 @@ pub fn spawn_collision_monitor(
                             change.new_name
                         );
                         let hostname = change.new_name.trim_end_matches('.').to_string();
-                        let mut s = status.write().expect("MdnsStatus lock poisoned");
+                        let mut s = status.write();
                         s.hostname = Some(hostname);
                     } else {
                         tracing::debug!(
@@ -211,7 +210,7 @@ pub fn deregister_mdns(handle: MdnsHandle, status: &SharedMdnsStatus) {
         }
     }
     {
-        let mut s = status.write().expect("MdnsStatus lock poisoned");
+        let mut s = status.write();
         s.active = false;
         s.hostname = None;
     }

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod pagination;
 pub mod profile_db;
 pub mod profile_switch;
 pub mod rate_limit;
+pub mod security_headers;
 pub mod server_info;
 pub mod ws;
 
@@ -820,6 +821,7 @@ fn build_app_inner(
         ))
         .layer(auth_layer)
         .layer(TraceLayer::new_for_http())
+        .layer(axum::middleware::from_fn(security_headers::middleware))
         .with_state(state)
 }
 

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -75,10 +75,10 @@ pub struct AppState {
     /// The currently active profile. Controls the unauthenticated fallback in
     /// `ProfileDbMiddleware` and demo auto-login detection.
     ///
-    /// Wrapped in `RwLock` so the profile-switch handler (Session 2) can update
-    /// it in-process without a restart. Reads are always `read().unwrap()`;
-    /// writes happen only in the profile-switch handler after persisting to disk.
-    pub active_profile: std::sync::RwLock<SetupMode>,
+    /// Wrapped in `parking_lot::RwLock` (non-poisoning) so the profile-switch
+    /// handler (Session 2) can update it in-process without a restart.
+    /// Writes happen only in the profile-switch handler after persisting to disk.
+    pub active_profile: parking_lot::RwLock<SetupMode>,
     pub ws: Arc<ws::manager::ConnectionManager>,
     pub shutdown: CancellationToken,
     pub started_at: std::time::Instant,
@@ -118,7 +118,7 @@ impl AppState {
     /// returns `true` unconditionally in demo mode. Production reads the
     /// `setup_completed` flag set when the wizard finishes.
     pub fn is_setup_complete(&self) -> bool {
-        match *self.active_profile.read().unwrap() {
+        match *self.active_profile.read() {
             SetupMode::Demo => true,
             SetupMode::Production => self
                 .setup_completed
@@ -728,7 +728,7 @@ fn build_app_inner(
     let state: SharedState = Arc::new(AppState {
         demo_db,
         production_db,
-        active_profile: std::sync::RwLock::new(active_profile),
+        active_profile: parking_lot::RwLock::new(active_profile),
         ws: Arc::new(ws::manager::ConnectionManager::new(64)),
         shutdown,
         started_at: std::time::Instant::now(),
@@ -1018,7 +1018,7 @@ async fn health(
 async fn setup_status(
     State(state): State<SharedState>,
 ) -> Result<Json<mokumo_types::setup::SetupStatusResponse>, crate::error::AppError> {
-    let active = *state.active_profile.read().unwrap();
+    let active = *state.active_profile.read();
     let setup_complete = state.is_setup_complete();
     let is_first_launch = state
         .is_first_launch

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -501,7 +501,7 @@ async fn main() {
         }
 
         {
-            let mut s = mdns_status.write().expect("MdnsStatus lock poisoned");
+            let mut s = mdns_status.write();
             s.port = actual_port;
             s.bind_host = config.host.clone();
         }

--- a/services/api/src/profile_db.rs
+++ b/services/api/src/profile_db.rs
@@ -71,7 +71,7 @@ pub async fn profile_db_middleware(
         let ProfileUserId(mode, _) = user.id();
         state.db_for(mode).clone()
     } else {
-        state.db_for(*state.active_profile.read().unwrap()).clone()
+        state.db_for(*state.active_profile.read()).clone()
     };
 
     request.extensions_mut().insert(ProfileDb(db));

--- a/services/api/src/profile_switch.rs
+++ b/services/api/src/profile_switch.rs
@@ -58,7 +58,7 @@ pub async fn profile_switch(
     }
 
     // Step 3: Origin validation — CSRF guard.
-    let port = state.mdns_status.read().unwrap().port;
+    let port = state.mdns_status.read().port;
     let origin = headers
         .get(axum::http::header::ORIGIN)
         .and_then(|v| v.to_str().ok())
@@ -151,7 +151,7 @@ pub async fn profile_switch(
     // Step 7: Update in-memory active_profile. Capture previous value for rollback if the session
     // operations below fail.
     let previous_profile = {
-        let mut guard = state.active_profile.write().unwrap();
+        let mut guard = state.active_profile.write();
         let prev = *guard;
         *guard = target;
         prev
@@ -168,7 +168,7 @@ pub async fn profile_switch(
             target = ?target,
             "Profile switch: logout failed — rolling back active_profile: {e}"
         );
-        *state.active_profile.write().unwrap() = previous_profile;
+        *state.active_profile.write() = previous_profile;
         let path = profile_path.clone();
         tokio::spawn(async move {
             let _ = tokio::fs::write(&path, previous_profile.as_str()).await;
@@ -183,7 +183,7 @@ pub async fn profile_switch(
             target = ?target,
             "Profile switch: login failed — rolling back active_profile: {e}"
         );
-        *state.active_profile.write().unwrap() = previous_profile;
+        *state.active_profile.write() = previous_profile;
         let path = profile_path.clone();
         tokio::spawn(async move {
             let _ = tokio::fs::write(&path, previous_profile.as_str()).await;

--- a/services/api/src/security_headers.rs
+++ b/services/api/src/security_headers.rs
@@ -4,7 +4,12 @@
 //! X-Content-Type-Options, Referrer-Policy, and X-XSS-Protection.
 //! Conditionally adds HSTS when the request arrives through Cloudflare Tunnel.
 
-use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Response};
+use axum::{
+    extract::Request,
+    http::{HeaderValue, header},
+    middleware::Next,
+    response::Response,
+};
 
 /// Content-Security-Policy for the SvelteKit SPA.
 ///
@@ -14,7 +19,7 @@ use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Resp
 /// See ADR `adr-security-headers.md` for rationale and tightening roadmap.
 const CSP: &str = "default-src 'self'; script-src 'self' 'unsafe-inline'; \
 style-src 'self' 'unsafe-inline'; img-src 'self' data:; \
-connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'";
+connect-src 'self'; object-src 'none'; frame-ancestors 'none'";
 
 /// HSTS value: 2 years, include subdomains, no preload (self-hosted domains vary).
 const HSTS: &str = "max-age=63072000; includeSubDomains";
@@ -29,21 +34,26 @@ pub async fn middleware(request: Request, next: Next) -> Response {
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
 
-    // SAFETY: all header values are ASCII constants validated at compile time.
-    headers.insert("content-security-policy", HeaderValue::from_static(CSP));
     headers.insert(
-        "x-content-type-options",
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(CSP),
+    );
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
         HeaderValue::from_static("nosniff"),
     );
-    headers.insert("x-frame-options", HeaderValue::from_static("DENY"));
-    headers.insert("x-xss-protection", HeaderValue::from_static("0"));
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    headers.insert(header::X_XSS_PROTECTION, HeaderValue::from_static("0"));
     headers.insert(
-        "referrer-policy",
+        header::REFERRER_POLICY,
         HeaderValue::from_static("strict-origin-when-cross-origin"),
     );
 
     if is_tunnel {
-        headers.insert("strict-transport-security", HeaderValue::from_static(HSTS));
+        headers.insert(
+            header::STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static(HSTS),
+        );
     }
 
     response

--- a/services/api/src/security_headers.rs
+++ b/services/api/src/security_headers.rs
@@ -14,7 +14,7 @@ use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Resp
 /// See ADR `adr-security-headers.md` for rationale and tightening roadmap.
 const CSP: &str = "default-src 'self'; script-src 'self' 'unsafe-inline'; \
 style-src 'self' 'unsafe-inline'; img-src 'self' data:; \
-connect-src 'self' ws: wss:; frame-ancestors 'none'";
+connect-src 'self' ws: wss:; object-src 'none'; frame-ancestors 'none'";
 
 /// HSTS value: 2 years, include subdomains, no preload (self-hosted domains vary).
 const HSTS: &str = "max-age=63072000; includeSubDomains";

--- a/services/api/src/security_headers.rs
+++ b/services/api/src/security_headers.rs
@@ -1,0 +1,133 @@
+//! HTTP security headers middleware.
+//!
+//! Sets defensive headers on every response: CSP, X-Frame-Options,
+//! X-Content-Type-Options, Referrer-Policy, and X-XSS-Protection.
+//! Conditionally adds HSTS when the request arrives through Cloudflare Tunnel.
+
+use axum::{extract::Request, http::HeaderValue, middleware::Next, response::Response};
+
+/// Content-Security-Policy for the SvelteKit SPA.
+///
+/// `script-src 'unsafe-inline'` is required because SvelteKit adapter-static
+/// emits an inline bootstrap `<script>` in index.html. `style-src 'unsafe-inline'`
+/// is required because SvelteKit inlines scoped component styles.
+/// See ADR `adr-security-headers.md` for rationale and tightening roadmap.
+const CSP: &str = "default-src 'self'; script-src 'self' 'unsafe-inline'; \
+style-src 'self' 'unsafe-inline'; img-src 'self' data:; \
+connect-src 'self' ws: wss:; frame-ancestors 'none'";
+
+/// HSTS value: 2 years, include subdomains, no preload (self-hosted domains vary).
+const HSTS: &str = "max-age=63072000; includeSubDomains";
+
+/// Middleware that sets security headers on every response.
+///
+/// HSTS is only set when the request passes through Cloudflare Tunnel,
+/// detected by the presence of the `cf-connecting-ip` header.
+pub async fn middleware(request: Request, next: Next) -> Response {
+    let is_tunnel = request.headers().contains_key("cf-connecting-ip");
+
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+
+    // SAFETY: all header values are ASCII constants validated at compile time.
+    headers.insert("content-security-policy", HeaderValue::from_static(CSP));
+    headers.insert(
+        "x-content-type-options",
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert("x-frame-options", HeaderValue::from_static("DENY"));
+    headers.insert("x-xss-protection", HeaderValue::from_static("0"));
+    headers.insert(
+        "referrer-policy",
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+
+    if is_tunnel {
+        headers.insert("strict-transport-security", HeaderValue::from_static(HSTS));
+    }
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Body, http::StatusCode, routing::get};
+    use tower::ServiceExt;
+
+    fn test_app() -> Router {
+        Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(middleware))
+    }
+
+    #[tokio::test]
+    async fn sets_static_security_headers() {
+        let app = test_app();
+        let response = app
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let h = response.headers();
+        assert_eq!(h.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(h.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(h.get("x-xss-protection").unwrap(), "0");
+        assert_eq!(
+            h.get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+        assert!(
+            h.get("content-security-policy")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("default-src 'self'")
+        );
+        assert!(
+            h.get("content-security-policy")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("frame-ancestors 'none'")
+        );
+    }
+
+    #[tokio::test]
+    async fn no_hsts_without_tunnel() {
+        let app = test_app();
+        let response = app
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert!(
+            response
+                .headers()
+                .get("strict-transport-security")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn sets_hsts_with_cloudflare_tunnel() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("cf-connecting-ip", "1.2.3.4")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get("strict-transport-security").unwrap(),
+            "max-age=63072000; includeSubDomains"
+        );
+    }
+}

--- a/services/api/src/server_info.rs
+++ b/services/api/src/server_info.rs
@@ -13,7 +13,7 @@ fn format_host(ip: &IpAddr) -> String {
 }
 
 pub async fn handler(State(state): State<SharedState>) -> Json<ServerInfoResponse> {
-    let status = state.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = state.mdns_status.read();
     let on_loopback = crate::discovery::is_loopback(&status.bind_host);
 
     let lan_url = if status.active {

--- a/services/api/tests/bdd_world/discovery_steps.rs
+++ b/services/api/tests/bdd_world/discovery_steps.rs
@@ -9,11 +9,11 @@ use mokumo_types::ServerInfoResponse;
 async fn server_started_with(w: &mut ApiWorld, flag: String) {
     if flag == "--host 0.0.0.0" {
         w.mdns_host = "0.0.0.0".into();
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+        let mut s = w.mdns_status.write();
         s.bind_host = "0.0.0.0".into();
     } else if flag == "--host 127.0.0.1" {
         w.mdns_host = "127.0.0.1".into();
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+        let mut s = w.mdns_status.write();
         s.bind_host = "127.0.0.1".into();
     }
 }
@@ -38,7 +38,7 @@ async fn port_in_use(_w: &mut ApiWorld, _port: u16) {
 
 #[given("mDNS is registered")]
 async fn mdns_is_registered(w: &mut ApiWorld) {
-    let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    let mut s = w.mdns_status.write();
     s.active = true;
     s.hostname = Some("mokumo.local".into());
     s.port = w.server.server_address().unwrap().port().unwrap();
@@ -52,7 +52,7 @@ async fn server_starts(w: &mut ApiWorld) {
 
     // Always record the bound port (mirrors production: set before register_mdns)
     {
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+        let mut s = w.mdns_status.write();
         s.port = port;
     }
 
@@ -75,7 +75,7 @@ async fn server_starts(w: &mut ApiWorld) {
 
 #[then(expr = "mDNS is registered as {string} on the actual bound port")]
 async fn mdns_registered_as(w: &mut ApiWorld, expected_hostname: String) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(status.active, "Expected mDNS to be active");
     assert_eq!(
         status.hostname.as_deref(),
@@ -99,7 +99,7 @@ async fn service_type_is(_w: &mut ApiWorld, _expected: String) {
 
 #[then("mDNS is not registered")]
 async fn mdns_not_registered(w: &mut ApiWorld) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(!status.active, "Expected mDNS to be inactive");
 }
 
@@ -122,7 +122,7 @@ async fn server_is_running(w: &mut ApiWorld) {
 
 #[then("mDNS is registered on the actual bound port")]
 async fn mdns_registered_on_actual_port(w: &mut ApiWorld) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(status.active, "Expected mDNS to be active");
     let actual_port = w.server.server_address().unwrap().port().unwrap();
     assert_ne!(actual_port, 0, "Bound port should not be 0");
@@ -135,7 +135,7 @@ async fn mdns_registered_on_actual_port(w: &mut ApiWorld) {
 #[then("the mDNS service is deregistered")]
 async fn mdns_deregistered(w: &mut ApiWorld) {
     // After shutdown, verify mDNS status reflects deregistration
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     assert!(
         !status.active,
         "Expected mDNS to be inactive after shutdown"
@@ -147,7 +147,7 @@ async fn mdns_deregistered(w: &mut ApiWorld) {
 #[given(expr = "mDNS is registered as {string}")]
 async fn mdns_registered_as_hostname(w: &mut ApiWorld, hostname: String) {
     let port = w.server.server_address().unwrap().port().unwrap();
-    let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    let mut s = w.mdns_status.write();
     s.active = true;
     s.hostname = Some(hostname);
     s.port = port;
@@ -173,7 +173,7 @@ async fn another_device_registers_hostname(w: &mut ApiWorld) {
     // Simulate host-type collision by directly updating MdnsStatus hostname.
     // Per RFC 6762 + mdns-sd convention, host renames use "-N" suffix (e.g. mokumo-2.local),
     // NOT "(N)" which is the service-instance rename format.
-    let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    let mut s = w.mdns_status.write();
     s.hostname = Some("mokumo-2.local".into());
 }
 
@@ -250,7 +250,7 @@ async fn response_shows_mdns_not_active(w: &mut ApiWorld) {
 
 #[then(expr = "the registered hostname is no longer {string}")]
 async fn hostname_changed(w: &mut ApiWorld, original: String) {
-    let status = w.mdns_status.read().expect("MdnsStatus lock poisoned");
+    let status = w.mdns_status.read();
     let current = status.hostname.as_deref().unwrap_or("");
     assert_ne!(
         current, original,

--- a/services/api/tests/bdd_world/mod.rs
+++ b/services/api/tests/bdd_world/mod.rs
@@ -385,8 +385,8 @@ async fn broadcast_completes_without_error(w: &mut ApiWorld) {
 #[when("the server begins shutting down")]
 async fn server_begins_shutdown(w: &mut ApiWorld) {
     // Deregister mDNS before cancelling token (mirrors production shutdown handler)
-    if w.mdns_status.read().expect("lock").active {
-        let mut s = w.mdns_status.write().expect("MdnsStatus lock poisoned");
+    if w.mdns_status.read().active {
+        let mut s = w.mdns_status.write();
         s.active = false;
     }
     w.shutdown_token.cancel();

--- a/tests/api/health/security-headers.hurl
+++ b/tests/api/health/security-headers.hurl
@@ -1,0 +1,16 @@
+# Verify security headers are present on every response.
+# Uses /api/health as a public, unauthenticated endpoint.
+
+GET http://{{host}}/api/health
+
+HTTP 200
+[Asserts]
+header "Content-Security-Policy" contains "default-src 'self'"
+header "Content-Security-Policy" contains "frame-ancestors 'none'"
+header "X-Content-Type-Options" == "nosniff"
+header "X-Frame-Options" == "DENY"
+header "X-XSS-Protection" == "0"
+header "Referrer-Policy" == "strict-origin-when-cross-origin"
+# HSTS is only set when behind Cloudflare Tunnel (cf-connecting-ip present).
+# LAN-only requests must NOT get HSTS to avoid breaking plain HTTP access.
+header "Strict-Transport-Security" not exists


### PR DESCRIPTION
## Summary

- Adds Tower middleware (`security_headers::middleware`) that sets CSP, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, and Referrer-Policy on every HTTP response
- Conditionally sets Strict-Transport-Security when Cloudflare Tunnel is detected (via `cf-connecting-ip` header)
- Includes ADR documenting CSP policy rationale (`unsafe-inline` required for SvelteKit adapter-static) and tightening roadmap

Closes #380

## Test plan

- [x] 3 unit tests: static headers, no HSTS without tunnel, HSTS with tunnel
- [x] Hurl smoke test `tests/api/health/security-headers.hurl` asserting all headers on `/api/health`
- [x] Clippy clean, `cargo fmt` clean
- [x] Full API test suite passes (pre-existing `try_bind` failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP security headers added to all responses: Content-Security-Policy, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy; HSTS (Strict-Transport-Security) applied only when requests appear to come via Cloudflare Tunnel.

* **Bug Fixes**
  * Improved server stability by changing lock handling to avoid cascading crash loops from poisoned locks.

* **Documentation**
  * Added ADR documenting security-header placement and future tightening roadmap.

* **Tests**
  * New integration test validating security headers on health endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->