### PR TITLE
fix(web): preserve history semantics in unsaved changes replay

### DIFF
--- a/apps/web/src/lib/components/unsaved-changes-dialog.svelte
+++ b/apps/web/src/lib/components/unsaved-changes-dialog.svelte
@@ -29,10 +29,7 @@
       </AlertDialog.Description>
     </AlertDialog.Header>
     <AlertDialog.Footer>
-      <AlertDialog.Cancel
-        onclick={oncancel}
-        data-testid="unsaved-changes-cancel-btn"
-      >
+      <AlertDialog.Cancel data-testid="unsaved-changes-cancel-btn">
         Cancel
       </AlertDialog.Cancel>
       <AlertDialog.Action

--- a/apps/web/src/lib/navigation-guard.ts
+++ b/apps/web/src/lib/navigation-guard.ts
@@ -1,0 +1,50 @@
+import { beforeNavigate, goto } from "$app/navigation";
+import { profile } from "$lib/stores/profile.svelte";
+
+/**
+ * Install the unsaved-changes navigation guard on the current layout.
+ * Call once at the top level of each layout's `<script>` block.
+ *
+ * When dirty forms exist and the user tries to navigate away,
+ * the navigation is cancelled and a confirmation dialog is shown.
+ */
+export function installNavigationGuard(): void {
+  beforeNavigate((navigation) => {
+    const { cancel, to, willUnload, type } = navigation;
+    if (willUnload) return;
+
+    if (profile.dirtyForms.size > 0 && !profile.unsavedChangesDialogOpen) {
+      cancel();
+      const delta =
+        type === "popstate" && "delta" in navigation ? (navigation.delta as number) : undefined;
+      profile.pendingNavigation = to?.url.href ? { href: to.url.href, delta } : null;
+      profile.unsavedChangesDialogOpen = true;
+      return;
+    }
+
+    if (profile.unsavedChangesDialogOpen) {
+      cancel();
+    }
+  });
+}
+
+/**
+ * Replay a previously cancelled navigation.
+ * Uses `history.go(delta)` for back/forward (popstate) to preserve
+ * browser history semantics, and `goto(href)` for link clicks.
+ */
+export async function replayNavigation(
+  pending: { href: string; delta?: number } | null,
+): Promise<void> {
+  if (!pending) return;
+  try {
+    if (pending.delta !== undefined) {
+      history.go(pending.delta);
+    } else {
+      await goto(pending.href);
+    }
+  } catch (error) {
+    console.error("Navigation replay failed:", error);
+    window.location.assign(pending.href);
+  }
+}

--- a/apps/web/src/lib/stores/profile.svelte.ts
+++ b/apps/web/src/lib/stores/profile.svelte.ts
@@ -23,8 +23,9 @@ export const profile = $state({
    */
   unsavedChangesDialogOpen: false,
   /**
-   * The URL href of a cancelled navigation that is awaiting user confirmation.
-   * Set by the beforeNavigate guard; cleared on confirm or cancel.
+   * A cancelled navigation awaiting user confirmation.
+   * Stores href + navigation type so replay can use history.go() for
+   * back/forward (popstate) instead of goto() which creates a new entry.
    */
-  pendingNavigation: null as string | null,
+  pendingNavigation: null as { href: string; delta?: number } | null,
 });

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
-  import { beforeNavigate, goto } from "$app/navigation";
+  import { goto } from "$app/navigation";
   import AppSidebar from "$lib/components/app-sidebar.svelte";
   import AppTopbar from "$lib/components/app-topbar.svelte";
   import DemoBanner from "$lib/components/demo-banner.svelte";
@@ -8,6 +8,10 @@
   import UnsavedChangesDialog from "$lib/components/unsaved-changes-dialog.svelte";
   import { SidebarInset, SidebarProvider } from "$lib/components/ui/sidebar";
   import { apiFetch } from "$lib/api";
+  import {
+    installNavigationGuard,
+    replayNavigation,
+  } from "$lib/navigation-guard";
   import { profile } from "$lib/stores/profile.svelte";
   import { toast } from "$lib/components/toast";
   import type { LayoutData } from "./$types";
@@ -27,39 +31,7 @@
     localStorage.setItem(STORAGE_KEY, String(open));
   }
 
-  // Guard against navigating away with unsaved form changes.
-  // 1. If confirmed replay (user clicked "Leave anyway") → allow through.
-  // 2. If dirty forms and no dialog open → cancel, store destination, show dialog.
-  // 3. If dialog already open → cancel (race guard).
-  beforeNavigate((navigation) => {
-    const { cancel, to, willUnload, type } = navigation;
-    if (willUnload) return; // beforeunload handles tab close / external nav
-
-    if (
-      profile.pendingNavigation &&
-      to?.url.href === profile.pendingNavigation.href
-    ) {
-      profile.pendingNavigation = null;
-      return; // confirmed replay — allow
-    }
-
-    if (profile.dirtyForms.size > 0 && !profile.unsavedChangesDialogOpen) {
-      cancel();
-      const delta =
-        type === "popstate" && "delta" in navigation
-          ? (navigation.delta as number)
-          : undefined;
-      profile.pendingNavigation = to?.url.href
-        ? { href: to.url.href, delta }
-        : null;
-      profile.unsavedChangesDialogOpen = true;
-      return;
-    }
-
-    if (profile.unsavedChangesDialogOpen) {
-      cancel();
-    }
-  });
+  installNavigationGuard();
 
   let confirmSwitching = $state(false);
 
@@ -111,18 +83,7 @@
     profile.unsavedChangesDialogOpen = false;
     profile.dirtyForms.clear();
     profile.pendingNavigation = null;
-    if (pending) {
-      try {
-        if (pending.delta !== undefined) {
-          history.go(pending.delta);
-        } else {
-          await goto(pending.href);
-        }
-      } catch (error) {
-        console.error("Navigation replay failed:", error);
-        window.location.assign(pending.href);
-      }
-    }
+    await replayNavigation(pending);
   }
 
   function handleDirtyCancel() {

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -31,12 +31,13 @@
   // 1. If confirmed replay (user clicked "Leave anyway") → allow through.
   // 2. If dirty forms and no dialog open → cancel, store destination, show dialog.
   // 3. If dialog already open → cancel (race guard).
-  beforeNavigate(({ cancel, to, willUnload }) => {
+  beforeNavigate((navigation) => {
+    const { cancel, to, willUnload, type } = navigation;
     if (willUnload) return; // beforeunload handles tab close / external nav
 
     if (
       profile.pendingNavigation &&
-      to?.url.href === profile.pendingNavigation
+      to?.url.href === profile.pendingNavigation.href
     ) {
       profile.pendingNavigation = null;
       return; // confirmed replay — allow
@@ -44,7 +45,13 @@
 
     if (profile.dirtyForms.size > 0 && !profile.unsavedChangesDialogOpen) {
       cancel();
-      profile.pendingNavigation = to?.url.href ?? null;
+      const delta =
+        type === "popstate" && "delta" in navigation
+          ? (navigation.delta as number)
+          : undefined;
+      profile.pendingNavigation = to?.url.href
+        ? { href: to.url.href, delta }
+        : null;
       profile.unsavedChangesDialogOpen = true;
       return;
     }
@@ -98,17 +105,22 @@
       return;
     }
 
-    // Navigation context
-    const dest = profile.pendingNavigation;
+    // Navigation context — replay with history.go() for back/forward,
+    // goto() for link clicks, to preserve browser history semantics.
+    const pending = profile.pendingNavigation;
     profile.unsavedChangesDialogOpen = false;
     profile.dirtyForms.clear();
     profile.pendingNavigation = null;
-    if (dest) {
+    if (pending) {
       try {
-        await goto(dest);
+        if (pending.delta !== undefined) {
+          history.go(pending.delta);
+        } else {
+          await goto(pending.href);
+        }
       } catch (error) {
         console.error("Navigation replay failed:", error);
-        window.location.assign(dest);
+        window.location.assign(pending.href);
       }
     }
   }

--- a/apps/web/src/routes/(auth)/+layout.svelte
+++ b/apps/web/src/routes/(auth)/+layout.svelte
@@ -1,56 +1,21 @@
 <script lang="ts">
-  import { beforeNavigate, goto } from "$app/navigation";
   import UnsavedChangesDialog from "$lib/components/unsaved-changes-dialog.svelte";
+  import {
+    installNavigationGuard,
+    replayNavigation,
+  } from "$lib/navigation-guard";
   import { profile } from "$lib/stores/profile.svelte";
 
   let { children } = $props();
 
-  beforeNavigate((navigation) => {
-    const { cancel, to, willUnload, type } = navigation;
-    if (willUnload) return;
-
-    if (
-      profile.pendingNavigation &&
-      to?.url.href === profile.pendingNavigation.href
-    ) {
-      profile.pendingNavigation = null;
-      return;
-    }
-
-    if (profile.dirtyForms.size > 0 && !profile.unsavedChangesDialogOpen) {
-      cancel();
-      const delta =
-        type === "popstate" && "delta" in navigation
-          ? (navigation.delta as number)
-          : undefined;
-      profile.pendingNavigation = to?.url.href
-        ? { href: to.url.href, delta }
-        : null;
-      profile.unsavedChangesDialogOpen = true;
-      return;
-    }
-
-    if (profile.unsavedChangesDialogOpen) {
-      cancel();
-    }
-  });
+  installNavigationGuard();
 
   async function handleConfirm() {
     const pending = profile.pendingNavigation;
     profile.unsavedChangesDialogOpen = false;
     profile.dirtyForms.clear();
     profile.pendingNavigation = null;
-    if (pending) {
-      try {
-        if (pending.delta !== undefined) {
-          history.go(pending.delta);
-        } else {
-          await goto(pending.href);
-        }
-      } catch {
-        window.location.assign(pending.href);
-      }
-    }
+    await replayNavigation(pending);
   }
 
   function handleCancel() {

--- a/apps/web/src/routes/(auth)/+layout.svelte
+++ b/apps/web/src/routes/(auth)/+layout.svelte
@@ -5,12 +5,13 @@
 
   let { children } = $props();
 
-  beforeNavigate(({ cancel, to, willUnload }) => {
+  beforeNavigate((navigation) => {
+    const { cancel, to, willUnload, type } = navigation;
     if (willUnload) return;
 
     if (
       profile.pendingNavigation &&
-      to?.url.href === profile.pendingNavigation
+      to?.url.href === profile.pendingNavigation.href
     ) {
       profile.pendingNavigation = null;
       return;
@@ -18,7 +19,13 @@
 
     if (profile.dirtyForms.size > 0 && !profile.unsavedChangesDialogOpen) {
       cancel();
-      profile.pendingNavigation = to?.url.href ?? null;
+      const delta =
+        type === "popstate" && "delta" in navigation
+          ? (navigation.delta as number)
+          : undefined;
+      profile.pendingNavigation = to?.url.href
+        ? { href: to.url.href, delta }
+        : null;
       profile.unsavedChangesDialogOpen = true;
       return;
     }
@@ -29,15 +36,19 @@
   });
 
   async function handleConfirm() {
-    const dest = profile.pendingNavigation;
+    const pending = profile.pendingNavigation;
     profile.unsavedChangesDialogOpen = false;
     profile.dirtyForms.clear();
     profile.pendingNavigation = null;
-    if (dest) {
+    if (pending) {
       try {
-        await goto(dest);
+        if (pending.delta !== undefined) {
+          history.go(pending.delta);
+        } else {
+          await goto(pending.href);
+        }
       } catch {
-        window.location.assign(dest);
+        window.location.assign(pending.href);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Fix `pendingNavigation` to store `{ href, delta? }` instead of plain string, preserving whether the cancelled navigation was a popstate (back/forward) or link click
- Replay popstate navigations with `history.go(delta)` instead of `goto()` to avoid creating spurious history entries
- Remove duplicate `onclick={oncancel}` on `AlertDialog.Cancel` — the `onOpenChange` callback on `AlertDialog.Root` already fires `oncancel` when the dialog closes

Addresses unresolved CodeRabbit review comments from PR #462.

Closes #420

## Test plan

- [x] `moon run web:check` — 0 errors, 0 warnings
- [x] `moon run web:test` — 219/219 tests pass
- [x] Pre-commit hooks (gitleaks, oxlint, prettier, oxfmt) — all green
- [ ] CI pipeline checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized navigation guard with replay support for previously cancelled navigations.

* **Bug Fixes**
  * Improved handling of browser back/forward navigation when forms have unsaved changes.
  * Cancel button now relies on dialog close behavior for consistent cancellation handling.

* **Refactor**
  * Pending navigation state updated to include both target URL and optional history delta for more accurate replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->