### PR TITLE
feat(db): add auto_vacuum + mmap_size SQLite PRAGMAs (#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Version CLI**: `mokumo --version` prints the version string; `mokumo version` prints extended build info including git hash, build date, target platform, and Rust version. (#405)
 - **`mokumo backup` CLI subcommand** creates a manual database backup using the SQLite Online Backup API. Supports `--output <path>` for custom location, verifies integrity with `PRAGMA integrity_check`, and prints path + size on success. Safe to run while the server is running. (#403)
 - **`mokumo restore <path>` CLI subcommand** restores the database from a backup file. Verifies backup integrity before restoring, creates a safety backup of the current database, removes WAL sidecars, and refuses to run while the server is active (process lock check). (#404)
+- **SQLite `auto_vacuum = INCREMENTAL`** PRAGMA with automatic upgrade of existing databases via one-time `VACUUM`. Ensures database files shrink after row deletions. (#424)
+- **SQLite `mmap_size = 268435456`** (256 MB) PRAGMA for read performance via memory-mapped I/O. (#424)
+- **`mokumo doctor` CLI subcommand** with `--fix` flag for database maintenance — reports auto_vacuum status, freelist fragmentation, and reclaims free pages on demand. (#424)
 - **HTTP security headers**: every response now includes `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 0`, and `Referrer-Policy: strict-origin-when-cross-origin`. `Strict-Transport-Security` is set conditionally when behind Cloudflare Tunnel. (#380)
 - **Branded error page** shows the Mokumo logo, status code, and human-readable message for 400/401/403/404/5xx errors with navigation back to the dashboard.
 - **Routing contract tests** verify unknown `/api/*` paths return JSON 404 and wrong HTTP methods return JSON 405 instead of silently serving SPA HTML. (#384)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -38,7 +38,7 @@ fn configure_sqlite_connection(
             .await?;
         // 256 MB memory-mapped I/O for read performance. Per-connection PRAGMA.
         // Caveat: on Windows, mmap prevents file truncation which makes
-        // incremental_vacuum unable to shrink the file. See follow-up issue.
+        // incremental_vacuum unable to shrink the file. See #457.
         sqlx::query("PRAGMA mmap_size=268435456")
             .execute(&mut *conn)
             .await?;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -36,6 +36,12 @@ fn configure_sqlite_connection(
         sqlx::query("PRAGMA cache_size=-64000")
             .execute(&mut *conn)
             .await?;
+        // 256 MB memory-mapped I/O for read performance. Per-connection PRAGMA.
+        // Caveat: on Windows, mmap prevents file truncation which makes
+        // incremental_vacuum unable to shrink the file. See follow-up issue.
+        sqlx::query("PRAGMA mmap_size=268435456")
+            .execute(&mut *conn)
+            .await?;
         Ok(())
     })
 }
@@ -443,6 +449,80 @@ pub fn check_schema_compatibility(db_path: &std::path::Path) -> Result<(), Datab
             unknown,
         ))
     }
+}
+
+/// Ensure `auto_vacuum = INCREMENTAL` is enabled on a database file.
+///
+/// `auto_vacuum` is a schema-level PRAGMA stored in the database file header.
+/// It cannot be reliably set via a connection pool's `after_connect` hook because
+/// the file header is written when the connection is first established. This
+/// function handles both new and existing databases:
+///
+/// - **New database** (file does not exist): creates the file via rusqlite and
+///   sets `auto_vacuum = INCREMENTAL` before any tables are created.
+/// - **Existing database with `auto_vacuum = 0`** (NONE): sets the PRAGMA and
+///   runs a one-time `VACUUM` to restructure the file.
+/// - **Existing database with `auto_vacuum = 1` or `2`**: no-op.
+///
+/// Uses a raw `rusqlite::Connection` (pre-pool) for the same reason as
+/// `check_application_id`: no pool resources should be allocated until the
+/// database file is structurally ready.
+///
+/// # Important
+/// Call this AFTER `pre_migration_backup` (for existing DBs, the VACUUM rewrites
+/// the file) and BEFORE `initialize_database`. The caller should wrap this in
+/// `tokio::task::spawn_blocking` since `VACUUM` is heavyweight blocking I/O.
+pub fn ensure_auto_vacuum(db_path: &std::path::Path) -> Result<(), DatabaseSetupError> {
+    if !db_path.exists() {
+        // Fresh install: create the file and set auto_vacuum before any tables.
+        // The file is closed immediately — initialize_database opens the pool next.
+        let conn = rusqlite::Connection::open(db_path)?;
+        conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL")?;
+        tracing::info!(
+            "Created new database with auto_vacuum=INCREMENTAL at {}",
+            db_path.display()
+        );
+        drop(conn);
+        return Ok(());
+    }
+
+    let conn = rusqlite::Connection::open(db_path)?;
+    let current: i32 = conn.query_row("PRAGMA auto_vacuum", [], |row| row.get(0))?;
+
+    match current {
+        0 => {
+            // NONE → INCREMENTAL: requires VACUUM to restructure the file.
+            tracing::info!(
+                "Upgrading auto_vacuum from NONE to INCREMENTAL on {}; running one-time VACUUM",
+                db_path.display()
+            );
+            conn.execute_batch("PRAGMA auto_vacuum = 2; VACUUM;")?;
+            tracing::info!("VACUUM complete for {}", db_path.display());
+        }
+        1 => {
+            // FULL — already tracking free pages. No VACUUM needed.
+            tracing::debug!(
+                "auto_vacuum is FULL on {}, no upgrade needed",
+                db_path.display()
+            );
+        }
+        2 => {
+            // INCREMENTAL — already set.
+            tracing::debug!(
+                "auto_vacuum is already INCREMENTAL on {}",
+                db_path.display()
+            );
+        }
+        other => {
+            tracing::warn!(
+                "Unexpected auto_vacuum value {other} on {}; skipping upgrade",
+                db_path.display()
+            );
+        }
+    }
+
+    drop(conn);
+    Ok(())
 }
 
 /// Open a raw SQLite connection pool with the same PRAGMAs as `initialize_database`.

--- a/crates/db/tests/database_init.rs
+++ b/crates/db/tests/database_init.rs
@@ -1,4 +1,4 @@
-use mokumo_db::initialize_database;
+use mokumo_db::{ensure_auto_vacuum, initialize_database};
 use sqlx::Row;
 
 #[tokio::test]
@@ -7,6 +7,9 @@ async fn pragmas_are_set_correctly() {
     let db_path = dir.path().join("test.db");
     let url = format!("sqlite:{}?mode=rwc", db_path.display());
 
+    // ensure_auto_vacuum must run before pool creation (auto_vacuum is a
+    // file-header PRAGMA, not a per-connection PRAGMA).
+    ensure_auto_vacuum(&db_path).unwrap();
     let db = initialize_database(&url).await.unwrap();
     let pool = db.get_sqlite_connection_pool();
 
@@ -45,6 +48,20 @@ async fn pragmas_are_set_correctly() {
         .get(0);
     assert_eq!(cache_size, -64000);
 
+    let auto_vacuum: i32 = sqlx::query("PRAGMA auto_vacuum")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(auto_vacuum, 2); // INCREMENTAL
+
+    let mmap_size: i64 = sqlx::query("PRAGMA mmap_size")
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(mmap_size, 268_435_456); // 256 MB
+
     drop(db);
 }
 
@@ -55,9 +72,11 @@ async fn database_creation_is_idempotent() {
     let url = format!("sqlite:{}?mode=rwc", db_path.display());
 
     // First initialization
+    ensure_auto_vacuum(&db_path).unwrap();
     let db1 = initialize_database(&url).await.unwrap();
     drop(db1);
 
     // Second initialization on same file
+    ensure_auto_vacuum(&db_path).unwrap();
     let _db2 = initialize_database(&url).await.unwrap();
 }

--- a/crates/db/tests/startup_guards.rs
+++ b/crates/db/tests/startup_guards.rs
@@ -423,7 +423,7 @@ fn ensure_auto_vacuum_fails_on_read_only_db() {
     let result = ensure_auto_vacuum(&db_path);
     assert!(
         result.is_err(),
-        "Read-only database should return an error when VACUUM is needed"
+        "Read-only database should return an error (cannot open for write)"
     );
 
     // Restore permissions for cleanup

--- a/crates/db/tests/startup_guards.rs
+++ b/crates/db/tests/startup_guards.rs
@@ -307,11 +307,16 @@ fn ensure_auto_vacuum_enables_on_existing_db() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.db");
 
-    // Create a database with auto_vacuum = NONE (default)
+    // Create a database with auto_vacuum = NONE (default) and insert data
     {
         let conn = rusqlite::Connection::open(&db_path).unwrap();
-        conn.execute_batch("CREATE TABLE dummy (id INTEGER PRIMARY KEY)")
+        conn.execute_batch("CREATE TABLE dummy (id INTEGER PRIMARY KEY, name TEXT)")
             .unwrap();
+        conn.execute(
+            "INSERT INTO dummy (id, name) VALUES (1, 'survive_vacuum')",
+            [],
+        )
+        .unwrap();
         let av: i32 = conn
             .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
             .unwrap();
@@ -320,12 +325,20 @@ fn ensure_auto_vacuum_enables_on_existing_db() {
 
     ensure_auto_vacuum(&db_path).unwrap();
 
-    // Verify auto_vacuum is now INCREMENTAL
+    // Verify auto_vacuum is now INCREMENTAL and data survived the VACUUM
     let conn = rusqlite::Connection::open(&db_path).unwrap();
     let av: i32 = conn
         .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
         .unwrap();
     assert_eq!(av, 2, "auto_vacuum should be INCREMENTAL after guard");
+
+    let name: String = conn
+        .query_row("SELECT name FROM dummy WHERE id = 1", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        name, "survive_vacuum",
+        "data must survive VACUUM during auto_vacuum upgrade"
+    );
 }
 
 #[test]

--- a/crates/db/tests/startup_guards.rs
+++ b/crates/db/tests/startup_guards.rs
@@ -8,7 +8,9 @@
 /// - PRAGMA user_version stamped correctly after full migration run
 /// - PRAGMA application_id stamped correctly after full migration run
 /// - All migrations return use_transaction() == Some(true)
-use mokumo_db::{check_application_id, check_schema_compatibility, initialize_database};
+use mokumo_db::{
+    check_application_id, check_schema_compatibility, ensure_auto_vacuum, initialize_database,
+};
 use sea_orm_migration::MigratorTrait as _;
 
 // ─── check_application_id ───────────────────────���────────────────────────────
@@ -282,6 +284,140 @@ async fn migrations_run_successfully_with_spaces_in_path() {
 }
 
 // ─── Migration quality assertions ──────────────────────────────��─────────────
+
+// ─── ensure_auto_vacuum ──────────────────────────────────────────────────��──
+
+#[test]
+fn ensure_auto_vacuum_creates_new_db_with_incremental() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("new.db");
+
+    ensure_auto_vacuum(&db_path).unwrap();
+
+    assert!(db_path.exists(), "file should be created for new database");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let av: i32 = conn
+        .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(av, 2, "new database should have auto_vacuum=INCREMENTAL");
+}
+
+#[test]
+fn ensure_auto_vacuum_enables_on_existing_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Create a database with auto_vacuum = NONE (default)
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE dummy (id INTEGER PRIMARY KEY)")
+            .unwrap();
+        let av: i32 = conn
+            .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(av, 0, "precondition: auto_vacuum should be NONE");
+    }
+
+    ensure_auto_vacuum(&db_path).unwrap();
+
+    // Verify auto_vacuum is now INCREMENTAL
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let av: i32 = conn
+        .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(av, 2, "auto_vacuum should be INCREMENTAL after guard");
+}
+
+#[test]
+fn ensure_auto_vacuum_noop_when_already_incremental() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Create a database with auto_vacuum = INCREMENTAL from the start
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA auto_vacuum = INCREMENTAL")
+            .unwrap();
+        conn.execute_batch("CREATE TABLE dummy (id INTEGER PRIMARY KEY)")
+            .unwrap();
+    }
+
+    assert!(
+        ensure_auto_vacuum(&db_path).is_ok(),
+        "Should succeed without error when already INCREMENTAL"
+    );
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let av: i32 = conn
+        .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(av, 2, "auto_vacuum should remain INCREMENTAL");
+}
+
+#[test]
+fn ensure_auto_vacuum_noop_when_full() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+
+    // Create a database with auto_vacuum = FULL
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA auto_vacuum = FULL").unwrap();
+        conn.execute_batch("CREATE TABLE dummy (id INTEGER PRIMARY KEY)")
+            .unwrap();
+    }
+
+    assert!(
+        ensure_auto_vacuum(&db_path).is_ok(),
+        "Should succeed without error when FULL"
+    );
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let av: i32 = conn
+        .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(av, 1, "auto_vacuum should remain FULL (no VACUUM needed)");
+}
+
+#[test]
+fn ensure_auto_vacuum_fails_on_corrupt_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("corrupt.db");
+
+    // Write garbage to simulate a corrupt database file
+    std::fs::write(&db_path, b"this is not a sqlite database").unwrap();
+
+    let result = ensure_auto_vacuum(&db_path);
+    assert!(result.is_err(), "Corrupt database should return an error");
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_auto_vacuum_fails_on_read_only_db() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("readonly.db");
+
+    // Create a valid database, then make it read-only
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch("CREATE TABLE dummy (id INTEGER PRIMARY KEY)")
+            .unwrap();
+    }
+    std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+    let result = ensure_auto_vacuum(&db_path);
+    assert!(
+        result.is_err(),
+        "Read-only database should return an error when VACUUM is needed"
+    );
+
+    // Restore permissions for cleanup
+    std::fs::set_permissions(&db_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+}
+
+// ─── Migration quality assertions ────────────────────────────────────────────
 
 #[test]
 fn all_migrations_use_transaction_returns_some_true() {

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -309,11 +309,34 @@ pub async fn prepare_database(
 /// Guards run in order:
 ///   1. `check_application_id` (pre-pool; only if DB file exists)
 ///   2. `pre_migration_backup` (only if DB file exists)
+///   2b. `ensure_auto_vacuum` (pre-pool; creates file for new DBs, VACUUMs existing ones)
 ///   3. `check_schema_compatibility` (pre-pool; only if DB file exists)
 ///      - If demo profile is incompatible: silently recreate from sidecar and continue.
 ///      - If production profile is incompatible: hard abort with actionable message.
 ///   4. `initialize_database` (pool + migrations)
 ///
+/// Run `ensure_auto_vacuum` on a blocking thread and convert errors to `ProfileDbError`.
+async fn run_auto_vacuum_guard(
+    db_path: &Path,
+    backup_path: Option<std::path::PathBuf>,
+) -> Result<(), ProfileDbError> {
+    let db_path_owned = db_path.to_path_buf();
+    let display = db_path.display().to_string();
+    tokio::task::spawn_blocking(move || mokumo_db::ensure_auto_vacuum(&db_path_owned))
+        .await
+        .map_err(|e| ProfileDbError {
+            message: format!("auto_vacuum guard panicked for {display}: {e}"),
+            backup_path: backup_path.clone(),
+        })?
+        .map_err(|e| ProfileDbError {
+            message: format!(
+                "Failed to enable auto_vacuum on {display}: {e}. \
+                 Check disk space (VACUUM requires ~2x database size).",
+            ),
+            backup_path,
+        })
+}
+
 /// Returns a human-readable error string on failure (technical detail sent to tracing).
 async fn setup_profile_db(
     db_path: &Path,
@@ -357,6 +380,9 @@ async fn setup_profile_db(
                 ),
                 backup_path: None,
             })?;
+
+        // Guard 2b: ensure auto_vacuum = INCREMENTAL (one-time VACUUM if needed)
+        run_auto_vacuum_guard(db_path, backup_path.clone()).await?;
 
         // Guard 3: reject databases from newer Mokumo versions
         match mokumo_db::check_schema_compatibility(db_path) {
@@ -416,6 +442,8 @@ async fn setup_profile_db(
                                 ),
                                 backup_path: None,
                             })?;
+                    // Guard 2b on sidecar: ensure auto_vacuum
+                    run_auto_vacuum_guard(db_path, None).await?;
                     if let Err(e) = mokumo_db::check_schema_compatibility(db_path) {
                         return Err(ProfileDbError {
                             message: format!(
@@ -443,6 +471,9 @@ async fn setup_profile_db(
                 });
             }
         }
+    } else {
+        // New database: ensure auto_vacuum is set before pool creation
+        run_auto_vacuum_guard(db_path, None).await?;
     }
 
     // Guard 4: initialize pool + run migrations

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -309,11 +309,11 @@ pub async fn prepare_database(
 /// Guards run in order:
 ///   1. `check_application_id` (pre-pool; only if DB file exists)
 ///   2. `pre_migration_backup` (only if DB file exists)
-///   2b. `ensure_auto_vacuum` (pre-pool; creates file for new DBs, VACUUMs existing ones)
-///   3. `check_schema_compatibility` (pre-pool; only if DB file exists)
+///   3. `ensure_auto_vacuum` (pre-pool; creates file for new DBs, VACUUMs existing ones)
+///   4. `check_schema_compatibility` (pre-pool; only if DB file exists)
 ///      - If demo profile is incompatible: silently recreate from sidecar and continue.
 ///      - If production profile is incompatible: hard abort with actionable message.
-///   4. `initialize_database` (pool + migrations)
+///   5. `initialize_database` (pool + migrations)
 ///
 /// Run `ensure_auto_vacuum` on a blocking thread and convert errors to `ProfileDbError`.
 async fn run_auto_vacuum_guard(

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -133,7 +133,7 @@ async fn main() {
     let data_dir = cli.data_dir.unwrap_or_else(resolve_default_data_dir);
 
     /// Resolve the profile directory for a --production flag.
-    fn profile_dir(data_dir: &PathBuf, production: bool) -> PathBuf {
+    fn profile_dir(data_dir: &std::path::Path, production: bool) -> PathBuf {
         let mode = if production {
             SetupMode::Production
         } else {
@@ -161,6 +161,61 @@ async fn main() {
                 std::process::exit(1);
             }
 
+            // Acquire process lock when --fix is requested to prevent concurrent
+            // access with a running server (VACUUM + incremental_vacuum are unsafe
+            // with concurrent writers).
+            if fix {
+                let lock_path = lock_file_path(&data_dir);
+                let mut flock = match std::fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(false)
+                    .read(true)
+                    .write(true)
+                    .open(&lock_path)
+                {
+                    Ok(f) => fd_lock::RwLock::new(f),
+                    Err(e) => {
+                        eprintln!("Cannot open lock file {}: {e}", lock_path.display());
+                        std::process::exit(1);
+                    }
+                };
+                if let Err(e) = flock.try_write() {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                        eprintln!(
+                            "The database appears to be in use by a running server.\n\
+                             Stop the server first, then try again with --fix."
+                        );
+                    } else {
+                        eprintln!("Cannot acquire process lock: {e}");
+                    }
+                    std::process::exit(1);
+                }
+                // Lock is verified and immediately released — we only need to check
+                // that no server is running. The doctor command is short-lived and
+                // the flock is advisory; holding it through the entire operation
+                // would require restructuring the control flow. The check-then-act
+                // window is acceptable for a CLI maintenance tool.
+            }
+
+            /// Query a PRAGMA value, exiting with an error message on failure.
+            fn query_pragma<T: rusqlite::types::FromSql>(
+                conn: &rusqlite::Connection,
+                pragma: &str,
+                db_path: &std::path::Path,
+            ) -> T {
+                match conn.query_row(&format!("PRAGMA {pragma}"), [], |row| row.get(0)) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!(
+                            "Failed to read PRAGMA {pragma} from {}: {e}\n\
+                             The database file may be corrupt or locked by another process.",
+                            db_path.display()
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            }
+
             // TODO: If a second consumer (Tauri, API endpoint) needs these diagnostics,
             // extract the query logic to crates/db/ as pub fn diagnose_database().
             let conn = match rusqlite::Connection::open(&db_path) {
@@ -171,18 +226,10 @@ async fn main() {
                 }
             };
 
-            let auto_vacuum: i32 = conn
-                .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
-                .unwrap_or(-1);
-            let freelist_count: i64 = conn
-                .query_row("PRAGMA freelist_count", [], |row| row.get(0))
-                .unwrap_or(0);
-            let page_count: i64 = conn
-                .query_row("PRAGMA page_count", [], |row| row.get(0))
-                .unwrap_or(0);
-            let page_size: i64 = conn
-                .query_row("PRAGMA page_size", [], |row| row.get(0))
-                .unwrap_or(4096);
+            let auto_vacuum: i32 = query_pragma(&conn, "auto_vacuum", &db_path);
+            let freelist_count: i64 = query_pragma(&conn, "freelist_count", &db_path);
+            let page_count: i64 = query_pragma(&conn, "page_count", &db_path);
+            let page_size: i64 = query_pragma(&conn, "page_size", &db_path);
 
             let auto_vacuum_label = match auto_vacuum {
                 0 => "NONE",
@@ -226,7 +273,14 @@ async fn main() {
 
             if fix {
                 println!();
-                if auto_vacuum != 2 {
+
+                // ensure_auto_vacuum opens its own connection and may run VACUUM,
+                // which rewrites the file. Drop our connection first, then reopen
+                // afterward so subsequent queries see the post-VACUUM state.
+                let needs_vacuum_upgrade = auto_vacuum != 2;
+                drop(conn);
+
+                if needs_vacuum_upgrade {
                     println!("  Enabling auto_vacuum = INCREMENTAL...");
                     match mokumo_db::ensure_auto_vacuum(&db_path) {
                         Ok(()) => println!("  auto_vacuum upgraded successfully."),
@@ -237,16 +291,25 @@ async fn main() {
                     }
                 }
 
-                if freelist_count > 0 {
+                // Reopen connection to get a fresh view after potential VACUUM
+                let conn = match rusqlite::Connection::open(&db_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("Cannot reopen database after fixes: {e}");
+                        std::process::exit(1);
+                    }
+                };
+
+                let current_freelist: i64 = query_pragma(&conn, "freelist_count", &db_path);
+
+                if current_freelist > 0 {
                     println!(
-                        "  Running incremental_vacuum (reclaiming {freelist_count} free pages)..."
+                        "  Running incremental_vacuum (reclaiming {current_freelist} free pages)..."
                     );
                     match conn.execute_batch("PRAGMA incremental_vacuum") {
                         Ok(()) => {
-                            let remaining: i64 = conn
-                                .query_row("PRAGMA freelist_count", [], |row| row.get(0))
-                                .unwrap_or(0);
-                            let reclaimed = freelist_count - remaining;
+                            let remaining: i64 = query_pragma(&conn, "freelist_count", &db_path);
+                            let reclaimed = current_freelist - remaining;
                             println!(
                                 "  Reclaimed {reclaimed} pages ({} KB).",
                                 reclaimed * page_size / 1024
@@ -261,14 +324,16 @@ async fn main() {
                     println!("  No free pages to reclaim.");
                 }
 
+                drop(conn);
                 println!("\n  Doctor complete (fixes applied).");
             } else if issues_found {
+                drop(conn);
                 println!("\n  Run with --fix to attempt repairs.");
             } else {
+                drop(conn);
                 println!("\n  All checks passed.");
             }
 
-            drop(conn);
             return;
         }
         Some(Commands::ResetPassword { email }) => {

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -45,6 +45,15 @@ enum Commands {
         #[arg(long)]
         email: String,
     },
+    /// Run database health checks and optional maintenance
+    Doctor {
+        /// Attempt automatic repairs (incremental vacuum, enable auto_vacuum)
+        #[arg(long)]
+        fix: bool,
+        /// Reset the production profile instead of the default demo profile.
+        #[arg(long)]
+        production: bool,
+    },
     /// Delete the database and start fresh (dev/testing)
     ResetDb {
         /// Skip the confirmation prompt
@@ -123,10 +132,143 @@ async fn main() {
 
     let data_dir = cli.data_dir.unwrap_or_else(resolve_default_data_dir);
 
+    /// Resolve the profile directory for a --production flag.
+    fn profile_dir(data_dir: &PathBuf, production: bool) -> PathBuf {
+        let mode = if production {
+            SetupMode::Production
+        } else {
+            SetupMode::Demo
+        };
+        data_dir.join(mode.as_dir_name())
+    }
+
     // Handle subcommands before server startup
     match cli.command {
         Some(Commands::Version) => {
             println!("mokumo {}", long_version());
+            return;
+        }
+        Some(Commands::Doctor { fix, production }) => {
+            let profile_dir = profile_dir(&data_dir, production);
+            let db_path = profile_dir.join("mokumo.db");
+
+            if !db_path.exists() {
+                let mode = if production { "production" } else { "demo" };
+                eprintln!(
+                    "No database found for the {mode} profile at {}",
+                    db_path.display()
+                );
+                std::process::exit(1);
+            }
+
+            // TODO: If a second consumer (Tauri, API endpoint) needs these diagnostics,
+            // extract the query logic to crates/db/ as pub fn diagnose_database().
+            let conn = match rusqlite::Connection::open(&db_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("Cannot open database at {}: {e}", db_path.display());
+                    std::process::exit(1);
+                }
+            };
+
+            let auto_vacuum: i32 = conn
+                .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+                .unwrap_or(-1);
+            let freelist_count: i64 = conn
+                .query_row("PRAGMA freelist_count", [], |row| row.get(0))
+                .unwrap_or(0);
+            let page_count: i64 = conn
+                .query_row("PRAGMA page_count", [], |row| row.get(0))
+                .unwrap_or(0);
+            let page_size: i64 = conn
+                .query_row("PRAGMA page_size", [], |row| row.get(0))
+                .unwrap_or(4096);
+
+            let auto_vacuum_label = match auto_vacuum {
+                0 => "NONE",
+                1 => "FULL",
+                2 => "INCREMENTAL",
+                _ => "UNKNOWN",
+            };
+
+            let db_size_bytes = page_count * page_size;
+            let freelist_bytes = freelist_count * page_size;
+            let fragmentation_pct = if page_count > 0 {
+                (freelist_count as f64 / page_count as f64) * 100.0
+            } else {
+                0.0
+            };
+
+            println!("Database: {}", db_path.display());
+            println!("  auto_vacuum:  {auto_vacuum_label} ({auto_vacuum})");
+            println!("  page_size:    {page_size} bytes");
+            println!("  page_count:   {page_count} ({} KB)", db_size_bytes / 1024);
+            println!(
+                "  freelist:     {freelist_count} pages ({} KB, {fragmentation_pct:.1}%)",
+                freelist_bytes / 1024
+            );
+
+            let mut issues_found = false;
+
+            if auto_vacuum != 2 {
+                println!(
+                    "\n  [WARN] auto_vacuum is not INCREMENTAL — database file will not shrink after deletions"
+                );
+                issues_found = true;
+            }
+
+            if fragmentation_pct > 10.0 {
+                println!(
+                    "\n  [WARN] freelist is {fragmentation_pct:.1}% of total pages — consider running with --fix"
+                );
+                issues_found = true;
+            }
+
+            if fix {
+                println!();
+                if auto_vacuum != 2 {
+                    println!("  Enabling auto_vacuum = INCREMENTAL...");
+                    match mokumo_db::ensure_auto_vacuum(&db_path) {
+                        Ok(()) => println!("  auto_vacuum upgraded successfully."),
+                        Err(e) => {
+                            eprintln!("  Failed to enable auto_vacuum: {e}");
+                            std::process::exit(1);
+                        }
+                    }
+                }
+
+                if freelist_count > 0 {
+                    println!(
+                        "  Running incremental_vacuum (reclaiming {freelist_count} free pages)..."
+                    );
+                    match conn.execute_batch("PRAGMA incremental_vacuum") {
+                        Ok(()) => {
+                            let remaining: i64 = conn
+                                .query_row("PRAGMA freelist_count", [], |row| row.get(0))
+                                .unwrap_or(0);
+                            let reclaimed = freelist_count - remaining;
+                            println!(
+                                "  Reclaimed {reclaimed} pages ({} KB).",
+                                reclaimed * page_size / 1024
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("  incremental_vacuum failed: {e}");
+                            std::process::exit(1);
+                        }
+                    }
+                } else {
+                    println!("  No free pages to reclaim.");
+                }
+
+                println!("\n  Doctor complete (fixes applied).");
+            } else if issues_found {
+                println!("\n  Run with --fix to attempt repairs.");
+            } else {
+                println!("\n  All checks passed.");
+            }
+
+            drop(conn);
             return;
         }
         Some(Commands::ResetPassword { email }) => {
@@ -164,13 +306,7 @@ async fn main() {
             include_backups,
             production,
         }) => {
-            // Determine which profile to target.
-            // Default: demo (safe). Production requires explicit --production flag.
-            let profile_dir = if production {
-                data_dir.join(SetupMode::Production.as_dir_name())
-            } else {
-                data_dir.join(SetupMode::Demo.as_dir_name())
-            };
+            let profile_dir = profile_dir(&data_dir, production);
             let db_path = profile_dir.join("mokumo.db");
 
             // Ensure data directories exist so the lock file can be created if needed.

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -163,10 +163,12 @@ async fn main() {
 
             // Acquire process lock when --fix is requested to prevent concurrent
             // access with a running server (VACUUM + incremental_vacuum are unsafe
-            // with concurrent writers).
+            // with concurrent writers). The lock is held for the entire Doctor arm.
+            let mut _flock_storage;
+            let _lock_guard;
             if fix {
                 let lock_path = lock_file_path(&data_dir);
-                let mut flock = match std::fs::OpenOptions::new()
+                _flock_storage = match std::fs::OpenOptions::new()
                     .create(true)
                     .truncate(false)
                     .read(true)
@@ -179,22 +181,23 @@ async fn main() {
                         std::process::exit(1);
                     }
                 };
-                if let Err(e) = flock.try_write() {
-                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                _lock_guard = match _flock_storage.try_write() {
+                    Ok(guard) => Some(guard),
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                         eprintln!(
                             "The database appears to be in use by a running server.\n\
                              Stop the server first, then try again with --fix."
                         );
-                    } else {
-                        eprintln!("Cannot acquire process lock: {e}");
+                        std::process::exit(1);
                     }
-                    std::process::exit(1);
-                }
-                // Lock is verified and immediately released — we only need to check
-                // that no server is running. The doctor command is short-lived and
-                // the flock is advisory; holding it through the entire operation
-                // would require restructuring the control flow. The check-then-act
-                // window is acceptable for a CLI maintenance tool.
+                    Err(e) => {
+                        eprintln!("Cannot acquire process lock: {e}");
+                        std::process::exit(1);
+                    }
+                };
+            } else {
+                // Satisfy the compiler — no lock needed for read-only diagnostics.
+                _lock_guard = None;
             }
 
             /// Query a PRAGMA value, exiting with an error message on failure.


### PR DESCRIPTION
## Summary

- Add `ensure_auto_vacuum` startup guard that upgrades existing databases from `auto_vacuum=NONE` to `INCREMENTAL` (one-time `VACUUM`), and creates new databases with `INCREMENTAL` pre-set
- Add `mmap_size=268435456` (256 MB) per-connection PRAGMA for read performance
- Add `mokumo doctor [--fix]` CLI subcommand for database health checks and maintenance (reports auto_vacuum mode, freelist fragmentation; `--fix` runs `incremental_vacuum` and enables auto_vacuum)
- Wire `ensure_auto_vacuum` into the startup guard chain (after backup, before schema compat) for both primary and demo sidecar paths

## Test plan

- [x] 6 new tests for `ensure_auto_vacuum` (new DB, NONE→INCREMENTAL upgrade with data survival, already INCREMENTAL, already FULL, corrupt DB, read-only DB)
- [x] Updated `pragmas_are_set_correctly` to assert `auto_vacuum=2` and `mmap_size=268435456`
- [x] Updated `database_creation_is_idempotent` to call `ensure_auto_vacuum` matching real startup sequence
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt` clean
- [ ] CI pipeline passes

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mokumo doctor` CLI subcommand with optional `--fix` for database diagnostics; reports auto_vacuum state, freelist fragmentation, and can reclaim free pages.
  * Enabled automatic one-time upgrade of existing SQLite databases to incremental auto_vacuum to compact freed space.

* **Chores**
  * Increased SQLite memory-mapped I/O to 256 MB to improve read performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->