### PR TITLE
docs(claude): split host vs container worktree rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ Underlying tools: `cargo` (Rust), `pnpm` (SvelteKit). Use directly only when dia
 
 ## Session Startup
 
-- Code-modifying sessions use `claude --worktree` for automatic isolation
-- If not launched with `--worktree`, use the `EnterWorktree` tool to create one before making changes
+- **Host sessions**: code-modifying work uses `claude --worktree` for automatic isolation. If not launched with `--worktree`, use the `EnterWorktree` tool to create one before making changes.
+- **Container sessions (cmux/Docker)**: the container **is** the worktree — do NOT run `claude --worktree`, `EnterWorktree`, or `git worktree add` inside `/workspace`. Git writes the new worktree's metadata with container-only paths (e.g. `gitdir: /workspace/...`) into the bind-mounted `.git/worktrees/`, the host sees those entries as `prunable`, and any host `git worktree prune` wipes them — silently breaking every git-backed tool (`moon`, `lefthook`, `gh`) in whichever container was using that metadata. Parallelism inside a container uses sub-agents that share the same `/workspace`; for a genuinely separate workspace, stop and spin up a second host-created worktree in its own container.
 - **Never push to main directly** — always branch + PR
 - **Commit+push after every logical chunk** — never leave work local-only
 - **Update CHANGELOG.md** — add user-facing changes (`feat`, `fix`, `perf`) to the `## Unreleased` section in each PR


### PR DESCRIPTION
## Summary

Add the container-session rule that prevents the silent-git-breakage class of bugs fixed in ops#270. In-container Claude sessions must **not** run `claude --worktree`, `EnterWorktree`, or `git worktree add` inside `/workspace` — the new worktree's metadata gets written with container-only paths into the bind-mounted `.git/worktrees/`, the host marks it `prunable`, and any later host-side `git worktree prune` wipes the metadata and silently breaks every git-backed tool (`moon`, `lefthook`, `gh`) in whichever container was using it.

Host sessions are unchanged — `--worktree` / `EnterWorktree` are still the right isolation pattern on the host.

## Context

- ops#270 adds the **detection/repair** half (validate in start script, warn at container boot).
- This PR adds the **prevention** half (don't create the broken state in the first place).

## Test plan

- [x] CLAUDE.md renders with the new bullet
- [ ] Next in-container Claude session reads the rule and refrains from creating sub-worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified session guidance distinguishing host and container-based environments.
  * Added specifications on constraints for container operations.
  * Enhanced documentation for configuring parallel workspaces correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->