### PR TITLE
feat(web): add unsaved changes guard (#420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Unsaved changes guard**: forms now block navigation (sidebar links, back button), browser tab close, and Tauri window close when there are unsaved changes. A confirmation dialog with "Cancel" / "Leave anyway" prevents accidental data loss. Applies to the customer form, setup wizard, and any future `use:formDirty` forms. (#420)
 - **Version CLI**: `mokumo --version` prints the version string; `mokumo version` prints extended build info including git hash, build date, target platform, and Rust version. (#405)
 - **`mokumo backup` CLI subcommand** creates a manual database backup using the SQLite Online Backup API. Supports `--output <path>` for custom location, verifies integrity with `PRAGMA integrity_check`, and prints path + size on success. Safe to run while the server is running. (#403)
 - **`mokumo restore <path>` CLI subcommand** restores the database from a backup file. Verifies backup integrity before restoring, creates a safety backup of the current database, removes WAL sidecars, and refuses to run while the server is active (process lock check). (#404)

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -14,6 +14,7 @@ const storybookTestDir = defineBddConfig({
     "!tests/features/demo-banner.feature",
     "!tests/features/profile-switcher.feature",
     "!tests/features/profile-switch-dirty-forms.feature",
+    "!tests/features/unsaved-changes-navigation.feature",
     "!tests/features/error-boundary.feature",
   ],
   steps: [
@@ -30,6 +31,7 @@ const storybookTestDir = defineBddConfig({
     "!tests/steps/profile-shared.steps.ts",
     "!tests/steps/settings-profile-switch.steps.ts",
     "!tests/steps/profile-switch-dirty-forms.steps.ts",
+    "!tests/steps/unsaved-changes-navigation.steps.ts",
     "!tests/steps/setup-state.steps.ts",
     "tests/support/storybook.fixture.ts",
     "tests/support/storybook.helpers.ts",
@@ -71,10 +73,12 @@ const profileTestDir = defineBddConfig({
     "tests/features/settings/settings-profile-switch.feature",
     "tests/features/settings/setup-state.feature",
     "tests/features/profile-switch-dirty-forms.feature",
+    "tests/features/unsaved-changes-navigation.feature",
   ],
   steps: [
     "tests/steps/profile-shared.steps.ts",
     "tests/steps/profile-switch-dirty-forms.steps.ts",
+    "tests/steps/unsaved-changes-navigation.steps.ts",
     "tests/steps/customer-shared.steps.ts",
     "tests/steps/settings-profile-switch.steps.ts",
     "tests/steps/setup-state.steps.ts",

--- a/apps/web/src/lib/components/unsaved-changes-dialog.svelte
+++ b/apps/web/src/lib/components/unsaved-changes-dialog.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
   import * as AlertDialog from "$lib/components/ui/alert-dialog";
-  import { buttonVariants } from "$lib/components/ui/button";
-  import { cn } from "$lib/utils.js";
-
   interface Props {
     open: boolean;
     description?: string;
@@ -38,14 +35,13 @@
       >
         Cancel
       </AlertDialog.Cancel>
-      <button
-        data-slot="alert-dialog-action"
-        class={cn(buttonVariants({ variant: "destructive" }))}
+      <AlertDialog.Action
+        variant="destructive"
         onclick={onconfirm}
         data-testid="unsaved-changes-confirm-btn"
       >
         Leave anyway
-      </button>
+      </AlertDialog.Action>
     </AlertDialog.Footer>
   </AlertDialog.Content>
 </AlertDialog.Root>

--- a/apps/web/src/lib/components/unsaved-changes-dialog.svelte
+++ b/apps/web/src/lib/components/unsaved-changes-dialog.svelte
@@ -1,44 +1,51 @@
 <script lang="ts">
-  import * as Dialog from "$lib/components/ui/dialog";
-  import { Button } from "$lib/components/ui/button";
+  import * as AlertDialog from "$lib/components/ui/alert-dialog";
+  import { buttonVariants } from "$lib/components/ui/button";
+  import { cn } from "$lib/utils.js";
 
   interface Props {
     open: boolean;
+    description?: string;
     onconfirm: () => void;
     oncancel: () => void;
   }
 
-  let { open, onconfirm, oncancel }: Props = $props();
+  let {
+    open,
+    description = "You have unsaved changes that will be lost if you leave this page.",
+    onconfirm,
+    oncancel,
+  }: Props = $props();
 </script>
 
-<Dialog.Root
+<AlertDialog.Root
   {open}
   onOpenChange={(isOpen) => {
     if (!isOpen && open) oncancel();
   }}
 >
-  <Dialog.Content data-testid="unsaved-changes-dialog" showCloseButton={false}>
-    <Dialog.Header>
-      <Dialog.Title>Unsaved changes</Dialog.Title>
-      <Dialog.Description>
-        You have unsaved changes that will be lost if you switch profiles.
-      </Dialog.Description>
-    </Dialog.Header>
-    <Dialog.Footer>
-      <Button
-        variant="outline"
+  <AlertDialog.Content data-testid="unsaved-changes-dialog">
+    <AlertDialog.Header>
+      <AlertDialog.Title>Unsaved changes</AlertDialog.Title>
+      <AlertDialog.Description>
+        {description}
+      </AlertDialog.Description>
+    </AlertDialog.Header>
+    <AlertDialog.Footer>
+      <AlertDialog.Cancel
         onclick={oncancel}
         data-testid="unsaved-changes-cancel-btn"
       >
         Cancel
-      </Button>
-      <Button
-        variant="destructive"
+      </AlertDialog.Cancel>
+      <button
+        data-slot="alert-dialog-action"
+        class={cn(buttonVariants({ variant: "destructive" }))}
         onclick={onconfirm}
         data-testid="unsaved-changes-confirm-btn"
       >
         Leave anyway
-      </Button>
-    </Dialog.Footer>
-  </Dialog.Content>
-</Dialog.Root>
+      </button>
+    </AlertDialog.Footer>
+  </AlertDialog.Content>
+</AlertDialog.Root>

--- a/apps/web/src/lib/stores/profile.svelte.ts
+++ b/apps/web/src/lib/stores/profile.svelte.ts
@@ -19,7 +19,12 @@ export const profile = $state({
   dirtyForms: new SvelteSet<string>(),
   /**
    * Whether the unsaved changes confirmation dialog is open.
-   * Set to true when a profile switch is blocked by dirty forms.
+   * Set to true when a profile switch or navigation is blocked by dirty forms.
    */
   unsavedChangesDialogOpen: false,
+  /**
+   * The URL href of a cancelled navigation that is awaiting user confirmation.
+   * Set by the beforeNavigate guard; cleared on confirm or cancel.
+   */
+  pendingNavigation: null as string | null,
 });

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -27,9 +27,28 @@
     localStorage.setItem(STORAGE_KEY, String(open));
   }
 
-  // Cancel any navigation that fires while the unsaved-changes dialog is open.
-  // This prevents the dialog state from being torn down mid-confirmation.
-  beforeNavigate(({ cancel }) => {
+  // Guard against navigating away with unsaved form changes.
+  // 1. If confirmed replay (user clicked "Leave anyway") → allow through.
+  // 2. If dirty forms and no dialog open → cancel, store destination, show dialog.
+  // 3. If dialog already open → cancel (race guard).
+  beforeNavigate(({ cancel, to, willUnload }) => {
+    if (willUnload) return; // beforeunload handles tab close / external nav
+
+    if (
+      profile.pendingNavigation &&
+      to?.url.href === profile.pendingNavigation
+    ) {
+      profile.pendingNavigation = null;
+      return; // confirmed replay — allow
+    }
+
+    if (profile.dirtyForms.size > 0 && !profile.unsavedChangesDialogOpen) {
+      cancel();
+      profile.pendingNavigation = to?.url.href ?? null;
+      profile.unsavedChangesDialogOpen = true;
+      return;
+    }
+
     if (profile.unsavedChangesDialogOpen) {
       cancel();
     }
@@ -37,43 +56,67 @@
 
   let confirmSwitching = $state(false);
 
+  let dialogDescription = $derived(
+    profile.switchTarget
+      ? "You have unsaved changes that will be lost if you switch profiles."
+      : "You have unsaved changes that will be lost if you leave this page.",
+  );
+
   async function handleDirtyConfirm() {
-    if (confirmSwitching) return;
-    const target = profile.switchTarget;
-    if (!target) return;
-    confirmSwitching = true;
-    try {
-      const result = await apiFetch("/api/profile/switch", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ profile: target }),
-      });
-      if (!result.ok) {
-        console.error(
-          "Profile switch failed (dirty path):",
-          result.status,
-          result.error,
-        );
-        toast.error("Failed to switch profile. Please try again.");
-        return;
-      }
-      profile.unsavedChangesDialogOpen = false;
-      profile.dirtyForms.clear();
-      profile.switchTarget = null;
+    // Profile-switch context
+    if (profile.switchTarget) {
+      if (confirmSwitching) return;
+      const target = profile.switchTarget;
+      confirmSwitching = true;
       try {
-        await goto("/");
-      } catch (error) {
-        console.error("Profile switch navigation failed:", error);
-        window.location.assign("/");
+        const result = await apiFetch("/api/profile/switch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profile: target }),
+        });
+        if (!result.ok) {
+          console.error(
+            "Profile switch failed (dirty path):",
+            result.status,
+            result.error,
+          );
+          toast.error("Failed to switch profile. Please try again.");
+          return;
+        }
+        profile.unsavedChangesDialogOpen = false;
+        profile.dirtyForms.clear();
+        profile.switchTarget = null;
+        try {
+          await goto("/");
+        } catch (error) {
+          console.error("Profile switch navigation failed:", error);
+          window.location.assign("/");
+        }
+      } finally {
+        confirmSwitching = false;
       }
-    } finally {
-      confirmSwitching = false;
+      return;
+    }
+
+    // Navigation context
+    const dest = profile.pendingNavigation;
+    profile.unsavedChangesDialogOpen = false;
+    profile.dirtyForms.clear();
+    profile.pendingNavigation = null;
+    if (dest) {
+      try {
+        await goto(dest);
+      } catch (error) {
+        console.error("Navigation replay failed:", error);
+        window.location.assign(dest);
+      }
     }
   }
 
   function handleDirtyCancel() {
     profile.unsavedChangesDialogOpen = false;
     profile.switchTarget = null;
+    profile.pendingNavigation = null;
   }
 </script>
 
@@ -96,6 +139,7 @@
   </SidebarInset>
   <UnsavedChangesDialog
     open={profile.unsavedChangesDialogOpen}
+    description={dialogDescription}
     onconfirm={handleDirtyConfirm}
     oncancel={handleDirtyCancel}
   />

--- a/apps/web/src/routes/(auth)/+layout.svelte
+++ b/apps/web/src/routes/(auth)/+layout.svelte
@@ -1,5 +1,51 @@
 <script lang="ts">
+  import { beforeNavigate, goto } from "$app/navigation";
+  import UnsavedChangesDialog from "$lib/components/unsaved-changes-dialog.svelte";
+  import { profile } from "$lib/stores/profile.svelte";
+
   let { children } = $props();
+
+  beforeNavigate(({ cancel, to, willUnload }) => {
+    if (willUnload) return;
+
+    if (
+      profile.pendingNavigation &&
+      to?.url.href === profile.pendingNavigation
+    ) {
+      profile.pendingNavigation = null;
+      return;
+    }
+
+    if (profile.dirtyForms.size > 0 && !profile.unsavedChangesDialogOpen) {
+      cancel();
+      profile.pendingNavigation = to?.url.href ?? null;
+      profile.unsavedChangesDialogOpen = true;
+      return;
+    }
+
+    if (profile.unsavedChangesDialogOpen) {
+      cancel();
+    }
+  });
+
+  async function handleConfirm() {
+    const dest = profile.pendingNavigation;
+    profile.unsavedChangesDialogOpen = false;
+    profile.dirtyForms.clear();
+    profile.pendingNavigation = null;
+    if (dest) {
+      try {
+        await goto(dest);
+      } catch {
+        window.location.assign(dest);
+      }
+    }
+  }
+
+  function handleCancel() {
+    profile.unsavedChangesDialogOpen = false;
+    profile.pendingNavigation = null;
+  }
 </script>
 
 <div class="flex min-h-screen items-center justify-center bg-background p-4">
@@ -17,3 +63,8 @@
     {@render children()}
   </div>
 </div>
+<UnsavedChangesDialog
+  open={profile.unsavedChangesDialogOpen}
+  onconfirm={handleConfirm}
+  oncancel={handleCancel}
+/>

--- a/apps/web/src/routes/(auth)/setup/+page.svelte
+++ b/apps/web/src/routes/(auth)/setup/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import { formDirty } from "$lib/actions/form-dirty";
   import { untrack } from "svelte";
   import { apiFetch } from "$lib/api";
   import CopyableUrl from "$lib/components/copyable-url.svelte";
@@ -130,6 +131,7 @@
     <CardContent>
       <form
         class="space-y-4"
+        use:formDirty
         onsubmit={(e) => {
           e.preventDefault();
           step = 3;
@@ -175,6 +177,7 @@
 
       <form
         class="space-y-4"
+        use:formDirty
         onsubmit={(e) => {
           e.preventDefault();
           handleCreateAccount();

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -3,14 +3,52 @@
   import { ModeWatcher, mode } from "mode-watcher";
   import { Toaster, toastClasses, toast } from "$lib/components/toast";
   import { onMount } from "svelte";
+  import { profile } from "$lib/stores/profile.svelte";
   import type { ServerStartupError } from "$lib/types/ServerStartupError";
 
   let { children } = $props();
+
+  // Register beforeunload only when forms are dirty (avoids bfcache penalty).
+  $effect(() => {
+    if (profile.dirtyForms.size > 0) {
+      const handler = (e: BeforeUnloadEvent) => {
+        e.preventDefault();
+      };
+      window.addEventListener("beforeunload", handler);
+      return () => window.removeEventListener("beforeunload", handler);
+    }
+  });
 
   onMount(() => {
     if (!("__TAURI_INTERNALS__" in window)) return;
 
     let mounted = true;
+    let unlistenClose: (() => void) | undefined;
+
+    // Tauri: intercept native window close when forms have unsaved changes.
+    import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
+      if (!mounted) return;
+      const win = getCurrentWindow();
+      win
+        .onCloseRequested(async (event) => {
+          if (profile.dirtyForms.size === 0) return;
+          event.preventDefault();
+          const confirmed = window.confirm(
+            "You have unsaved changes that will be lost. Leave anyway?",
+          );
+          if (confirmed) {
+            profile.dirtyForms.clear();
+            win.destroy();
+          }
+        })
+        .then((fn) => {
+          if (mounted) {
+            unlistenClose = fn;
+          } else {
+            fn();
+          }
+        });
+    });
 
     import("@tauri-apps/api/event").then(({ listen }) => {
       listen<ServerStartupError>("server-error", ({ payload }) => {
@@ -32,6 +70,7 @@
     return () => {
       mounted = false;
       unlisten?.();
+      unlistenClose?.();
     };
   });
 

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
     if (profile.dirtyForms.size > 0) {
       const handler = (e: BeforeUnloadEvent) => {
         e.preventDefault();
+        e.returnValue = "";
       };
       window.addEventListener("beforeunload", handler);
       return () => window.removeEventListener("beforeunload", handler);

--- a/apps/web/tests/features/profile-switch-dirty-forms.feature
+++ b/apps/web/tests/features/profile-switch-dirty-forms.feature
@@ -45,10 +45,10 @@ Feature: Unsaved changes guard on profile switch
     Then the dialog closes
     And no profile switch request has been sent
 
-  Scenario: Clicking outside the dialog cancels the switch
+  Scenario: Clicking outside the dialog does not dismiss it
     Given the unsaved changes dialog is open
     When I click outside the dialog
-    Then the dialog closes
+    Then the "Unsaved changes" dialog remains open
     And no profile switch request has been sent
 
   # --- Form dirty state tracking ---

--- a/apps/web/tests/features/unsaved-changes-navigation.feature
+++ b/apps/web/tests/features/unsaved-changes-navigation.feature
@@ -1,0 +1,50 @@
+Feature: Unsaved changes guard on page navigation
+
+  If a user navigates away from a page with unsaved form changes,
+  an "Unsaved Changes" dialog blocks the navigation. The user must
+  confirm ("Leave anyway") or cancel. Confirming completes the
+  navigation and discards the changes. Canceling keeps them on the
+  current page with form data intact.
+
+  # --- Clean path (no dirty forms) ---
+
+  Scenario: Navigation proceeds immediately with no unsaved changes
+    Given I am on the customers page with no dirty forms
+    When I click a sidebar link to navigate away
+    Then the navigation completes without a dialog
+
+  # --- Dirty path ---
+
+  Scenario: Unsaved changes dialog appears on navigation with dirty form
+    Given I have unsaved changes in the customer form
+    When I click a sidebar link to navigate away
+    Then the "Unsaved changes" navigation dialog appears
+    And the navigation has not completed
+
+  Scenario: "Leave anyway" allows navigation to proceed
+    Given the navigation unsaved changes dialog is open
+    When I click "Leave anyway" in the navigation dialog
+    Then the dialog closes
+    And the navigation completes to the destination
+
+  Scenario: "Cancel" keeps user on current page
+    Given the navigation unsaved changes dialog is open
+    When I click "Cancel" in the navigation dialog
+    Then the dialog closes
+    And I remain on the customers page with form data intact
+
+  # --- Back button ---
+
+  Scenario: Browser back button triggers guard when form is dirty
+    Given I navigated to the customers page from the home page
+    And I have unsaved changes in the customer form
+    When I press the browser back button
+    Then the "Unsaved changes" navigation dialog appears
+
+  # --- Clean after save ---
+
+  Scenario: Guard does not trigger after successful save
+    Given I have unsaved changes in the customer form
+    When I save the customer form successfully
+    And I click a sidebar link to navigate away
+    Then the navigation completes without a dialog

--- a/apps/web/tests/steps/profile-switch-dirty-forms.steps.ts
+++ b/apps/web/tests/steps/profile-switch-dirty-forms.steps.ts
@@ -353,3 +353,7 @@ Then('clicking "Leave anyway" switches the profile', async ({ page }) => {
 Then("the unsaved changes dialog appears", async ({ page }) => {
   await expect(page.getByTestId("unsaved-changes-dialog")).toBeVisible();
 });
+
+Then('the "Unsaved changes" dialog remains open', async ({ page }) => {
+  await expect(page.getByTestId("unsaved-changes-dialog")).toBeVisible();
+});

--- a/apps/web/tests/steps/unsaved-changes-navigation.steps.ts
+++ b/apps/web/tests/steps/unsaved-changes-navigation.steps.ts
@@ -1,0 +1,147 @@
+import { expect, type Page } from "@playwright/test";
+import { Given, When, Then } from "../support/app.fixture";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────────────
+
+const SETUP_STATUS_ROUTE = "**/api/setup-status";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+async function mockSetupStatus(page: Page): Promise<void> {
+  await page.route(SETUP_STATUS_ROUTE, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        setup_complete: true,
+        setup_mode: "demo",
+        is_first_launch: false,
+        production_setup_complete: true,
+        shop_name: "Gary's Printing Co",
+      }),
+    }),
+  );
+}
+
+async function navigateToCustomerForm(page: Page): Promise<void> {
+  await mockSetupStatus(page);
+  await page.goto("/customers");
+  await page.waitForLoadState("networkidle");
+  await page.getByRole("button", { name: "Add Customer" }).first().click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+}
+
+async function typeInCustomerForm(page: Page): Promise<void> {
+  await page.getByLabel("Display Name").fill("Test Customer");
+}
+
+async function clickSidebarHome(page: Page): Promise<void> {
+  await page.getByRole("link", { name: "Home" }).click();
+}
+
+async function setupNavigationDialogOpen(page: Page): Promise<void> {
+  await navigateToCustomerForm(page);
+  await typeInCustomerForm(page);
+  await clickSidebarHome(page);
+  await expect(page.getByTestId("unsaved-changes-dialog")).toBeVisible();
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Givens
+// ────────────────────────────────────────────────────────────────────────────
+
+Given("I am on the customers page with no dirty forms", async ({ page }) => {
+  await mockSetupStatus(page);
+  await page.goto("/customers");
+  await page.waitForLoadState("networkidle");
+});
+
+Given("I have unsaved changes in the customer form", async ({ page }) => {
+  await navigateToCustomerForm(page);
+  await typeInCustomerForm(page);
+});
+
+Given("the navigation unsaved changes dialog is open", async ({ page }) => {
+  await setupNavigationDialogOpen(page);
+});
+
+Given("I navigated to the customers page from the home page", async ({ page }) => {
+  await mockSetupStatus(page);
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await page.getByRole("link", { name: "Customers" }).click();
+  await page.waitForURL((url) => url.pathname === "/customers");
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Whens
+// ────────────────────────────────────────────────────────────────────────────
+
+When("I click a sidebar link to navigate away", async ({ page }) => {
+  await clickSidebarHome(page);
+});
+
+When('I click "Leave anyway" in the navigation dialog', async ({ page }) => {
+  await page.getByTestId("unsaved-changes-confirm-btn").click();
+});
+
+When('I click "Cancel" in the navigation dialog', async ({ page }) => {
+  await page.getByTestId("unsaved-changes-cancel-btn").click();
+});
+
+When("I press the browser back button", async ({ page }) => {
+  await page.goBack();
+});
+
+When("I save the customer form successfully", async ({ page }) => {
+  await page.route("**/api/customers", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ id: 999, display_name: "Test Customer" }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+  const nameInput = page.getByLabel("Display Name");
+  if (!(await nameInput.inputValue())) {
+    await nameInput.fill("Test Customer");
+  }
+  await page.getByRole("button", { name: /Create|Save Changes/i }).click();
+  await expect(page.getByRole("dialog", { name: "Add Customer" })).not.toBeVisible({
+    timeout: 3000,
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Thens
+// ────────────────────────────────────────────────────────────────────────────
+
+Then("the navigation completes without a dialog", async ({ page }) => {
+  await page.waitForURL((url) => url.pathname === "/", { timeout: 5000 });
+  await expect(page.getByTestId("unsaved-changes-dialog")).not.toBeVisible();
+});
+
+Then('the "Unsaved changes" navigation dialog appears', async ({ page }) => {
+  await expect(page.getByTestId("unsaved-changes-dialog")).toBeVisible();
+});
+
+Then("the navigation has not completed", async ({ page }) => {
+  expect(page.url()).toContain("/customers");
+});
+
+Then("the navigation completes to the destination", async ({ page }) => {
+  await page.waitForURL((url) => url.pathname === "/", { timeout: 5000 });
+});
+
+Then("I remain on the customers page with form data intact", async ({ page }) => {
+  expect(page.url()).toContain("/customers");
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(page.getByLabel("Display Name")).toHaveValue("Test Customer");
+});


### PR DESCRIPTION
## Summary

- Three-layer guard prevents accidental data loss when navigating away from dirty forms:
  1. **`beforeNavigate`** (SvelteKit): cancels client-side navigation, shows custom AlertDialog
  2. **`beforeunload`** (browser): native dialog on tab close, registered only when dirty (bfcache-safe)
  3. **`onCloseRequested`** (Tauri): intercepts desktop window close with `window.confirm()` fallback
- Migrated `UnsavedChangesDialog` from `Dialog` to `AlertDialog` (prevents accidental dismissal via overlay click)
- Added `use:formDirty` to setup wizard steps 2 and 3
- Guard is generic/reusable — applies to any form using `use:formDirty`

Closes #420

## Test plan

- [ ] Open customer form, type in a field, click sidebar link → dialog appears with "Cancel" / "Leave anyway"
- [ ] Click "Leave anyway" → navigates to destination
- [ ] Click "Cancel" → stays on page with form data intact
- [ ] Open customer form, type, close browser tab → browser-native "Changes may not be saved" dialog
- [ ] Open setup wizard, type shop name, navigate away → dialog appears
- [ ] Profile switch with dirty form → still works as before (with "switch profiles" text)
- [ ] Clicking outside the dialog does NOT dismiss it (AlertDialog behavior)
- [ ] Clean form → navigation proceeds without guard
- [ ] `moon run web:check` passes (0 errors)
- [ ] `moon run web:test` passes (219 tests)
- [ ] `moon run web:build` succeeds
- [ ] BDD test generation includes 6 new navigation guard scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide unsaved-changes guard: blocks sidebar/back/tab/window close and shows a confirmation dialog with Clearer copy and Cancel / Leave anyway, and correctly resumes intended navigation after confirmation.
* **Behavior Changes / Bug Fixes**
  * Dialog now persists on outside clicks (won’t close unintentionally); improved back-button, tab/window-close, and app-close handling.
* **Tests**
  * Added end-to-end BDD tests covering navigation guard scenarios, dialog interactions, back-button, save-then-navigate, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->