### PR TITLE
feat(api): add version CLI subcommand and --version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Version CLI**: `mokumo --version` prints the version string; `mokumo version` prints extended build info including git hash, build date, target platform, and Rust version. (#405)
 - **HTTP security headers**: every response now includes `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 0`, and `Referrer-Policy: strict-origin-when-cross-origin`. `Strict-Transport-Security` is set conditionally when behind Cloudflare Tunnel. (#380)
 - **Branded error page** shows the Mokumo logo, status code, and human-readable message for 400/401/403/404/5xx errors with navigation back to the dashboard.
 - **Routing contract tests** verify unknown `/api/*` paths return JSON 404 and wrong HTTP methods return JSON 405 instead of silently serving SPA HTML. (#384)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,13 +980,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform 0.3.2",
  "semver",
  "serde",
  "serde_json",
@@ -3845,6 +3869,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -4158,6 +4183,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7386,7 +7420,7 @@ checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
 dependencies = [
  "anyhow",
  "brotli",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "ctor",
  "dunce",
  "glob",
@@ -7557,7 +7591,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -8328,6 +8364,47 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.23.1",
+ "derive_builder",
+ "regex",
+ "rustc_version",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version-compare"

--- a/crap4rs.toml
+++ b/crap4rs.toml
@@ -12,4 +12,5 @@ exclude = [
   "services/api/src/**",
   "apps/desktop/**",
   "**/tests/**",
+  "**/build.rs",
 ]

--- a/services/api/Cargo.toml
+++ b/services/api/Cargo.toml
@@ -40,6 +40,9 @@ fd-lock = { workspace = true }
 parking_lot = { workspace = true }
 url = "2"
 
+[build-dependencies]
+vergen-gitcl = { version = "9", features = ["build", "cargo", "rustc"] }
+
 [features]
 bdd = []
 

--- a/services/api/build.rs
+++ b/services/api/build.rs
@@ -1,0 +1,20 @@
+use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let build = BuildBuilder::default().build_timestamp(true).build()?;
+    let cargo = CargoBuilder::default().target_triple(true).build()?;
+    let gitcl = GitclBuilder::default()
+        .sha(true)
+        .commit_timestamp(true)
+        .build()?;
+    let rustc = RustcBuilder::default().semver(true).build()?;
+
+    Emitter::default()
+        .add_instructions(&build)?
+        .add_instructions(&cargo)?
+        .add_instructions(&gitcl)?
+        .add_instructions(&rustc)?
+        .emit()?;
+
+    Ok(())
+}

--- a/services/api/build.rs
+++ b/services/api/build.rs
@@ -3,18 +3,25 @@ use vergen_gitcl::{BuildBuilder, CargoBuilder, Emitter, GitclBuilder, RustcBuild
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let build = BuildBuilder::default().build_timestamp(true).build()?;
     let cargo = CargoBuilder::default().target_triple(true).build()?;
-    let gitcl = GitclBuilder::default()
-        .sha(true)
-        .commit_timestamp(true)
-        .build()?;
     let rustc = RustcBuilder::default().semver(true).build()?;
 
-    Emitter::default()
+    let mut emitter = Emitter::default();
+    emitter
         .add_instructions(&build)?
         .add_instructions(&cargo)?
-        .add_instructions(&gitcl)?
-        .add_instructions(&rustc)?
-        .emit()?;
+        .add_instructions(&rustc)?;
 
+    // Git metadata is best-effort: source archives lack .git
+    if let Ok(gitcl) = GitclBuilder::default()
+        .sha(true)
+        .commit_timestamp(true)
+        .build()
+    {
+        emitter.add_instructions(&gitcl)?;
+    } else {
+        println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown");
+    }
+
+    emitter.emit()?;
     Ok(())
 }

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -11,8 +11,13 @@ use mokumo_api::{
 };
 use mokumo_core::setup::SetupMode;
 
-#[derive(Parser)]
-#[command(name = "mokumo", about = "Mokumo Print — production management server")]
+#[derive(Debug, Parser)]
+#[command(
+    name = "mokumo",
+    about = "Mokumo Print — production management server",
+    version,
+    long_version = long_version()
+)]
 struct Cli {
     /// Port to listen on
     #[arg(short, long, default_value = "6565")]
@@ -30,8 +35,10 @@ struct Cli {
     command: Option<Commands>,
 }
 
-#[derive(clap::Subcommand)]
+#[derive(Debug, clap::Subcommand)]
 enum Commands {
+    /// Print version and build information
+    Version,
     /// Reset a user's password directly (no running server required)
     ResetPassword {
         /// Email address of the user to reset
@@ -51,6 +58,28 @@ enum Commands {
         #[arg(long)]
         production: bool,
     },
+}
+
+/// Build extended version string from compile-time environment variables.
+///
+/// Returns a static string with version, git hash, build date, platform, and
+/// Rust version — all injected by vergen-gitcl at build time.
+fn long_version() -> &'static str {
+    concat!(
+        env!("CARGO_PKG_VERSION"),
+        "\n",
+        "git hash:   ",
+        env!("VERGEN_GIT_SHA"),
+        "\n",
+        "built:      ",
+        env!("VERGEN_BUILD_TIMESTAMP"),
+        "\n",
+        "target:     ",
+        env!("VERGEN_CARGO_TARGET_TRIPLE"),
+        "\n",
+        "rustc:      ",
+        env!("VERGEN_RUSTC_SEMVER"),
+    )
 }
 
 /// Resolve the default data directory using platform conventions.
@@ -79,6 +108,10 @@ async fn main() {
 
     // Handle subcommands before server startup
     match cli.command {
+        Some(Commands::Version) => {
+            println!("mokumo {}", long_version());
+            return;
+        }
         Some(Commands::ResetPassword { email }) => {
             let profile = resolve_active_profile(&data_dir);
             let db_path = data_dir.join(profile.as_str()).join("mokumo.db");
@@ -547,6 +580,49 @@ mod tests {
     use mokumo_api::migrate_flat_layout;
     use mokumo_core::setup::SetupMode;
     use tempfile::tempdir;
+
+    #[test]
+    fn long_version_contains_version_number() {
+        let version = long_version();
+        assert!(
+            version.contains(env!("CARGO_PKG_VERSION")),
+            "long_version should contain the package version"
+        );
+    }
+
+    #[test]
+    fn long_version_contains_git_hash() {
+        let version = long_version();
+        assert!(
+            version.contains("git hash:"),
+            "long_version should contain git hash label"
+        );
+    }
+
+    #[test]
+    fn long_version_contains_build_metadata() {
+        let version = long_version();
+        assert!(version.contains("built:"), "should contain build timestamp");
+        assert!(version.contains("target:"), "should contain target triple");
+        assert!(version.contains("rustc:"), "should contain rustc version");
+    }
+
+    #[test]
+    fn cli_parses_version_subcommand() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["mokumo", "version"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Version)));
+    }
+
+    #[test]
+    fn cli_parses_version_flag() {
+        use clap::Parser;
+        let result = Cli::try_parse_from(["mokumo", "--version"]);
+        // --version causes Clap to return an error with DisplayVersion kind
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+    }
 
     #[test]
     fn resolve_active_profile_missing_file_defaults_to_demo() {


### PR DESCRIPTION
## Summary

- Add `mokumo --version` flag for short version output (via Clap `#[command(version)]`)
- Add `mokumo version` subcommand for extended build info: version, git hash, build date, target platform, rustc version
- Uses `vergen-gitcl` to inject build-time metadata via `build.rs`

Closes #405

## Test plan

- [x] Unit tests: `long_version()` contains expected fields (version, git hash label, build timestamp, target, rustc)
- [x] Integration tests: Clap parses `--version` flag and `version` subcommand correctly
- [x] Manual verification: both `--version` and `version` produce correct output
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] All 14 binary tests pass (5 new + 9 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mokumo --version` to show brief version
  * Added `mokumo version` to show extended build metadata (git hash, build date, target platform, Rust version)

* **Documentation**
  * Updated changelog "Unreleased" to include the new Version CLI entry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->