### PR TITLE
fix(ci): promote bdd-lint and test-storybook to blocking quality gates

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -178,7 +178,6 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -227,7 +226,6 @@ jobs:
     needs: [changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.tooling == 'true')
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -447,7 +445,7 @@ jobs:
   verdict:
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, lint-rust, test-rust, quality-ts, seam-check, demo-smoke, crap-rust, api-smoke, security]
+    needs: [changes, lint-rust, test-rust, quality-ts, seam-check, demo-smoke, crap-rust, api-smoke, security, bdd-lint, test-storybook]
     steps:
       - name: Check upstream results
         env:
@@ -459,9 +457,11 @@ jobs:
           CRAP_RUST: ${{ needs.crap-rust.result }}
           API_SMOKE: ${{ needs.api-smoke.result }}
           SECURITY: ${{ needs.security.result }}
+          BDD_LINT: ${{ needs.bdd-lint.result }}
+          TEST_STORYBOOK: ${{ needs.test-storybook.result }}
         run: |
           # Jobs that were skipped due to path filtering are fine
-          for job in LINT_RUST TEST_RUST QUALITY_TS SEAM_CHECK DEMO_SMOKE CRAP_RUST API_SMOKE SECURITY; do
+          for job in LINT_RUST TEST_RUST QUALITY_TS SEAM_CHECK DEMO_SMOKE CRAP_RUST API_SMOKE SECURITY BDD_LINT TEST_STORYBOOK; do
             result=$(eval echo "\$$job")
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "Job $job failed with result: $result"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Routing contract tests** verify unknown `/api/*` paths return JSON 404 and wrong HTTP methods return JSON 405 instead of silently serving SPA HTML. (#384)
 - **Method-not-allowed fallback** returns structured JSON 405 responses for wrong HTTP methods on all API endpoints. (#384)
 
+### Fixed
+
+- **bdd-lint exit code** now fails when dead specs exceed a configurable threshold (`--max-dead-specs`), enabling it to function as a blocking CI gate. Previously always exited 0 regardless of findings. (#385)
+
 ### Changed
+
+- **CI quality gates** `bdd-lint` and `test-storybook` promoted from advisory to blocking — failures now prevent PR merge. `mutation-ts` remains advisory pending baseline stabilization. (#385)
 
 - **Settings Shop page** LAN URL and IP address display now use the shared `CopyableUrl` component, removing duplicated inline copy logic. (#162)
 - **Dashboard heading** now shows the configured shop name (falls back to "Your Shop" if none set). (#331)

--- a/tools/bdd-lint/moon.yml
+++ b/tools/bdd-lint/moon.yml
@@ -1,6 +1,6 @@
 tasks:
   check-staleness:
-    command: node --experimental-strip-types tools/bdd-lint/src/index.ts --format ci
+    command: node --experimental-strip-types tools/bdd-lint/src/index.ts --format ci --max-dead-specs 26
     inputs:
       - apps/web/tests/features/**/*.feature
       - apps/web/tests/steps/**/*.steps.ts

--- a/tools/bdd-lint/src/index.ts
+++ b/tools/bdd-lint/src/index.ts
@@ -54,9 +54,9 @@ console.log(output);
 // This tolerates known false positives from matcher limitations (unsupported regex
 // patterns, unparseable Cucumber expressions) while preventing regressions.
 const rawMaxDeadSpecs = values["max-dead-specs"];
-const maxDeadSpecs = rawMaxDeadSpecs ? parseInt(rawMaxDeadSpecs, 10) : 0;
-if (rawMaxDeadSpecs && Number.isNaN(maxDeadSpecs)) {
-  console.error(`\nFAIL: --max-dead-specs must be a number, got "${rawMaxDeadSpecs}"`);
+const maxDeadSpecs = rawMaxDeadSpecs ? Number(rawMaxDeadSpecs) : 0;
+if (rawMaxDeadSpecs && (!Number.isInteger(maxDeadSpecs) || maxDeadSpecs < 0)) {
+  console.error(`\nFAIL: --max-dead-specs must be a non-negative integer, got "${rawMaxDeadSpecs}"`);
   process.exit(1);
 }
 const hasErrors = result.deadSpecs.length > maxDeadSpecs;

--- a/tools/bdd-lint/src/index.ts
+++ b/tools/bdd-lint/src/index.ts
@@ -9,6 +9,7 @@ const { values } = parseArgs({
     format: { type: "string", default: "text" },
     "exclude-tags": { type: "string", default: "@wip" },
     "base-dir": { type: "string", default: "." },
+    "max-dead-specs": { type: "string", default: "" },
   },
 });
 
@@ -48,4 +49,15 @@ if (warningOutput) {
 const output = formatReport(result, format);
 console.log(output);
 
-process.exit(0);
+// Dead specs are blocking errors; orphan defs and stale WIP are advisory warnings.
+// --max-dead-specs ratchets the count: fail only if dead specs exceed the threshold.
+// This tolerates known false positives from matcher limitations (unsupported regex
+// patterns, unparseable Cucumber expressions) while preventing regressions.
+const maxDeadSpecs = values["max-dead-specs"] ? parseInt(values["max-dead-specs"], 10) : 0;
+const hasErrors = result.deadSpecs.length > maxDeadSpecs;
+if (hasErrors) {
+  console.error(
+    `\nFAIL: ${result.deadSpecs.length} dead specs found (max allowed: ${maxDeadSpecs})`
+  );
+}
+process.exit(hasErrors ? 1 : 0);

--- a/tools/bdd-lint/src/index.ts
+++ b/tools/bdd-lint/src/index.ts
@@ -53,7 +53,12 @@ console.log(output);
 // --max-dead-specs ratchets the count: fail only if dead specs exceed the threshold.
 // This tolerates known false positives from matcher limitations (unsupported regex
 // patterns, unparseable Cucumber expressions) while preventing regressions.
-const maxDeadSpecs = values["max-dead-specs"] ? parseInt(values["max-dead-specs"], 10) : 0;
+const rawMaxDeadSpecs = values["max-dead-specs"];
+const maxDeadSpecs = rawMaxDeadSpecs ? parseInt(rawMaxDeadSpecs, 10) : 0;
+if (rawMaxDeadSpecs && Number.isNaN(maxDeadSpecs)) {
+  console.error(`\nFAIL: --max-dead-specs must be a number, got "${rawMaxDeadSpecs}"`);
+  process.exit(1);
+}
 const hasErrors = result.deadSpecs.length > maxDeadSpecs;
 if (hasErrors) {
   console.error(


### PR DESCRIPTION
## Summary

Closes #385

- **bdd-lint** promoted to blocking: removed `continue-on-error: true`, added to verdict `needs` and check loop
- **test-storybook** promoted to blocking: same treatment
- **mutation-ts** remains advisory (`continue-on-error: true`) pending baseline stabilization — current Stryker `break: 50` threshold is already configured
- **bdd-lint exit code fixed**: previously always exited 0 regardless of findings. Now exits 1 when dead specs exceed `--max-dead-specs` threshold (ratchet baseline set to 26 known false positives from matcher limitations)

### Files changed

| File | Change |
|---|---|
| `.github/workflows/quality.yml` | Remove `continue-on-error` from bdd-lint + test-storybook; add both to verdict |
| `tools/bdd-lint/src/index.ts` | Fix exit code, add `--max-dead-specs` threshold flag |
| `tools/bdd-lint/moon.yml` | Pass `--max-dead-specs 26` to CI task |
| `CHANGELOG.md` | Document changes |

### Why the ratchet approach

bdd-lint currently reports 26 dead specs, mostly false positives from matcher limitations (unsupported regex patterns in Rust step defs, unparseable Cucumber expressions). The `--max-dead-specs 26` threshold prevents regressions while tolerating known false positives. As the matcher improves, this threshold can be lowered.

### Verification

- All 3 jobs (bdd-lint, test-storybook, mutation-ts) passed in the most recent PR CI run
- bdd-lint unit tests pass (41/41)
- bdd-lint check-staleness passes with `--max-dead-specs 26`

## Test plan

- [ ] CI verdict job correctly includes bdd-lint and test-storybook in its checks
- [ ] bdd-lint fails if a new dead spec is introduced (count exceeds 26)
- [ ] test-storybook failure would block PR merge
- [ ] mutation-ts remains non-blocking (continue-on-error still set)
- [ ] Existing open PRs are not blocked by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * bdd-lint now fails CI when dead specs exceed the configured limit, preventing merges on excess dead specs.
  * The CLI option for the dead-spec threshold now validates input and returns an error on invalid values.

* **Chores**
  * CI quality gates strengthened: bdd-lint and Storybook tests are now blocking (failures prevent PR merge).
  * Dead-spec threshold for CI checks adjusted to 26, tightening staleness detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->