### PR TITLE
feat(api,web): adopt negative path testing standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Branded error page** shows the Mokumo logo, status code, and human-readable message for 400/401/403/404/5xx errors with navigation back to the dashboard.
+- **Routing contract tests** verify unknown `/api/*` paths return JSON 404 and wrong HTTP methods return JSON 405 instead of silently serving SPA HTML. (#384)
+- **Method-not-allowed fallback** returns structured JSON 405 responses for wrong HTTP methods on all API endpoints. (#384)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ Build features end-to-end as vertical slices (core/customer → db/customer → 
 13. **No sealed traits on internal crates** — crate boundaries provide sufficient encapsulation. Sealing blocks test doubles.
 14. **SeaORM entity placement** — entities with `DeriveEntityModel` belong in `crates/db/` only, never in `crates/core/` or `crates/types/`. SeaORM entities are infrastructure types; domain types in `core/` remain ORM-free. Repository impls convert between the two.
 15. **SeaORM migrations** — every migration must return `Some(true)` from `use_transaction()` (atomic SQLite migrations). Pre-migration backup is non-negotiable. `updated_at` triggers still required per item 11.
+16. **Pre-implementation boundary checklist** — before writing any conditional, path-matching, or range-checking code, answer four questions: (a) What are the boundary values? (b) What happens *at* each boundary? (c) What is the "almost right" input that should be rejected? (d) How does the caller see a rejected input (error code, status, message)? Each answer should have a corresponding test. See `ops/standards/testing/negative-path.md`.
 
 ## Pre-Build Ritual
 

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -14,10 +14,12 @@ const storybookTestDir = defineBddConfig({
     "!tests/features/demo-banner.feature",
     "!tests/features/profile-switcher.feature",
     "!tests/features/profile-switch-dirty-forms.feature",
+    "!tests/features/error-boundary.feature",
   ],
   steps: [
     "tests/steps/*.ts",
     "!tests/steps/shared-steps.ts",
+    "!tests/steps/error-boundary.steps.ts",
     "!tests/steps/settings-lan.steps.ts",
     "!tests/steps/shared-lan.steps.ts",
     "!tests/steps/dashboard.steps.ts",
@@ -44,6 +46,7 @@ const appTestDir = defineBddConfig({
     "tests/features/customers/**/*.feature",
     "tests/features/help-popover/**/*.feature",
     "tests/features/logout/**/*.feature",
+    "tests/features/error-boundary.feature",
   ],
   steps: [
     "tests/steps/shared-steps.ts",
@@ -52,6 +55,7 @@ const appTestDir = defineBddConfig({
     "tests/steps/customer-*.steps.ts",
     "tests/steps/help-popover.steps.ts",
     "tests/steps/logout.steps.ts",
+    "tests/steps/error-boundary.steps.ts",
     "tests/support/app.fixture.ts",
   ],
   importTestFrom: "tests/support/app.fixture.ts",

--- a/apps/web/src/lib/types/ErrorCode.ts
+++ b/apps/web/src/lib/types/ErrorCode.ts
@@ -19,4 +19,5 @@ export type ErrorCode =
   | "forbidden"
   | "invalid_token"
   | "setup_failed"
-  | "rate_limited";
+  | "rate_limited"
+  | "method_not_allowed";

--- a/apps/web/tests/features/error-boundary.feature
+++ b/apps/web/tests/features/error-boundary.feature
@@ -1,0 +1,16 @@
+Feature: Error boundary
+
+  The branded error page (+error.svelte) renders for invalid routes and API errors.
+  Displays the Mokumo logo, status code, human-readable title, and navigation options.
+
+  Scenario: Unknown route shows branded 404 error page
+    When I navigate to "/this-route-does-not-exist"
+    Then I see the branded error page
+    And the error page shows status "404"
+    And the error page shows title "Page not found"
+    And the error page has a "Return to Dashboard" link
+
+  Scenario: Error page has a go-back button
+    When I navigate to "/this-route-does-not-exist"
+    Then I see the branded error page
+    And the error page has a "Go back" button

--- a/apps/web/tests/features/error-boundary.feature
+++ b/apps/web/tests/features/error-boundary.feature
@@ -1,6 +1,6 @@
 Feature: Error boundary
 
-  The branded error page (+error.svelte) renders for invalid routes and API errors.
+  The branded error page (+error.svelte) renders for invalid routes.
   Displays the Mokumo logo, status code, human-readable title, and navigation options.
 
   Scenario: Unknown route shows branded 404 error page

--- a/apps/web/tests/steps/error-boundary.steps.ts
+++ b/apps/web/tests/steps/error-boundary.steps.ts
@@ -1,5 +1,9 @@
 import { expect } from "@playwright/test";
-import { Then } from "../support/app.fixture";
+import { When, Then } from "../support/app.fixture";
+
+When("I navigate to {string}", async ({ page, appUrl }, path: string) => {
+  await page.goto(`${appUrl}${path}`);
+});
 
 Then("I see the branded error page", async ({ page }) => {
   await expect(page.locator("img[alt='Mokumo']")).toBeVisible();

--- a/apps/web/tests/steps/error-boundary.steps.ts
+++ b/apps/web/tests/steps/error-boundary.steps.ts
@@ -1,0 +1,22 @@
+import { expect } from "@playwright/test";
+import { Then } from "../support/app.fixture";
+
+Then("I see the branded error page", async ({ page }) => {
+  await expect(page.locator("img[alt='Mokumo']")).toBeVisible();
+});
+
+Then("the error page shows status {string}", async ({ page }, status: string) => {
+  await expect(page.getByText(status, { exact: true })).toBeVisible();
+});
+
+Then("the error page shows title {string}", async ({ page }, title: string) => {
+  await expect(page.getByRole("heading", { name: title })).toBeVisible();
+});
+
+Then("the error page has a {string} link", async ({ page }, text: string) => {
+  await expect(page.getByRole("link", { name: text })).toBeVisible();
+});
+
+Then("the error page has a {string} button", async ({ page }, text: string) => {
+  await expect(page.getByRole("button", { name: text })).toBeVisible();
+});

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -32,6 +32,8 @@ pub enum ErrorCode {
     SetupFailed,
     /// Too many requests (rate limit exceeded).
     RateLimited,
+    /// HTTP method not allowed on this endpoint.
+    MethodNotAllowed,
 }
 
 impl std::fmt::Display for ErrorCode {
@@ -49,6 +51,7 @@ impl std::fmt::Display for ErrorCode {
             Self::InvalidToken => write!(f, "invalid_token"),
             Self::SetupFailed => write!(f, "setup_failed"),
             Self::RateLimited => write!(f, "rate_limited"),
+            Self::MethodNotAllowed => write!(f, "method_not_allowed"),
         }
     }
 }
@@ -71,7 +74,7 @@ mod tests {
 
     /// Exhaustive list of all ErrorCode variants.
     /// Update the array size when adding variants — the compiler enforces the count.
-    fn all_error_codes() -> [ErrorCode; 12] {
+    fn all_error_codes() -> [ErrorCode; 13] {
         [
             ErrorCode::NotFound,
             ErrorCode::Conflict,
@@ -85,6 +88,7 @@ mod tests {
             ErrorCode::InvalidToken,
             ErrorCode::SetupFailed,
             ErrorCode::RateLimited,
+            ErrorCode::MethodNotAllowed,
         ]
     }
 
@@ -109,6 +113,7 @@ mod tests {
             (ErrorCode::InvalidToken, "\"invalid_token\""),
             (ErrorCode::SetupFailed, "\"setup_failed\""),
             (ErrorCode::RateLimited, "\"rate_limited\""),
+            (ErrorCode::MethodNotAllowed, "\"method_not_allowed\""),
         ];
         for (variant, expected) in cases {
             assert_eq!(
@@ -134,6 +139,7 @@ mod tests {
             ("\"invalid_token\"", ErrorCode::InvalidToken),
             ("\"setup_failed\"", ErrorCode::SetupFailed),
             ("\"rate_limited\"", ErrorCode::RateLimited),
+            ("\"method_not_allowed\"", ErrorCode::MethodNotAllowed),
         ];
         for (json, expected) in cases {
             let code: ErrorCode = serde_json::from_str(json).unwrap();
@@ -267,6 +273,7 @@ mod tests {
                 Just(ErrorCode::InvalidToken),
                 Just(ErrorCode::SetupFailed),
                 Just(ErrorCode::RateLimited),
+                Just(ErrorCode::MethodNotAllowed),
             ]
         }
 

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -167,6 +167,8 @@ tasks:
       # list-unauthenticated.hurl excluded: demo auto-login returns 200 locally.
       # That test is valid in CI where the server boots without demo mode.
       hurl --variables-file tests/api/envs/ci.env --test \
+        tests/api/routing/api-prefix-boundary.hurl \
+        tests/api/routing/method-rejection.hurl \
         tests/api/health/health.hurl \
         tests/api/auth/login-bad-credentials.hurl \
         tests/api/auth/me-unauthenticated.hurl \

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -811,6 +811,7 @@ fn build_app_inner(
     }
 
     router
+        .method_not_allowed_fallback(handle_method_not_allowed)
         .fallback(serve_spa)
         // ProfileDbMiddleware: innermost — runs after auth session is populated.
         // Injects ProfileDb into request extensions for all routes.
@@ -1061,6 +1062,20 @@ fn spa_response(status: StatusCode, content_type: &str, cache: &str, body: Vec<u
         .into_response()
 }
 
+async fn handle_method_not_allowed() -> Response {
+    let body = mokumo_types::error::ErrorBody {
+        code: mokumo_types::error::ErrorCode::MethodNotAllowed,
+        message: "Method not allowed".into(),
+        details: None,
+    };
+    (
+        StatusCode::METHOD_NOT_ALLOWED,
+        [(axum::http::header::CACHE_CONTROL, "no-store")],
+        Json(body),
+    )
+        .into_response()
+}
+
 async fn serve_spa(uri: axum::http::Uri) -> Response {
     let path = uri.path().trim_start_matches('/');
 
@@ -1116,10 +1131,24 @@ mod tests {
 
     #[tokio::test]
     async fn serve_spa_api_path_returns_not_found_code() {
-        for path in ["/api/nonexistent", "/api"] {
+        // All /api* paths that should return JSON 404 — including boundary cases
+        for path in [
+            "/api/nonexistent",
+            "/api",
+            "/api/",           // trailing slash
+            "/api/v2/foo/bar", // deeply nested
+        ] {
             let uri: axum::http::Uri = path.parse().unwrap();
             let response = serve_spa(uri).await;
             assert_eq!(response.status(), StatusCode::NOT_FOUND, "path: {path}");
+            let ct = response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap();
+            assert!(
+                ct.to_str().unwrap().contains("application/json"),
+                "path: {path} should return JSON, got: {ct:?}"
+            );
             let cc = response
                 .headers()
                 .get(axum::http::header::CACHE_CONTROL)
@@ -1131,5 +1160,48 @@ mod tests {
             let error_body: ErrorBody = serde_json::from_slice(&body).unwrap();
             assert_eq!(error_body.code, ErrorCode::NotFound, "path: {path}");
         }
+    }
+
+    #[tokio::test]
+    async fn serve_spa_prefix_collision_not_caught_by_api_guard() {
+        // Paths that look like /api but are not — must NOT match the API prefix guard.
+        // Without SPA assets embedded these fall through to "SPA not built" (text/plain),
+        // not the JSON 404 returned for actual /api/* paths.
+        for path in ["/api-docs", "/apiary", "/application"] {
+            let uri: axum::http::Uri = path.parse().unwrap();
+            let response = serve_spa(uri).await;
+            let ct = response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .unwrap();
+            assert!(
+                !ct.to_str().unwrap().contains("application/json"),
+                "path: {path} should not return JSON — it should bypass the API prefix guard"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_method_not_allowed_returns_json_405() {
+        let response = handle_method_not_allowed().await;
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        let ct = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .unwrap();
+        assert!(
+            ct.to_str().unwrap().contains("application/json"),
+            "405 response should be JSON, got: {ct:?}"
+        );
+        let cc = response
+            .headers()
+            .get(axum::http::header::CACHE_CONTROL)
+            .unwrap();
+        assert_eq!(cc.to_str().unwrap(), "no-store");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let error_body: ErrorBody = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error_body.code, ErrorCode::MethodNotAllowed);
     }
 }

--- a/tests/api/routing/api-prefix-boundary.hurl
+++ b/tests/api/routing/api-prefix-boundary.hurl
@@ -1,0 +1,37 @@
+# Routing contract: unknown /api/* paths return JSON 404, never SPA HTML.
+# Covers the boundary between API routes and the SPA fallback handler.
+
+# Unknown API path returns 404 JSON
+GET http://{{host}}/api/nonexistent
+HTTP 404
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "not_found"
+jsonpath "$.message" exists
+
+# Bare /api returns 404 JSON (not SPA HTML)
+GET http://{{host}}/api
+HTTP 404
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "not_found"
+
+# /api/ with trailing slash returns 404 JSON
+GET http://{{host}}/api/
+HTTP 404
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "not_found"
+
+# Deeply nested unknown API path returns 404 JSON
+GET http://{{host}}/api/v2/customers/list
+HTTP 404
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "not_found"
+
+# Known API path returns JSON (positive control)
+GET http://{{host}}/api/health
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"

--- a/tests/api/routing/api-prefix-boundary.hurl
+++ b/tests/api/routing/api-prefix-boundary.hurl
@@ -15,6 +15,8 @@ HTTP 404
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "not_found"
+jsonpath "$.message" exists
+jsonpath "$.details" == null
 
 # /api/ with trailing slash returns 404 JSON
 GET http://{{host}}/api/
@@ -22,6 +24,8 @@ HTTP 404
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "not_found"
+jsonpath "$.message" exists
+jsonpath "$.details" == null
 
 # Deeply nested unknown API path returns 404 JSON
 GET http://{{host}}/api/v2/customers/list
@@ -29,6 +33,8 @@ HTTP 404
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "not_found"
+jsonpath "$.message" exists
+jsonpath "$.details" == null
 
 # Known API path returns JSON (positive control)
 GET http://{{host}}/api/health

--- a/tests/api/routing/method-rejection.hurl
+++ b/tests/api/routing/method-rejection.hurl
@@ -8,6 +8,7 @@ HTTP 405
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "method_not_allowed"
 jsonpath "$.message" exists
+jsonpath "$.details" == null
 
 # DELETE to GET-only /api/health returns 405
 DELETE http://{{host}}/api/health
@@ -15,6 +16,8 @@ HTTP 405
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "method_not_allowed"
+jsonpath "$.message" exists
+jsonpath "$.details" == null
 
 # PATCH to GET-only /api/health returns 405
 PATCH http://{{host}}/api/health
@@ -22,6 +25,8 @@ HTTP 405
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "method_not_allowed"
+jsonpath "$.message" exists
+jsonpath "$.details" == null
 
 # GET to POST-only /api/auth/login returns 405
 GET http://{{host}}/api/auth/login
@@ -29,6 +34,8 @@ HTTP 405
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "method_not_allowed"
+jsonpath "$.message" exists
+jsonpath "$.details" == null
 
 # PUT to POST-only /api/auth/login returns 405
 PUT http://{{host}}/api/auth/login
@@ -36,3 +43,5 @@ HTTP 405
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "method_not_allowed"
+jsonpath "$.message" exists
+jsonpath "$.details" == null

--- a/tests/api/routing/method-rejection.hurl
+++ b/tests/api/routing/method-rejection.hurl
@@ -1,0 +1,38 @@
+# Routing contract: wrong HTTP methods on known endpoints return 405 JSON.
+# Verifies method_not_allowed_fallback returns structured error responses.
+
+# POST to GET-only /api/health returns 405
+POST http://{{host}}/api/health
+HTTP 405
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "method_not_allowed"
+jsonpath "$.message" exists
+
+# DELETE to GET-only /api/health returns 405
+DELETE http://{{host}}/api/health
+HTTP 405
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "method_not_allowed"
+
+# PATCH to GET-only /api/health returns 405
+PATCH http://{{host}}/api/health
+HTTP 405
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "method_not_allowed"
+
+# GET to POST-only /api/auth/login returns 405
+GET http://{{host}}/api/auth/login
+HTTP 405
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "method_not_allowed"
+
+# PUT to POST-only /api/auth/login returns 405
+PUT http://{{host}}/api/auth/login
+HTTP 405
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "method_not_allowed"


### PR DESCRIPTION
## Summary

Adopts the negative path testing standard from `ops/standards/testing/negative-path.md` into the Mokumo codebase.

- **Routing contract test suite** at `tests/api/routing/` — Hurl tests proving unknown `/api/*` paths return JSON 404 (not SPA HTML) and wrong HTTP methods return JSON 405
- **`method_not_allowed_fallback`** on the Axum router returning structured JSON 405 with the standard `ErrorBody` shape
- **Pre-implementation boundary checklist** added as coding standard #16 in CLAUDE.md
- **Frontend error boundary tests** — Playwright BDD scenarios verifying `+error.svelte` renders branded 404 page
- **Expanded `serve_spa` unit tests** — trailing slash, prefix collision, Content-Type assertions
- **`MethodNotAllowed` ErrorCode variant** added to `crates/types/src/error.rs`

### Endpoint Negative Path Coverage Audit

| Category | Before | After | Notes |
|---|---|---|---|
| Routing contract (404 JSON) | 0 Hurl tests | 5 assertions | `api-prefix-boundary.hurl` |
| Method rejection (405 JSON) | 0 Hurl tests | 5 assertions | `method-rejection.hurl` |
| Auth failures (401) | 3 Hurl tests | 3 Hurl tests | Existing coverage adequate |
| Entity not found (404) | 1 Hurl test | 1 Hurl test | `not-found.hurl` covers zero-UUID |
| Malformed body (422) | 0 | 0 | Follow-up: #TBD |
| Boundary IDs | 0 | 0 | Follow-up: #TBD |
| Frontend error boundary | 0 | 2 scenarios | `error-boundary.feature` |

Closes #384

## Test plan

- [ ] `moon run api:test` passes (new unit tests for `serve_spa` boundary cases and `handle_method_not_allowed`)
- [ ] `moon run api:smoke` passes (new routing Hurl tests run against live server)
- [ ] `moon run api:lint` passes (new code passes clippy)
- [ ] `moon run web:test` passes (new error boundary BDD scenarios)
- [ ] Verify `POST /api/health` returns 405 JSON (not HTML)
- [ ] Verify `GET /api/nonexistent` returns 404 JSON (not SPA HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown /api/* routes now return structured JSON 404; unsupported HTTP methods on API endpoints return structured JSON 405. API-prefix collisions still serve non-API responses.

* **Tests**
  * Added routing and method-rejection contract tests plus end-to-end checks for the branded error page and updated BDD test inclusion/exclusion.

* **Documentation**
  * Updated changelog and added a pre-implementation boundary checklist rule.

* **Types**
  * Added a new machine-readable error code: "method_not_allowed".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->