### PR TITLE
feat(api): add backup and restore CLI subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Version CLI**: `mokumo --version` prints the version string; `mokumo version` prints extended build info including git hash, build date, target platform, and Rust version. (#405)
+- **`mokumo backup` CLI subcommand** creates a manual database backup using the SQLite Online Backup API. Supports `--output <path>` for custom location, verifies integrity with `PRAGMA integrity_check`, and prints path + size on success. Safe to run while the server is running. (#403)
+- **`mokumo restore <path>` CLI subcommand** restores the database from a backup file. Verifies backup integrity before restoring, creates a safety backup of the current database, removes WAL sidecars, and refuses to run while the server is active (process lock check). (#404)
 - **HTTP security headers**: every response now includes `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 0`, and `Referrer-Policy: strict-origin-when-cross-origin`. `Strict-Transport-Security` is set conditionally when behind Cloudflare Tunnel. (#380)
 - **Branded error page** shows the Mokumo logo, status code, and human-readable message for 400/401/403/404/5xx errors with navigation back to the dashboard.
 - **Routing contract tests** verify unknown `/api/*` paths return JSON 404 and wrong HTTP methods return JSON 405 instead of silently serving SPA HTML. (#384)

--- a/crates/db/src/backup.rs
+++ b/crates/db/src/backup.rs
@@ -1,0 +1,380 @@
+//! CLI backup and restore operations using the SQLite Online Backup API.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Result of a successful backup operation.
+#[derive(Debug)]
+pub struct BackupResult {
+    /// Path to the created backup file.
+    pub path: PathBuf,
+    /// Size of the backup file in bytes.
+    pub size: u64,
+}
+
+/// Result of a successful restore operation.
+#[derive(Debug)]
+pub struct RestoreResult {
+    /// Path of the backup file that was restored from.
+    pub restored_from: PathBuf,
+    /// Path to the safety backup created before overwriting, if one was made.
+    /// `None` when restoring into a directory with no existing database.
+    pub safety_backup_path: Option<PathBuf>,
+}
+
+/// Errors that can occur during backup or restore operations.
+#[derive(Debug, thiserror::Error)]
+pub enum BackupError {
+    #[error("database not found: {}", path.display())]
+    DatabaseNotFound { path: PathBuf },
+
+    #[error("backup file not found: {}", path.display())]
+    BackupFileNotFound { path: PathBuf },
+
+    #[error("integrity check failed: {details}")]
+    IntegrityCheckFailed { details: String },
+
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Build a timestamped backup filename.
+///
+/// Format: `mokumo-backup-{YYYYMMDD-HHMMSS}.db`
+pub fn build_timestamped_name() -> String {
+    let now = chrono::Local::now();
+    format!("mokumo-backup-{}.db", now.format("%Y%m%d-%H%M%S"))
+}
+
+/// Create a backup of the SQLite database using the Online Backup API.
+///
+/// The backup API is safe to use while the database is open and in WAL mode —
+/// it produces a single self-contained `.db` file with no sidecars.
+pub fn create_backup(db_path: &Path, output_path: &Path) -> Result<BackupResult, BackupError> {
+    if !db_path.exists() {
+        return Err(BackupError::DatabaseNotFound {
+            path: db_path.to_path_buf(),
+        });
+    }
+
+    let src = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let mut dst = rusqlite::Connection::open(output_path)?;
+
+    let backup = rusqlite::backup::Backup::new(&src, &mut dst)?;
+    backup.run_to_completion(100, Duration::from_millis(50), None)?;
+    drop(backup);
+    drop(dst);
+    drop(src);
+
+    let size = std::fs::metadata(output_path)?.len();
+
+    Ok(BackupResult {
+        path: output_path.to_path_buf(),
+        size,
+    })
+}
+
+/// Verify the integrity of a SQLite database file.
+///
+/// Runs `PRAGMA integrity_check` and returns `Ok(())` if the database passes,
+/// or `Err(BackupError::IntegrityCheckFailed)` with the error details.
+pub fn verify_integrity(path: &Path) -> Result<(), BackupError> {
+    if !path.exists() {
+        return Err(BackupError::DatabaseNotFound {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let conn = rusqlite::Connection::open_with_flags(
+        path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+
+    let mut stmt = conn.prepare("PRAGMA integrity_check")?;
+    let rows: Vec<String> = stmt
+        .query_map([], |row| row.get(0))?
+        .collect::<Result<Vec<String>, _>>()?;
+
+    if rows.len() == 1 && rows[0] == "ok" {
+        Ok(())
+    } else {
+        Err(BackupError::IntegrityCheckFailed {
+            details: rows.join("; "),
+        })
+    }
+}
+
+/// Restore a database from a backup file.
+///
+/// 1. Verifies the backup file's integrity.
+/// 2. Creates a safety backup of the current database (if it exists).
+/// 3. Uses the SQLite Online Backup API to copy from backup → db_path.
+/// 4. Removes WAL/SHM sidecars left by the previous database.
+///
+/// The caller must ensure the server is not running (process lock acquired).
+pub fn restore_from_backup(
+    db_path: &Path,
+    backup_path: &Path,
+    sidecar_suffixes: &[&str],
+) -> Result<RestoreResult, BackupError> {
+    if !backup_path.exists() {
+        return Err(BackupError::BackupFileNotFound {
+            path: backup_path.to_path_buf(),
+        });
+    }
+
+    // 1. Verify backup integrity before touching anything
+    verify_integrity(backup_path)?;
+
+    // 2. Safety backup of the current database (if it exists)
+    let safety_backup_path = if db_path.exists() {
+        let mut path = db_path.with_extension("db.pre-restore-backup");
+        // Guard against overwriting the restore source with the safety backup
+        if path == backup_path {
+            let now = chrono::Local::now();
+            path = db_path.with_extension(format!(
+                "db.pre-restore-backup.{}",
+                now.format("%Y%m%d-%H%M%S")
+            ));
+        }
+        create_backup(db_path, &path)?;
+        Some(path)
+    } else {
+        None
+    };
+
+    // 3. Remove WAL/SHM sidecars from the current database (they're incompatible
+    //    with the backup's page state). Skip the empty suffix — that's the main file.
+    for suffix in sidecar_suffixes {
+        if suffix.is_empty() {
+            continue;
+        }
+        let sidecar = db_path.with_file_name(format!(
+            "{}{}",
+            db_path.file_name().unwrap_or_default().to_string_lossy(),
+            suffix
+        ));
+        if sidecar.exists() {
+            std::fs::remove_file(&sidecar)?;
+        }
+    }
+
+    // 4. Use Backup API to copy from backup file → db_path
+    let src = rusqlite::Connection::open_with_flags(
+        backup_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    let mut dst = rusqlite::Connection::open(db_path)?;
+
+    let backup = rusqlite::backup::Backup::new(&src, &mut dst)?;
+    backup.run_to_completion(100, Duration::ZERO, None)?;
+    drop(backup);
+    drop(dst);
+    drop(src);
+
+    Ok(RestoreResult {
+        restored_from: backup_path.to_path_buf(),
+        safety_backup_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Helper: create a minimal valid SQLite database at the given path.
+    fn create_test_db(path: &Path) {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+             INSERT INTO test (name) VALUES ('alice');
+             INSERT INTO test (name) VALUES ('bob');",
+        )
+        .unwrap();
+    }
+
+    /// Helper: count rows in the test table.
+    fn count_rows(path: &Path) -> i64 {
+        let conn =
+            rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .unwrap();
+        conn.query_row("SELECT COUNT(*) FROM test", [], |row| row.get(0))
+            .unwrap()
+    }
+
+    // ── build_timestamped_name ────────────────────────────────────────────
+
+    #[test]
+    fn timestamped_name_has_expected_format() {
+        let name = build_timestamped_name();
+        assert!(name.starts_with("mokumo-backup-"));
+        assert!(name.ends_with(".db"));
+        // Format: mokumo-backup-YYYYMMDD-HHMMSS.db
+        assert_eq!(name.len(), "mokumo-backup-20260409-143022.db".len());
+    }
+
+    // ── create_backup ─────────────────────────────────────────────────────
+
+    #[test]
+    fn create_backup_produces_valid_copy() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("mokumo.db");
+        let backup_path = tmp.path().join("backup.db");
+
+        create_test_db(&db_path);
+
+        let result = create_backup(&db_path, &backup_path).unwrap();
+        assert_eq!(result.path, backup_path);
+        assert!(result.size > 0);
+
+        // Verify the backup has the same data
+        assert_eq!(count_rows(&backup_path), 2);
+    }
+
+    #[test]
+    fn create_backup_fails_for_nonexistent_db() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("nonexistent.db");
+        let backup_path = tmp.path().join("backup.db");
+
+        let err = create_backup(&db_path, &backup_path).unwrap_err();
+        assert!(matches!(err, BackupError::DatabaseNotFound { .. }));
+    }
+
+    // ── verify_integrity ──────────────────────────────────────────────────
+
+    #[test]
+    fn verify_integrity_passes_for_valid_db() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("valid.db");
+        create_test_db(&db_path);
+
+        verify_integrity(&db_path).unwrap();
+    }
+
+    #[test]
+    fn verify_integrity_fails_for_nonexistent_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("nonexistent.db");
+
+        let err = verify_integrity(&path).unwrap_err();
+        assert!(matches!(err, BackupError::DatabaseNotFound { .. }));
+    }
+
+    #[test]
+    fn verify_integrity_fails_for_corrupt_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("corrupt.db");
+        // Write garbage that starts with SQLite magic but is otherwise corrupt
+        let mut data = b"SQLite format 3\0".to_vec();
+        data.extend_from_slice(&[0u8; 100]);
+        std::fs::write(&path, &data).unwrap();
+
+        let err = verify_integrity(&path).unwrap_err();
+        // Either IntegrityCheckFailed or Sqlite error depending on how corrupt
+        assert!(
+            matches!(
+                err,
+                BackupError::IntegrityCheckFailed { .. } | BackupError::Sqlite(_)
+            ),
+            "expected integrity or sqlite error, got: {err}"
+        );
+    }
+
+    // ── restore_from_backup ───────────────────────────────────────────────
+
+    #[test]
+    fn restore_replaces_database_with_backup_contents() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("mokumo.db");
+        let backup_path = tmp.path().join("backup.db");
+
+        // Create original DB with 2 rows
+        create_test_db(&db_path);
+        assert_eq!(count_rows(&db_path), 2);
+
+        // Create a different backup with 3 rows
+        {
+            let conn = rusqlite::Connection::open(&backup_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+                 INSERT INTO test (name) VALUES ('x');
+                 INSERT INTO test (name) VALUES ('y');
+                 INSERT INTO test (name) VALUES ('z');",
+            )
+            .unwrap();
+        }
+
+        let suffixes: &[&str] = &["", "-wal", "-shm", "-journal"];
+        let result = restore_from_backup(&db_path, &backup_path, suffixes).unwrap();
+
+        assert_eq!(result.restored_from, backup_path);
+        let safety_path = result
+            .safety_backup_path
+            .expect("safety backup should exist");
+        assert!(safety_path.exists());
+
+        // DB should now have 3 rows (from backup)
+        assert_eq!(count_rows(&db_path), 3);
+
+        // Safety backup should have original 2 rows
+        assert_eq!(count_rows(&safety_path), 2);
+    }
+
+    #[test]
+    fn restore_removes_wal_sidecars() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("mokumo.db");
+        let wal_path = tmp.path().join("mokumo.db-wal");
+        let shm_path = tmp.path().join("mokumo.db-shm");
+        let backup_path = tmp.path().join("backup.db");
+
+        create_test_db(&db_path);
+        create_test_db(&backup_path);
+
+        // Create fake sidecar files
+        std::fs::write(&wal_path, b"fake-wal").unwrap();
+        std::fs::write(&shm_path, b"fake-shm").unwrap();
+
+        let suffixes: &[&str] = &["", "-wal", "-shm", "-journal"];
+        restore_from_backup(&db_path, &backup_path, suffixes).unwrap();
+
+        assert!(!wal_path.exists(), "WAL sidecar should be removed");
+        assert!(!shm_path.exists(), "SHM sidecar should be removed");
+    }
+
+    #[test]
+    fn restore_fails_for_nonexistent_backup() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("mokumo.db");
+        let backup_path = tmp.path().join("nonexistent.db");
+
+        let suffixes: &[&str] = &["", "-wal", "-shm", "-journal"];
+        let err = restore_from_backup(&db_path, &backup_path, suffixes).unwrap_err();
+        assert!(matches!(err, BackupError::BackupFileNotFound { .. }));
+    }
+
+    #[test]
+    fn restore_to_empty_directory_skips_safety_backup() {
+        let tmp = tempdir().unwrap();
+        let db_path = tmp.path().join("mokumo.db");
+        let backup_path = tmp.path().join("backup.db");
+
+        // No existing DB — just a backup to restore from
+        create_test_db(&backup_path);
+
+        let suffixes: &[&str] = &["", "-wal", "-shm", "-journal"];
+        let result = restore_from_backup(&db_path, &backup_path, suffixes).unwrap();
+
+        assert_eq!(count_rows(&db_path), 2);
+        // No existing DB means no safety backup was created
+        assert!(result.safety_backup_path.is_none());
+    }
+}

--- a/crates/db/src/backup.rs
+++ b/crates/db/src/backup.rs
@@ -110,12 +110,55 @@ pub fn verify_integrity(path: &Path) -> Result<(), BackupError> {
     }
 }
 
+/// Create a safety backup of the current database, choosing a path that
+/// won't collide with the restore source.
+fn create_safety_backup(
+    db_path: &Path,
+    restore_source: &Path,
+) -> Result<Option<PathBuf>, BackupError> {
+    if !db_path.exists() {
+        return Ok(None);
+    }
+
+    let mut path = db_path.with_extension("db.pre-restore-backup");
+    if path == restore_source {
+        let now = chrono::Local::now();
+        path = db_path.with_extension(format!(
+            "db.pre-restore-backup.{}",
+            now.format("%Y%m%d-%H%M%S")
+        ));
+    }
+    create_backup(db_path, &path)?;
+    Ok(Some(path))
+}
+
+/// Remove WAL/SHM/journal sidecars that are incompatible with the backup's
+/// page state. Skips empty suffixes (the main file).
+fn remove_sidecars(db_path: &Path, suffixes: &[&str]) -> Result<(), BackupError> {
+    let base = db_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    for suffix in suffixes {
+        if suffix.is_empty() {
+            continue;
+        }
+        let sidecar = db_path.with_file_name(format!("{base}{suffix}"));
+        if sidecar.exists() {
+            std::fs::remove_file(&sidecar)?;
+        }
+    }
+    Ok(())
+}
+
 /// Restore a database from a backup file.
 ///
 /// 1. Verifies the backup file's integrity.
 /// 2. Creates a safety backup of the current database (if it exists).
-/// 3. Uses the SQLite Online Backup API to copy from backup → db_path.
-/// 4. Removes WAL/SHM sidecars left by the previous database.
+/// 3. Removes WAL/SHM sidecars left by the previous database.
+/// 4. Uses the SQLite Online Backup API to copy from backup → db_path.
 ///
 /// The caller must ensure the server is not running (process lock acquired).
 pub fn restore_from_backup(
@@ -129,43 +172,10 @@ pub fn restore_from_backup(
         });
     }
 
-    // 1. Verify backup integrity before touching anything
     verify_integrity(backup_path)?;
+    let safety_backup_path = create_safety_backup(db_path, backup_path)?;
+    remove_sidecars(db_path, sidecar_suffixes)?;
 
-    // 2. Safety backup of the current database (if it exists)
-    let safety_backup_path = if db_path.exists() {
-        let mut path = db_path.with_extension("db.pre-restore-backup");
-        // Guard against overwriting the restore source with the safety backup
-        if path == backup_path {
-            let now = chrono::Local::now();
-            path = db_path.with_extension(format!(
-                "db.pre-restore-backup.{}",
-                now.format("%Y%m%d-%H%M%S")
-            ));
-        }
-        create_backup(db_path, &path)?;
-        Some(path)
-    } else {
-        None
-    };
-
-    // 3. Remove WAL/SHM sidecars from the current database (they're incompatible
-    //    with the backup's page state). Skip the empty suffix — that's the main file.
-    for suffix in sidecar_suffixes {
-        if suffix.is_empty() {
-            continue;
-        }
-        let sidecar = db_path.with_file_name(format!(
-            "{}{}",
-            db_path.file_name().unwrap_or_default().to_string_lossy(),
-            suffix
-        ));
-        if sidecar.exists() {
-            std::fs::remove_file(&sidecar)?;
-        }
-    }
-
-    // 4. Use Backup API to copy from backup file → db_path
     let src = rusqlite::Connection::open_with_flags(
         backup_path,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod backup;
 pub mod customer;
 pub mod migration;
 pub mod role;

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -962,6 +962,48 @@ pub fn cli_reset_db(
     Ok(report)
 }
 
+/// Create a manual backup of the database using the SQLite Online Backup API.
+///
+/// Resolves the output path: if `output` is provided, uses it directly; otherwise
+/// generates a timestamped filename in the database's directory.
+///
+/// This is safe to run while the server is running — the Online Backup API
+/// handles WAL mode and concurrent access correctly.
+pub fn cli_backup(
+    db_path: &Path,
+    output: Option<&Path>,
+) -> Result<mokumo_db::backup::BackupResult, String> {
+    let output_path = match output {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let dir = db_path.parent().unwrap_or(Path::new("."));
+            dir.join(mokumo_db::backup::build_timestamped_name())
+        }
+    };
+
+    let result =
+        mokumo_db::backup::create_backup(db_path, &output_path).map_err(|e| format!("{e}"))?;
+
+    mokumo_db::backup::verify_integrity(&output_path)
+        .map_err(|e| format!("Backup created but integrity check failed: {e}"))?;
+
+    Ok(result)
+}
+
+/// Restore the database from a backup file.
+///
+/// Verifies the backup's integrity, creates a safety backup of the current
+/// database, then overwrites it with the backup contents.
+///
+/// The caller must hold the process lock (server must not be running).
+pub fn cli_restore(
+    db_path: &Path,
+    backup_path: &Path,
+) -> Result<mokumo_db::backup::RestoreResult, String> {
+    mokumo_db::backup::restore_from_backup(db_path, backup_path, DB_SIDECAR_SUFFIXES)
+        .map_err(|e| format!("{e}"))
+}
+
 fn delete_file(path: &Path, report: &mut ResetReport) {
     match std::fs::remove_file(path) {
         Ok(()) => report.deleted.push(path.to_path_buf()),

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -5,9 +5,9 @@ use tokio_util::sync::CancellationToken;
 use tracing_subscriber::EnvFilter;
 
 use mokumo_api::{
-    DB_SIDECAR_SUFFIXES, ServerConfig, build_app_with_shutdown, cli_reset_db, cli_reset_password,
-    discovery, ensure_data_dirs, lock_file_path, prepare_database, resolve_active_profile,
-    try_bind,
+    DB_SIDECAR_SUFFIXES, ServerConfig, build_app_with_shutdown, cli_backup, cli_reset_db,
+    cli_reset_password, cli_restore, discovery, ensure_data_dirs, lock_file_path, prepare_database,
+    resolve_active_profile, try_bind,
 };
 use mokumo_core::setup::SetupMode;
 
@@ -55,6 +55,23 @@ enum Commands {
         include_backups: bool,
         /// Reset the production profile instead of the default demo profile.
         /// Requires typing "reset production" to confirm (irreversible).
+        #[arg(long)]
+        production: bool,
+    },
+    /// Create a manual backup of the database
+    Backup {
+        /// Write the backup to this path instead of the default timestamped name
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Back up the production profile instead of the default demo profile
+        #[arg(long)]
+        production: bool,
+    },
+    /// Restore the database from a backup file
+    Restore {
+        /// Path to the backup file to restore from
+        path: PathBuf,
+        /// Restore to the production profile instead of the default demo profile
         #[arg(long)]
         production: bool,
     },
@@ -383,6 +400,99 @@ async fn main() {
                     );
                 }
                 std::process::exit(1);
+            }
+            return;
+        }
+        Some(Commands::Backup { output, production }) => {
+            let profile = if production {
+                SetupMode::Production
+            } else {
+                resolve_active_profile(&data_dir)
+            };
+            let db_path = data_dir.join(profile.as_dir_name()).join("mokumo.db");
+
+            match db_path.try_exists() {
+                Ok(false) => {
+                    eprintln!("No database found at {}", db_path.display());
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Cannot access database path {}: {e}", db_path.display());
+                    std::process::exit(1);
+                }
+                Ok(true) => {}
+            }
+
+            match cli_backup(&db_path, output.as_deref()) {
+                Ok(result) => {
+                    println!("Backup created: {}", result.path.display());
+                    println!("Size: {} bytes", result.size);
+                }
+                Err(e) => {
+                    eprintln!("Backup failed: {e}");
+                    std::process::exit(1);
+                }
+            }
+            return;
+        }
+        Some(Commands::Restore { path, production }) => {
+            let profile = if production {
+                SetupMode::Production
+            } else {
+                resolve_active_profile(&data_dir)
+            };
+            let db_path = data_dir.join(profile.as_dir_name()).join("mokumo.db");
+
+            if let Err(e) = ensure_data_dirs(&data_dir) {
+                eprintln!("Cannot create data directory {}: {e}", data_dir.display());
+                std::process::exit(1);
+            }
+
+            // Acquire process lock — refuse to restore while server is running
+            let lock_path = lock_file_path(&data_dir);
+            let mut flock = match std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+            {
+                Ok(f) => fd_lock::RwLock::new(f),
+                Err(e) => {
+                    eprintln!("Cannot open lock file {}: {e}", lock_path.display());
+                    std::process::exit(1);
+                }
+            };
+            let _lock_guard = match flock.try_write() {
+                Ok(guard) => guard,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    eprintln!(
+                        "The database appears to be in use by a running server.\n\
+                         Stop the server first, then try again."
+                    );
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Cannot acquire process lock: {e}");
+                    std::process::exit(1);
+                }
+            };
+
+            match cli_restore(&db_path, &path) {
+                Ok(result) => {
+                    println!("Restored from: {}", result.restored_from.display());
+                    if let Some(ref safety_path) = result.safety_backup_path {
+                        println!(
+                            "Safety backup of previous database: {}",
+                            safety_path.display()
+                        );
+                    }
+                    println!("Restore complete.");
+                }
+                Err(e) => {
+                    eprintln!("Restore failed: {e}");
+                    std::process::exit(1);
+                }
             }
             return;
         }

--- a/services/api/tests/cli_backup.rs
+++ b/services/api/tests/cli_backup.rs
@@ -1,0 +1,59 @@
+//! Integration tests for the `mokumo-api backup` CLI subcommand.
+
+use std::path::Path;
+use tempfile::tempdir;
+
+/// Helper: create a minimal valid SQLite database at the given path.
+fn create_test_db(path: &Path) {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+         INSERT INTO test (name) VALUES ('alice');",
+    )
+    .unwrap();
+}
+
+#[test]
+fn backup_creates_timestamped_file() {
+    let tmp = tempdir().unwrap();
+    let data_dir = tmp.path();
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+
+    let db_path = data_dir.join("demo").join("mokumo.db");
+    create_test_db(&db_path);
+
+    let result = mokumo_api::cli_backup(&db_path, None).unwrap();
+    assert!(result.path.exists());
+    assert!(result.size > 0);
+
+    let name = result.path.file_name().unwrap().to_str().unwrap();
+    assert!(name.starts_with("mokumo-backup-"));
+    assert!(name.ends_with(".db"));
+}
+
+#[test]
+fn backup_with_custom_output_path() {
+    let tmp = tempdir().unwrap();
+    let data_dir = tmp.path();
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+
+    let db_path = data_dir.join("demo").join("mokumo.db");
+    let output_path = tmp.path().join("my-backup.db");
+    create_test_db(&db_path);
+
+    let result = mokumo_api::cli_backup(&db_path, Some(&output_path)).unwrap();
+    assert_eq!(result.path, output_path);
+    assert!(output_path.exists());
+}
+
+#[test]
+fn backup_fails_for_nonexistent_db() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("nonexistent.db");
+
+    let err = mokumo_api::cli_backup(&db_path, None).unwrap_err();
+    assert!(
+        err.contains("not found"),
+        "expected 'not found', got: {err}"
+    );
+}

--- a/services/api/tests/cli_backup_restore_binary.rs
+++ b/services/api/tests/cli_backup_restore_binary.rs
@@ -1,0 +1,295 @@
+//! Binary-level integration tests for `mokumo-api backup` and `mokumo-api restore`.
+//!
+//! Tests the actual binary CLI parsing and output formatting. Also verifies
+//! that `restore` is blocked by a running server's flock guard.
+
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// RAII guard that kills the server child process on drop.
+struct ServerGuard {
+    child: Child,
+}
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn strip_ansi(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut in_escape = false;
+    for c in s.chars() {
+        if in_escape {
+            if c.is_ascii() && (0x40u8..=0x7Eu8).contains(&(c as u8)) {
+                in_escape = false;
+            }
+        } else if c == '\x1b' {
+            in_escape = true;
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+fn parse_port_from_log(line: &str) -> Option<u16> {
+    let clean = strip_ansi(line);
+    if !clean.contains("Listening on") {
+        return None;
+    }
+    let port_str = clean.rsplit(':').next()?;
+    port_str.trim().parse().ok()
+}
+
+async fn wait_for_health(port: u16, timeout: Duration) -> Result<(), String> {
+    let start = Instant::now();
+    let url = format!("http://127.0.0.1:{port}/api/health");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .unwrap();
+
+    loop {
+        if start.elapsed() > timeout {
+            return Err(format!("Server did not become healthy within {timeout:?}"));
+        }
+
+        match client.get(&url).send().await {
+            Ok(resp) if resp.status().is_success() => return Ok(()),
+            _ => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    }
+}
+
+fn create_test_db(path: &Path) {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+         INSERT INTO test (name) VALUES ('alice');",
+    )
+    .unwrap();
+}
+
+// ── backup binary tests ───────────────────────────────────────────────────
+
+#[test]
+fn backup_binary_prints_path_and_size() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+    let db_path = data_dir.join("demo").join("mokumo.db");
+    create_test_db(&db_path);
+
+    let output = Command::new(binary)
+        .args(["--data-dir", data_dir.to_str().unwrap(), "backup"])
+        .output()
+        .expect("failed to spawn backup");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "backup should succeed, got exit {}: stderr={stderr}",
+        output.status
+    );
+    assert!(
+        stdout.contains("Backup created:"),
+        "stdout should contain backup path, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Size:"),
+        "stdout should contain size, got: {stdout}"
+    );
+}
+
+#[test]
+fn backup_binary_with_custom_output() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+    let output_path = tmp.path().join("custom-backup.db");
+
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+    let db_path = data_dir.join("demo").join("mokumo.db");
+    create_test_db(&db_path);
+
+    let output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "backup",
+            "--output",
+            output_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn backup");
+
+    assert!(output.status.success());
+    assert!(output_path.exists(), "custom output file should exist");
+}
+
+#[test]
+fn backup_binary_fails_for_missing_db() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+    // No database created
+
+    let output = Command::new(binary)
+        .args(["--data-dir", data_dir.to_str().unwrap(), "backup"])
+        .output()
+        .expect("failed to spawn backup");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No database found"),
+        "stderr should mention missing database, got: {stderr}"
+    );
+}
+
+// ── restore binary tests ──────────────────────────────────────────────────
+
+#[test]
+fn restore_binary_prints_confirmation() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path();
+
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+    let db_path = data_dir.join("demo").join("mokumo.db");
+    create_test_db(&db_path);
+
+    // Create a backup to restore from
+    let backup_path = tmp.path().join("backup.db");
+    create_test_db(&backup_path);
+
+    let output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "restore",
+            backup_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn restore");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "restore should succeed, got exit {}: stderr={stderr}",
+        output.status
+    );
+    assert!(
+        stdout.contains("Restored from:"),
+        "stdout should contain restore confirmation, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Restore complete"),
+        "stdout should contain completion message, got: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn restore_blocked_by_running_server() {
+    let binary = env!("CARGO_BIN_EXE_mokumo-api");
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().to_path_buf();
+
+    mokumo_api::ensure_data_dirs(&data_dir).unwrap();
+
+    // Initialize a real database so the server can start
+    let db_path = data_dir.join("demo").join("mokumo.db");
+    let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    let db = mokumo_db::initialize_database(&database_url).await.unwrap();
+    db.close().await.ok();
+
+    // Create a backup file to try restoring
+    let backup_path = data_dir.join("backup.db");
+    create_test_db(&backup_path);
+
+    // Spawn the server
+    let mut server_proc = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "--port",
+            "0",
+            "--host",
+            "127.0.0.1",
+        ])
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn server");
+
+    let stderr = server_proc.stderr.take().expect("stderr not captured");
+    let stdout = server_proc.stdout.take().expect("stdout not captured");
+    let guard = ServerGuard { child: server_proc };
+
+    let (port_tx, port_rx) = std::sync::mpsc::channel();
+    let port_tx_clone = port_tx.clone();
+    let stdout_thread = std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines().map_while(Result::ok) {
+            if let Some(port) = parse_port_from_log(&line) {
+                let _ = port_tx_clone.send(port);
+            }
+        }
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            if let Some(port) = parse_port_from_log(&line) {
+                let _ = port_tx.send(port);
+            }
+        }
+    });
+
+    let port = port_rx
+        .recv_timeout(Duration::from_secs(30))
+        .expect("server did not report its port within 30s");
+
+    wait_for_health(port, Duration::from_secs(10))
+        .await
+        .expect("server health check failed");
+
+    // Try restore while server is running — should be blocked
+    let restore_output = Command::new(binary)
+        .args([
+            "--data-dir",
+            data_dir.to_str().unwrap(),
+            "restore",
+            backup_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn restore");
+
+    let restore_stderr = String::from_utf8_lossy(&restore_output.stderr);
+
+    assert!(
+        !restore_output.status.success(),
+        "restore should have failed, but succeeded. stderr: {restore_stderr}"
+    );
+    assert!(
+        restore_stderr.contains("in use by a running server"),
+        "stderr should contain the flock rejection message, got: {restore_stderr}"
+    );
+
+    drop(guard);
+    let _ = stdout_thread.join();
+    let _ = stderr_thread.join();
+}

--- a/services/api/tests/cli_restore.rs
+++ b/services/api/tests/cli_restore.rs
@@ -1,0 +1,69 @@
+//! Integration tests for the `mokumo-api restore` CLI subcommand.
+
+use std::path::Path;
+use tempfile::tempdir;
+
+/// Helper: create a minimal valid SQLite database at the given path.
+fn create_test_db(path: &Path) {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+         INSERT INTO test (name) VALUES ('alice');
+         INSERT INTO test (name) VALUES ('bob');",
+    )
+    .unwrap();
+}
+
+/// Helper: count rows in the test table.
+fn count_rows(path: &Path) -> i64 {
+    let conn =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .unwrap();
+    conn.query_row("SELECT COUNT(*) FROM test", [], |row| row.get(0))
+        .unwrap()
+}
+
+#[test]
+fn restore_replaces_database() {
+    let tmp = tempdir().unwrap();
+    let data_dir = tmp.path();
+    mokumo_api::ensure_data_dirs(data_dir).unwrap();
+
+    let db_path = data_dir.join("demo").join("mokumo.db");
+    let backup_path = tmp.path().join("backup.db");
+
+    // Original DB with 2 rows
+    create_test_db(&db_path);
+    assert_eq!(count_rows(&db_path), 2);
+
+    // Backup with 1 row
+    {
+        let conn = rusqlite::Connection::open(&backup_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);
+             INSERT INTO test (name) VALUES ('restored');",
+        )
+        .unwrap();
+    }
+
+    let result = mokumo_api::cli_restore(&db_path, &backup_path).unwrap();
+    assert_eq!(count_rows(&db_path), 1);
+    let safety_path = result
+        .safety_backup_path
+        .expect("safety backup should exist");
+    assert!(safety_path.exists());
+    assert_eq!(count_rows(&safety_path), 2);
+}
+
+#[test]
+fn restore_fails_for_nonexistent_backup() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("mokumo.db");
+    let backup_path = tmp.path().join("nonexistent.db");
+
+    let err = mokumo_api::cli_restore(&db_path, &backup_path).unwrap_err();
+    assert!(
+        err.contains("not found"),
+        "expected 'not found', got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `mokumo backup` CLI subcommand that creates a manual database backup using the SQLite Online Backup API, with optional `--output <path>`, integrity verification via `PRAGMA integrity_check`, and path + size output. Safe to run while the server is active.
- Add `mokumo restore <path>` CLI subcommand that restores from a backup file with integrity verification, safety backup of the current database, WAL sidecar cleanup, and process lock check (refuses when server is running).
- Both commands support `--production` flag for profile targeting, following the established `reset-db` pattern.

Closes #403
Closes #404

## Implementation

- Core logic in `crates/db/src/backup.rs` — reuses the existing `rusqlite::backup::Backup` pattern from `pre_migration_backup()` with larger page steps (100 vs 5) for CLI use
- CLI wiring follows the established `ResetDb`/`ResetPassword` pattern in `services/api/src/main.rs`
- No new dependencies — all crates (rusqlite with backup feature, fd-lock, chrono, clap) already in workspace

## Test plan

- [x] 10 unit tests in `crates/db/src/backup.rs` (create_backup, verify_integrity, restore_from_backup, edge cases)
- [x] 5 integration tests in `services/api/tests/cli_backup.rs` and `cli_restore.rs` (library-level)
- [x] 5 binary integration tests in `services/api/tests/cli_backup_restore_binary.rs` (real binary, flock guard rejection)
- [x] 263 existing tests still pass (1 pre-existing skip: `try_bind_short_circuits_on_permission_error`)
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `mokumo backup`: Create manual SQLite backups with configurable output, integrity verification, and reporting of backup path and size; allowed while the server is running.
  * `mokumo restore <path>`: Restore from a backup with prior integrity checks, automatic safety backup of the current DB, sidecar cleanup, and blocked when the server is active.
* **Tests**
  * Added integration and binary-level tests covering backup, restore, error cases, and blocking restore while the server runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->