### PR TITLE
feat(api): migrate status CLI + --verbose/--quiet global flags (#406 #407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **`mokumo migrate status`**: New CLI subcommand that shows the current schema version, lists all applied migrations with timestamps, and lists any pending (unapplied) migrations. Useful for advanced users and CI pipelines that need to verify migration state before upgrades. (#406)
-- **`--verbose` / `--quiet` global CLI flags**: `-v` sets tracing to `debug`, `-vv` sets it to `trace`, and `-q` suppresses all output except errors. Both flags apply server-wide and override `RUST_LOG` when specified. (#407)
+- **`--verbose` / `--quiet` global CLI flags**: `-v` sets the server tracing level to `debug`, `-vv` to `trace`, and `-q` suppresses all output except errors. Accepted in any position on the command line (global Clap args); override `RUST_LOG` for the server console layer on startup. (#407)
 
 - **Shop logo upload**: `POST /api/shop/logo` accepts PNG, JPEG, or WebP (≤ 2 MB, ≤ 2048×2048 px). `GET /api/shop/logo` serves the file publicly. `DELETE /api/shop/logo` removes it. Setup status includes `logo_url` for sidebar display. Sidebar profile trigger shows the custom logo or falls back to a Store glyph. Backup and restore preserve the logo file alongside the database. (#283)
 - **Support-facing health surface**: `GET /api/diagnostics` now includes system-level signals — memory usage, disk space, hostname — so support can perform first-pass triage without SSH access. Build commit SHA is included for version tracking. (#319)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`mokumo migrate status`**: New CLI subcommand that shows the current schema version, lists all applied migrations with timestamps, and lists any pending (unapplied) migrations. Useful for advanced users and CI pipelines that need to verify migration state before upgrades. (#406)
+- **`--verbose` / `--quiet` global CLI flags**: `-v` sets tracing to `debug`, `-vv` sets it to `trace`, and `-q` suppresses all output except errors. Both flags apply server-wide and override `RUST_LOG` when specified. (#407)
+
 - **Shop logo upload**: `POST /api/shop/logo` accepts PNG, JPEG, or WebP (≤ 2 MB, ≤ 2048×2048 px). `GET /api/shop/logo` serves the file publicly. `DELETE /api/shop/logo` removes it. Setup status includes `logo_url` for sidebar display. Sidebar profile trigger shows the custom logo or falls back to a Store glyph. Backup and restore preserve the logo file alongside the database. (#283)
 - **Support-facing health surface**: `GET /api/diagnostics` now includes system-level signals — memory usage, disk space, hostname — so support can perform first-pass triage without SSH access. Build commit SHA is included for version tracking. (#319)
 - **Diagnosis bundle export**: New `GET /api/diagnostics/bundle` endpoint assembles a downloadable ZIP containing app logs (up to 7 days, sensitive values scrubbed) and a `metadata.json` runtime snapshot. The Diagnostics card on the System Settings page gains an "Export Bundle" button. (#316)

--- a/apps/mokumo-desktop/src/lib.rs
+++ b/apps/mokumo-desktop/src/lib.rs
@@ -275,7 +275,7 @@ fn handle_quit(app: &tauri::AppHandle) {
 pub fn run() {
     // Console-only tracing for now — desktop file logging will be added when
     // Tauri's app_data_dir path is wired into init_tracing after .setup().
-    let _log_guard = init_tracing(None);
+    let _log_guard = init_tracing(None, None);
 
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![])

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -16,6 +16,19 @@ use sqlx::sqlite::{SqliteConnection, SqlitePoolOptions};
 
 pub use sea_orm::DatabaseConnection;
 
+/// Returns the names of all migrations registered with the Migrator, in declaration order.
+///
+/// Used by `mokumo migrate status` to compare known migrations against those recorded
+/// in the `seaql_migrations` table, computing which are pending.
+pub fn known_migration_names() -> Vec<String> {
+    use crate::migration::Migrator;
+    use sea_orm_migration::MigratorTrait;
+    Migrator::migrations()
+        .iter()
+        .map(|m| m.name().to_string())
+        .collect()
+}
+
 /// Standard PRAGMAs applied to every SQLite connection pool in Mokumo.
 ///
 /// WAL mode, normal synchronous, 5s busy timeout, foreign keys enforced, 64MB cache.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,14 @@ pre-commit:
       timeout: 60s
     rust-fmt:
       glob: "*.rs"
+      # Override env vars that cause failures in dev containers where the
+      # sccache Redis server is unreachable and /workspace/target is read-only.
+      # cargo fmt doesn't invoke the compiler, but PATH may not include
+      # /cargo-home/bin in all hook environments, so we set it explicitly.
+      env:
+        RUSTC_WRAPPER: ""
+        CARGO_TARGET_DIR: /tmp/mokumo-target
+        PATH: /cargo-home/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       run: cargo fmt --all --check
       timeout: 60s
     oxlint:

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1234,8 +1234,11 @@ pub struct MigrateStatusReport {
 ///
 /// Returns an error string on any database or query failure.
 pub fn cli_migrate_status(db_path: &Path) -> Result<MigrateStatusReport, String> {
-    let conn = rusqlite::Connection::open(db_path)
-        .map_err(|e| format!("Cannot open database at {}: {e}", db_path.display()))?;
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(|e| format!("Cannot open database at {}: {e}", db_path.display()))?;
 
     let table_exists: bool = conn
         .query_row(

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1224,6 +1224,9 @@ pub struct MigrateStatusReport {
     pub current_version: Option<String>,
     pub applied: Vec<MigrationRecord>,
     pub pending: Vec<String>,
+    /// Migrations recorded in the DB but not known to this binary.
+    /// Non-empty only on binary downgrade — the schema is ahead of the binary.
+    pub unknown: Vec<String>,
 }
 
 /// Query the migration state of a database file.
@@ -1254,6 +1257,7 @@ pub fn cli_migrate_status(db_path: &Path) -> Result<MigrateStatusReport, String>
             current_version: None,
             applied: vec![],
             pending: known,
+            unknown: vec![],
         });
     }
 
@@ -1277,10 +1281,19 @@ pub fn cli_migrate_status(db_path: &Path) -> Result<MigrateStatusReport, String>
         .collect::<Result<_, _>>()
         .map_err(|e: rusqlite::Error| format!("Failed to read migration row: {e}"))?;
 
+    let known = mokumo_db::known_migration_names();
+    let known_set: std::collections::HashSet<&str> =
+        known.iter().map(|n| n.as_str()).collect();
+
+    let unknown: Vec<String> = applied
+        .iter()
+        .filter(|r| !known_set.contains(r.name.as_str()))
+        .map(|r| r.name.clone())
+        .collect();
+
     let applied_names: std::collections::HashSet<&str> =
         applied.iter().map(|r| r.name.as_str()).collect();
 
-    let known = mokumo_db::known_migration_names();
     let pending: Vec<String> = known
         .into_iter()
         .filter(|n| !applied_names.contains(n.as_str()))
@@ -1292,6 +1305,7 @@ pub fn cli_migrate_status(db_path: &Path) -> Result<MigrateStatusReport, String>
         current_version,
         applied,
         pending,
+        unknown,
     })
 }
 

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1211,6 +1211,87 @@ pub fn cli_restore(
     Ok(result)
 }
 
+/// A single migration record from `seaql_migrations`, with computed status.
+#[derive(Debug)]
+pub struct MigrationRecord {
+    pub name: String,
+    pub applied_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Output of `mokumo migrate status`.
+#[derive(Debug)]
+pub struct MigrateStatusReport {
+    pub current_version: Option<String>,
+    pub applied: Vec<MigrationRecord>,
+    pub pending: Vec<String>,
+}
+
+/// Query the migration state of a database file.
+///
+/// Opens the database with a raw rusqlite connection (no pool, no migrations).
+/// Returns the set of applied migrations (with timestamps) and pending migrations
+/// (known to the binary but not recorded in `seaql_migrations`).
+///
+/// Returns an error string on any database or query failure.
+pub fn cli_migrate_status(db_path: &Path) -> Result<MigrateStatusReport, String> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| format!("Cannot open database at {}: {e}", db_path.display()))?;
+
+    let table_exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='seaql_migrations'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Failed to query sqlite_master: {e}"))?;
+
+    if !table_exists {
+        let known = mokumo_db::known_migration_names();
+        return Ok(MigrateStatusReport {
+            current_version: None,
+            applied: vec![],
+            pending: known,
+        });
+    }
+
+    let mut stmt = conn
+        .prepare("SELECT version, applied_at FROM seaql_migrations ORDER BY version")
+        .map_err(|e| format!("Failed to prepare migration query: {e}"))?;
+
+    let applied: Vec<MigrationRecord> = stmt
+        .query_map([], |row| {
+            let name: String = row.get(0)?;
+            let ts: i64 = row.get(1)?;
+            Ok((name, ts))
+        })
+        .map_err(|e| format!("Failed to query seaql_migrations: {e}"))?
+        .map(|r| {
+            r.map(|(name, ts)| MigrationRecord {
+                applied_at: chrono::DateTime::from_timestamp(ts, 0),
+                name,
+            })
+        })
+        .collect::<Result<_, _>>()
+        .map_err(|e: rusqlite::Error| format!("Failed to read migration row: {e}"))?;
+
+    let applied_names: std::collections::HashSet<&str> =
+        applied.iter().map(|r| r.name.as_str()).collect();
+
+    let known = mokumo_db::known_migration_names();
+    let pending: Vec<String> = known
+        .into_iter()
+        .filter(|n| !applied_names.contains(n.as_str()))
+        .collect();
+
+    let current_version = applied.last().map(|r| r.name.clone());
+
+    Ok(MigrateStatusReport {
+        current_version,
+        applied,
+        pending,
+    })
+}
+
 fn delete_file(path: &Path, report: &mut ResetReport) {
     match std::fs::remove_file(path) {
         Ok(()) => report.deleted.push(path.to_path_buf()),

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -1282,8 +1282,7 @@ pub fn cli_migrate_status(db_path: &Path) -> Result<MigrateStatusReport, String>
         .map_err(|e: rusqlite::Error| format!("Failed to read migration row: {e}"))?;
 
     let known = mokumo_db::known_migration_names();
-    let known_set: std::collections::HashSet<&str> =
-        known.iter().map(|n| n.as_str()).collect();
+    let known_set: std::collections::HashSet<&str> = known.iter().map(|n| n.as_str()).collect();
 
     let unknown: Vec<String> = applied
         .iter()

--- a/services/api/src/logging.rs
+++ b/services/api/src/logging.rs
@@ -7,11 +7,15 @@ use tracing_subscriber::{
 
 /// Initialize the global tracing subscriber with dual-layer output.
 ///
-/// - **Console layer**: human-readable text with ANSI colors, filtered by `RUST_LOG`
-///   (defaults to `info`).
+/// - **Console layer**: human-readable text with ANSI colors, filtered by `console_level`
+///   when provided, otherwise by `RUST_LOG` (defaults to `info`).
 /// - **File layer** (when `log_dir` is `Some`): JSON (NDJSON) with daily rotation and
 ///   7-day retention via `max_log_files(7)`. Uses a fixed `info` filter regardless of
 ///   `RUST_LOG` to keep production log volume predictable.
+///
+/// `console_level` accepts a tracing directive string (`"error"`, `"warn"`, `"info"`,
+/// `"debug"`, `"trace"`). When `Some`, it overrides `RUST_LOG` for the console layer.
+/// When `None`, `RUST_LOG` is used (defaulting to `"info"` on parse failure).
 ///
 /// Returns the [`WorkerGuard`] for the non-blocking file writer. The caller **must**
 /// hold this guard for the process lifetime — dropping it flushes buffered logs and
@@ -19,13 +23,17 @@ use tracing_subscriber::{
 ///
 /// If `log_dir` is `None` or the file appender fails to initialize, only console
 /// output is active and `None` is returned.
-pub fn init_tracing(log_dir: Option<&Path>) -> Option<WorkerGuard> {
-    let console_filter = EnvFilter::try_from_default_env().unwrap_or_else(|e| {
-        if std::env::var_os("RUST_LOG").is_some() {
-            eprintln!("WARNING: Invalid RUST_LOG value, falling back to 'info': {e}");
-        }
-        "info".into()
-    });
+pub fn init_tracing(log_dir: Option<&Path>, console_level: Option<&str>) -> Option<WorkerGuard> {
+    let console_filter = if let Some(level) = console_level {
+        EnvFilter::new(level)
+    } else {
+        EnvFilter::try_from_default_env().unwrap_or_else(|e| {
+            if std::env::var_os("RUST_LOG").is_some() {
+                eprintln!("WARNING: Invalid RUST_LOG value, falling back to 'info': {e}");
+            }
+            "info".into()
+        })
+    };
 
     let console_layer = fmt::layer().with_target(true).with_filter(console_filter);
 
@@ -72,10 +80,53 @@ fn build_file_layer(
     Ok((layer, guard))
 }
 
+/// Map `--verbose` / `--quiet` CLI flags to a tracing directive string.
+///
+/// Returns `None` when neither flag is set, deferring to `RUST_LOG`.
+/// `quiet` takes precedence over `verbose` when both are somehow present.
+pub fn console_level_from_flags(quiet: bool, verbose: u8) -> Option<&'static str> {
+    if quiet {
+        Some("error")
+    } else {
+        match verbose {
+            0 => None,
+            1 => Some("debug"),
+            _ => Some("trace"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn console_level_from_flags_defaults_to_none() {
+        assert_eq!(console_level_from_flags(false, 0), None);
+    }
+
+    #[test]
+    fn console_level_from_flags_single_v_is_debug() {
+        assert_eq!(console_level_from_flags(false, 1), Some("debug"));
+    }
+
+    #[test]
+    fn console_level_from_flags_double_v_is_trace() {
+        assert_eq!(console_level_from_flags(false, 2), Some("trace"));
+        assert_eq!(console_level_from_flags(false, 255), Some("trace"));
+    }
+
+    #[test]
+    fn console_level_from_flags_quiet_is_error() {
+        assert_eq!(console_level_from_flags(true, 0), Some("error"));
+    }
+
+    #[test]
+    fn console_level_from_flags_quiet_takes_precedence() {
+        // quiet wins even if verbose is also somehow set
+        assert_eq!(console_level_from_flags(true, 2), Some("error"));
+    }
 
     #[test]
     fn build_file_layer_fails_for_nonexistent_path() {

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -38,11 +38,11 @@ struct Cli {
     ws_ping_ms: Option<u64>,
 
     /// Increase log verbosity: -v = debug, -vv = trace. Overrides RUST_LOG.
-    #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "quiet")]
+    #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "quiet", global = true)]
     verbose: u8,
 
     /// Suppress all log output except errors. Overrides RUST_LOG.
-    #[arg(short, long, conflicts_with = "verbose")]
+    #[arg(short, long, conflicts_with = "verbose", global = true)]
     quiet: bool,
 
     #[command(subcommand)]
@@ -98,8 +98,17 @@ enum Commands {
         #[arg(long)]
         production: bool,
     },
-    /// Show current schema version and pending migrations
-    MigrateStatus {
+    /// Database migration commands
+    Migrate {
+        #[command(subcommand)]
+        action: MigrateCommands,
+    },
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum MigrateCommands {
+    /// Show current schema version, applied migrations, and any pending migrations
+    Status {
         /// Check the production profile instead of the default demo profile
         #[arg(long)]
         production: bool,
@@ -719,7 +728,9 @@ async fn main() {
             }
             return;
         }
-        Some(Commands::MigrateStatus { production }) => {
+        Some(Commands::Migrate {
+            action: MigrateCommands::Status { production },
+        }) => {
             let profile_dir = profile_dir(&data_dir, production);
             let db_path = profile_dir.join("mokumo.db");
 

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -731,15 +731,21 @@ async fn main() {
         Some(Commands::Migrate {
             action: MigrateCommands::Status { production },
         }) => {
-            let profile_dir = profile_dir(&data_dir, production);
-            let db_path = profile_dir.join("mokumo.db");
+            // -v/-q flags are accepted (global = true) but have no effect here:
+            // output is plain println!/eprintln!, not tracing. init_tracing is
+            // only called for the server startup path below.
+            let profile = if production {
+                SetupMode::Production
+            } else {
+                resolve_active_profile(&data_dir)
+            };
+            let db_path = data_dir.join(profile.as_dir_name()).join("mokumo.db");
 
             match db_path.try_exists() {
                 Ok(true) => {}
                 Ok(false) => {
-                    let mode = if production { "production" } else { "demo" };
                     eprintln!(
-                        "No database found for the {mode} profile at {}",
+                        "No database found at {}",
                         db_path.display()
                     );
                     std::process::exit(1);
@@ -762,6 +768,18 @@ async fn main() {
                         report.applied.len()
                     );
                     println!();
+
+                    if !report.unknown.is_empty() {
+                        eprintln!(
+                            "WARNING: {} migration(s) in DB not recognized by this binary \
+                             (binary downgrade?)",
+                            report.unknown.len()
+                        );
+                        for name in &report.unknown {
+                            eprintln!("  [?] {name}");
+                        }
+                        eprintln!();
+                    }
 
                     if !report.applied.is_empty() {
                         println!("Applied migrations:");

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -744,10 +744,7 @@ async fn main() {
             match db_path.try_exists() {
                 Ok(true) => {}
                 Ok(false) => {
-                    eprintln!(
-                        "No database found at {}",
-                        db_path.display()
-                    );
+                    eprintln!("No database found at {}", db_path.display());
                     std::process::exit(1);
                 }
                 Err(e) => {

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -4,10 +4,11 @@ use clap::Parser;
 use tokio_util::sync::CancellationToken;
 
 use mokumo_api::{
-    DB_SIDECAR_SUFFIXES, ServerConfig, build_app_with_shutdown, cli_backup, cli_reset_db,
-    cli_reset_password, cli_restore, discovery, ensure_data_dirs, format_lock_conflict_message,
-    format_reset_db_conflict_message, lock_file_path, logging::init_tracing, prepare_database,
-    read_lock_info, resolve_active_profile, try_bind, write_lock_info,
+    DB_SIDECAR_SUFFIXES, ServerConfig, build_app_with_shutdown, cli_backup, cli_migrate_status,
+    cli_reset_db, cli_reset_password, cli_restore, discovery, ensure_data_dirs,
+    format_lock_conflict_message, format_reset_db_conflict_message, lock_file_path,
+    logging::{console_level_from_flags, init_tracing},
+    prepare_database, read_lock_info, resolve_active_profile, try_bind, write_lock_info,
 };
 use mokumo_core::setup::SetupMode;
 
@@ -35,6 +36,14 @@ struct Cli {
     #[cfg(debug_assertions)]
     #[arg(long, hide = true)]
     ws_ping_ms: Option<u64>,
+
+    /// Increase log verbosity: -v = debug, -vv = trace. Overrides RUST_LOG.
+    #[arg(short, long, action = clap::ArgAction::Count, conflicts_with = "quiet")]
+    verbose: u8,
+
+    /// Suppress all log output except errors. Overrides RUST_LOG.
+    #[arg(short, long, conflicts_with = "verbose")]
+    quiet: bool,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -86,6 +95,12 @@ enum Commands {
         /// Path to the backup file to restore from
         path: PathBuf,
         /// Restore to the production profile instead of the default demo profile
+        #[arg(long)]
+        production: bool,
+    },
+    /// Show current schema version and pending migrations
+    MigrateStatus {
+        /// Check the production profile instead of the default demo profile
         #[arg(long)]
         production: bool,
     },
@@ -704,6 +719,67 @@ async fn main() {
             }
             return;
         }
+        Some(Commands::MigrateStatus { production }) => {
+            let profile_dir = profile_dir(&data_dir, production);
+            let db_path = profile_dir.join("mokumo.db");
+
+            match db_path.try_exists() {
+                Ok(true) => {}
+                Ok(false) => {
+                    let mode = if production { "production" } else { "demo" };
+                    eprintln!(
+                        "No database found for the {mode} profile at {}",
+                        db_path.display()
+                    );
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("Cannot access database path {}: {e}", db_path.display());
+                    std::process::exit(1);
+                }
+            }
+
+            match cli_migrate_status(&db_path) {
+                Ok(report) => {
+                    let total = report.applied.len() + report.pending.len();
+                    match &report.current_version {
+                        Some(v) => println!("Current schema version: {v}"),
+                        None => println!("Current schema version: (none — no migrations applied)"),
+                    }
+                    println!(
+                        "Status: {}/{total} migrations applied",
+                        report.applied.len()
+                    );
+                    println!();
+
+                    if !report.applied.is_empty() {
+                        println!("Applied migrations:");
+                        for m in &report.applied {
+                            let ts = match m.applied_at {
+                                Some(dt) => dt.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+                                None => "unknown timestamp".to_string(),
+                            };
+                            println!("  [x] {:<50} ({})", m.name, ts);
+                        }
+                        println!();
+                    }
+
+                    if report.pending.is_empty() {
+                        println!("Pending migrations: none");
+                    } else {
+                        println!("Pending migrations:");
+                        for name in &report.pending {
+                            println!("  [ ] {name}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("migrate status failed: {e}");
+                    std::process::exit(1);
+                }
+            }
+            return;
+        }
         None => {} // No subcommand — fall through to server startup
     }
 
@@ -730,7 +806,8 @@ async fn main() {
     // Initialize tracing: human-readable console + JSON file output with daily
     // rotation and 7-day retention. The guard must live for the process lifetime
     // to ensure buffered log entries are flushed on shutdown.
-    let _log_guard = init_tracing(Some(&config.data_dir.join("logs")));
+    let console_level = console_level_from_flags(cli.quiet, cli.verbose);
+    let _log_guard = init_tracing(Some(&config.data_dir.join("logs")), console_level);
 
     // Acquire process-level flock — prevents concurrent server instances and
     // signals to `reset-db` that this process is running. Held for the entire

--- a/services/api/tests/cli_migrate_status.rs
+++ b/services/api/tests/cli_migrate_status.rs
@@ -1,0 +1,122 @@
+//! Integration tests for the `mokumo migrate status` CLI subcommand.
+
+use tempfile::tempdir;
+
+fn create_seaql_table(conn: &rusqlite::Connection) {
+    conn.execute_batch(
+        "CREATE TABLE seaql_migrations (version TEXT NOT NULL, applied_at BIGINT NOT NULL);",
+    )
+    .unwrap();
+}
+
+fn insert_migration(conn: &rusqlite::Connection, version: &str, applied_at: i64) {
+    conn.execute(
+        "INSERT INTO seaql_migrations (version, applied_at) VALUES (?1, ?2)",
+        rusqlite::params![version, applied_at],
+    )
+    .unwrap();
+}
+
+#[test]
+fn migrate_status_fresh_db_all_pending() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("mokumo.db");
+
+    // Fresh DB: seaql_migrations table does not exist.
+    rusqlite::Connection::open(&db_path).unwrap();
+
+    let report = mokumo_api::cli_migrate_status(&db_path).unwrap();
+
+    assert!(report.current_version.is_none(), "no version on fresh db");
+    assert!(
+        report.applied.is_empty(),
+        "no applied migrations on fresh db"
+    );
+    assert!(
+        !report.pending.is_empty(),
+        "all known migrations should be pending"
+    );
+    let known = mokumo_db::known_migration_names();
+    assert_eq!(
+        report.pending, known,
+        "pending should equal all known migrations"
+    );
+}
+
+#[test]
+fn migrate_status_fully_migrated_no_pending() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("mokumo.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    create_seaql_table(&conn);
+
+    let known = mokumo_db::known_migration_names();
+    for name in &known {
+        insert_migration(&conn, name, 1_700_000_000);
+    }
+
+    let report = mokumo_api::cli_migrate_status(&db_path).unwrap();
+
+    assert_eq!(
+        report.current_version.as_deref(),
+        known.last().map(|s| s.as_str()),
+        "current version should be the last applied migration"
+    );
+    assert_eq!(report.applied.len(), known.len(), "all migrations applied");
+    assert!(report.pending.is_empty(), "no pending migrations");
+}
+
+#[test]
+fn migrate_status_partial_pending() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("mokumo.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    create_seaql_table(&conn);
+
+    let known = mokumo_db::known_migration_names();
+    // Apply only the first migration.
+    insert_migration(&conn, &known[0], 1_700_000_000);
+
+    let report = mokumo_api::cli_migrate_status(&db_path).unwrap();
+
+    assert_eq!(report.applied.len(), 1);
+    assert_eq!(report.applied[0].name, known[0]);
+    assert_eq!(report.pending.len(), known.len() - 1);
+    assert_eq!(
+        report.pending,
+        known[1..],
+        "pending should be all after the first"
+    );
+}
+
+#[test]
+fn migrate_status_applied_at_parses_timestamp() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("mokumo.db");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    create_seaql_table(&conn);
+
+    let known = mokumo_db::known_migration_names();
+    // 2024-01-15 12:00:00 UTC = 1705320000
+    insert_migration(&conn, &known[0], 1_705_320_000);
+
+    let report = mokumo_api::cli_migrate_status(&db_path).unwrap();
+
+    let applied_at = report.applied[0]
+        .applied_at
+        .expect("should parse timestamp");
+    assert_eq!(applied_at.format("%Y-%m-%d").to_string(), "2024-01-15");
+}
+
+#[test]
+fn migrate_status_invalid_path_returns_error() {
+    // SQLite creates files on open, so testing a truly nonexistent path requires
+    // a path whose parent directory doesn't exist (SQLite can't create parent dirs).
+    let db_path = std::path::Path::new("/nonexistent/parent/dir/mokumo.db");
+
+    let err = mokumo_api::cli_migrate_status(db_path).unwrap_err();
+    assert!(
+        !err.is_empty(),
+        "should return a non-empty error for invalid path"
+    );
+}


### PR DESCRIPTION
## Summary

  - **`mokumo migrate status`** (#406): New CLI subcommand that reads the `seaql_migrations` table directly (read-only SQLite connection) and reports current schema version, all applied migrations with UTC timestamps, and all pending migrations diffed against the known migration list in `crates/db`.
  - **`--verbose` / `--quiet` global flags** (#407): `-v` sets console log level to `debug`, `-vv` to `trace`, `-q` to `error`; accepted in any Clap position via `global = true`; overrides `RUST_LOG` for the server console layer on startup.
  - `known_migration_names()` added to `crates/db` to keep `sea-orm-migration` dependency boundary correct.

  ## Test plan

  - [ ] `moon run api:test` — all unit + integration tests pass (5 new integration tests in `tests/cli_migrate_status.rs`)
  - [ ] `mokumo migrate status` against a fresh DB shows all migrations pending
  - [ ] `mokumo migrate status` after running migrations shows all applied with timestamps
  - [ ] `mokumo serve -v` starts with debug-level console logs
  - [ ] `mokumo serve -vv` starts with trace-level console logs
  - [ ] `mokumo serve -q` starts with error-only console logs
  - [ ] `mokumo migrate status -v` parses global flag in subcommand position

  Closes #406
  Closes #407