### PR TITLE
test(api): offline startup validation — BDD + Hurl smoke (#315)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,88 +7,65 @@ node_modules/
 .svelte-kit/
 apps/web/build/
 .pnpm-store/
-
 # Environment
 .env
 .env.*
 !.env.example
 .envrc
-
 # SQLite
 *.db
 *.db-wal
 *.db-shm
-
 # Moon
 .moon/cache/
-
 # Claude Code
 .claude/*
 !.claude/rules/
 !.claude/rules/**
-
 # OS
 .DS_Store
 Thumbs.db
-
 # Claude Code session focus (ephemeral)
 .claude/focus.md
-
 # Pipeline state (ephemeral)
 .workflow/
-
 # IDE
 .idea/
 .vscode/
 *.swp
 *.swo
-
 # Build artifacts
 tmp/
 dist/
-
 # Test coverage
 coverage/
 coverage.json
 lcov.info
-
 # Storybook
 apps/web/storybook-static/
 apps/web/.features-gen/
-
 # Playwright
 test-results/
 apps/web/test-results/
 apps/web/playwright-report/
-
 # Lefthook personal overrides
 lefthook-local.yml
-
 # Pipeline state (transient, per-session)
-.workflow/
-
 # ts-rs default output (canonical path is apps/web/src/lib/types/ via Moon)
 **/bindings/
-
 # SQLx offline cache (.sqlx/) — commit after running: moon run api:db-prepare
 mutants.out/
 mutants.out.old/
-
 # ts-rs export artifacts in crate dirs
 crates/types/apps/
-
 # Vitest coverage
 apps/web/coverage/
-
 # Stryker mutation testing
 **/reports/mutation/
 **/.stryker-tmp/
-
 # Firecrawl research cache
 .firecrawl/
-
 # Hurl env files (contain credentials) — commit *.env.example, not *.env
 tests/api/envs/*.env
-
 # Bruno collection (local exploration scratchpad — .hurl files are the committed contract)
 tests/api/bruno/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Offline startup validation**: BDD scenarios and Hurl smoke test confirm the server boots and serves the internal shop API with zero internet access. mDNS registration failure degrades gracefully (logged warning, `mdns_active: false` in `/api/server-info` and `/api/diagnostics`) without blocking boot. (#315)
 - **Support-visible diagnostics endpoint and settings card**: new `GET /api/diagnostics` returns app version, database schema/file size/WAL mode for both profiles, runtime state (uptime, active profile, setup flags, LAN host/port, mDNS), and OS family/arch. System Settings now renders a Diagnostics card with a "Copy as Markdown" button so shop owners can share state when troubleshooting. (#318)
 - **Open Existing Shop**: welcome screen now includes a third button to restore a production shop from an existing `.db` backup file. The file is validated (application ID, integrity, schema compatibility), copied to the production slot, and the server restarts. Users then log in with their existing credentials. (#282)
 - **Graceful shutdown with drain timeout**: Server now exits within 10 seconds of receiving a shutdown signal, even with in-flight requests. CLI handles both SIGINT (Ctrl+C) and SIGTERM on Unix. Desktop wraps server drain with a 10-second timeout. (#312)

--- a/services/api/moon.yml
+++ b/services/api/moon.yml
@@ -170,6 +170,7 @@ tasks:
         tests/api/routing/api-prefix-boundary.hurl \
         tests/api/routing/method-rejection.hurl \
         tests/api/health/health.hurl \
+        tests/api/offline/boot.hurl \
         tests/api/auth/login-bad-credentials.hurl \
         tests/api/auth/me-unauthenticated.hurl \
         tests/api/customers/not-found.hurl

--- a/services/api/tests/bdd_world/mod.rs
+++ b/services/api/tests/bdd_world/mod.rs
@@ -6,6 +6,7 @@ pub mod discovery_steps;
 pub mod health_steps;
 pub mod lock_steps;
 pub mod mdns_retry_steps;
+pub mod offline_startup_steps;
 pub mod port_fallback_steps;
 pub mod regen_steps;
 pub mod restore_steps;

--- a/services/api/tests/bdd_world/offline_startup_steps.rs
+++ b/services/api/tests/bdd_world/offline_startup_steps.rs
@@ -1,0 +1,50 @@
+use super::ApiWorld;
+use cucumber::{given, then, when};
+
+// ---- Given steps ----
+
+#[given("setup is completed")]
+async fn setup_completed(w: &mut ApiWorld) {
+    w.ensure_auth().await;
+}
+
+// ---- When steps ----
+
+#[when("the diagnostics endpoint is requested")]
+async fn request_diagnostics(w: &mut ApiWorld) {
+    w.response = Some(w.server.get("/api/diagnostics").await);
+}
+
+// ---- Then steps ----
+
+#[then("the health response includes database ok")]
+async fn health_database_ok(w: &mut ApiWorld) {
+    let resp = w.server.get("/api/health").await;
+    resp.assert_status_ok();
+    let body: serde_json::Value = resp.json();
+    assert_eq!(
+        body["database"].as_str(),
+        Some("ok"),
+        "Expected health.database to be \"ok\", got: {:?}",
+        body["database"]
+    );
+}
+
+#[then("the diagnostics return 200")]
+async fn diagnostics_return_200(w: &mut ApiWorld) {
+    let resp = w.response.as_ref().expect("no response captured");
+    resp.assert_status_ok();
+}
+
+#[then("the diagnostics show mdns_active is false")]
+async fn diagnostics_mdns_inactive(w: &mut ApiWorld) {
+    let resp = w.response.as_ref().expect("no response captured");
+    let body: serde_json::Value = resp.json();
+    let mdns_active = body["runtime"]["mdns_active"]
+        .as_bool()
+        .expect("runtime.mdns_active should be a boolean");
+    assert!(
+        !mdns_active,
+        "Expected runtime.mdns_active to be false, got true"
+    );
+}

--- a/services/api/tests/bdd_world/offline_startup_steps.rs
+++ b/services/api/tests/bdd_world/offline_startup_steps.rs
@@ -45,6 +45,6 @@ async fn diagnostics_mdns_inactive(w: &mut ApiWorld) {
         .expect("runtime.mdns_active should be a boolean");
     assert!(
         !mdns_active,
-        "Expected runtime.mdns_active to be false, got true"
+        "Expected runtime.mdns_active to be false, but it was true"
     );
 }

--- a/services/api/tests/features/offline_startup.feature
+++ b/services/api/tests/features/offline_startup.feature
@@ -4,18 +4,18 @@ Feature: Offline startup validation
   Optional online dependencies (mDNS LAN discovery) must degrade
   gracefully without blocking boot or the internal shop API.
 
-  @offline
-  Scenario: Health endpoint responds when mDNS registration fails
+  Background:
     Given the server is started with "--host 0.0.0.0"
     And mDNS registration will fail
+
+  @offline
+  Scenario: Health endpoint responds when mDNS registration fails
     When the server starts
     Then the server is running
     And the health response includes database ok
 
   @offline
   Scenario: Server-info reports degraded LAN state when offline
-    Given the server is started with "--host 0.0.0.0"
-    And mDNS registration will fail
     When the server starts
     And a client requests the server info endpoint
     Then the response shows LAN access is disabled
@@ -23,9 +23,7 @@ Feature: Offline startup validation
 
   @offline
   Scenario: Authenticated shop API responds when mDNS is unavailable
-    Given the server is started with "--host 0.0.0.0"
-    And mDNS registration will fail
-    And setup is completed
+    Given setup is completed
     When the server starts
     And the diagnostics endpoint is requested
     Then the diagnostics return 200

--- a/services/api/tests/features/offline_startup.feature
+++ b/services/api/tests/features/offline_startup.feature
@@ -1,0 +1,32 @@
+Feature: Offline startup validation
+
+  Mokumo's core local workflow must function with zero internet access.
+  Optional online dependencies (mDNS LAN discovery) must degrade
+  gracefully without blocking boot or the internal shop API.
+
+  @offline
+  Scenario: Health endpoint responds when mDNS registration fails
+    Given the server is started with "--host 0.0.0.0"
+    And mDNS registration will fail
+    When the server starts
+    Then the server is running
+    And the health response includes database ok
+
+  @offline
+  Scenario: Server-info reports degraded LAN state when offline
+    Given the server is started with "--host 0.0.0.0"
+    And mDNS registration will fail
+    When the server starts
+    And a client requests the server info endpoint
+    Then the response shows LAN access is disabled
+    And the LAN URL is absent
+
+  @offline
+  Scenario: Authenticated shop API responds when mDNS is unavailable
+    Given the server is started with "--host 0.0.0.0"
+    And mDNS registration will fail
+    And setup is completed
+    When the server starts
+    And the diagnostics endpoint is requested
+    Then the diagnostics return 200
+    And the diagnostics show mdns_active is false

--- a/tests/api/offline/boot.hurl
+++ b/tests/api/offline/boot.hurl
@@ -1,0 +1,21 @@
+# Offline boot smoke — asserts health and server-info respond correctly.
+# Does not assert mdns_active (depends on CI network state); that contract
+# is proven by the BDD offline_startup.feature scenarios.
+
+GET http://{{host}}/api/health
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.status" == "ok"
+jsonpath "$.version" exists
+jsonpath "$.database" == "ok"
+
+
+GET http://{{host}}/api/server-info
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.port" isInteger
+jsonpath "$.host" exists


### PR DESCRIPTION
## Summary

- Adds 3 BDD scenarios in `offline_startup.feature` proving the server boots and serves the internal shop API with zero internet access
- Step definitions reuse existing `ApiWorld` fields (`mdns_should_fail`, `FailingDiscovery`, `ensure_auth`) — no new production code
- Hurl smoke test (`tests/api/offline/boot.hurl`) asserts `/api/health` and `/api/server-info` respond correctly; wired into `api:smoke` Moon task

Closes #315

## What was validated

Research confirmed Mokumo's architecture is already offline-capable:
- `local_ip_address::local_ip()` returns `Ok(None)` when offline — graceful
- mDNS registration errors are caught and logged as warnings — server continues
- TCP bind is a local socket operation — not internet-dependent
- All DB guard chain operations are local SQLite

The gap was test coverage. These scenarios close it.

## Acceptance criteria coverage

| AC | Verified by |
|---|---|
| App boots without internet access | Scenario 1: health endpoint responds when mDNS fails |
| Internal shop workflow usable | Scenario 3: `/api/diagnostics` returns 200 when mDNS unavailable |
| Optional online deps fail gracefully | Scenario 2: server-info shows `mdns_active: false`, `lan_url: null` |
| Repeatable before alpha rollout | `moon run api:test-bdd` + `moon run api:smoke` — both CI-runnable |

## Test plan

- [ ] `moon run api:test-bdd` — 3 new scenarios pass (no @wip)
- [ ] `moon run api:smoke` — `boot.hurl` passes against a running local server
- [ ] `moon run api:lint` — no new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added offline startup validation: BDD scenarios and a smoke test verify the server boots and serves API endpoints with no internet, including health checks reporting database "ok", server-info reflecting disabled LAN access, and diagnostics confirming mdns_active is false.
* **Documentation**
  * Updated changelog to document graceful mDNS registration failure handling: logged warning, continued startup, and degraded state exposed via API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->