### PR TITLE
chore(devex): fix container git hooks silently skipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mokumo",
   "private": true,
   "scripts": {
-    "postinstall": "lefthook install --force"
+    "postinstall": "lefthook install --force --reset-hooks-path"
   },
   "devDependencies": {
     "lefthook": "^2.1.4"


### PR DESCRIPTION
## Summary

- Adds `--reset-hooks-path` to the `lefthook install --force` postinstall script
- When a dev container mounts the worktree's `.git`, it inherits any `core.hooksPath` written by the host — pointing to a host-only path that doesn't exist inside the container, so all hooks silently no-op
- The new flag unsets the stale `core.hooksPath` before reinstalling hooks, so `pre-commit` (rust-fmt, oxlint, gitleaks, etc.) and `pre-push` (rust-clippy) actually execute in container sessions
- On host (where `core.hooksPath` is already unset), the flag is a safe no-op — verified locally

## Root cause

`lefthook install --force` in `postinstall` doesn't clear a pre-existing `core.hooksPath`. When the container mounts the shared `.git` directory, it inherits whatever the host wrote. The `--reset-hooks-path` flag (added in lefthook 2.x) was specifically designed for this scenario.

## Verification

After merging, in a fresh container session:
```bash
git config --local core.hooksPath   # should return nothing (unset)
# stage a .rs file with a formatting violation and git commit — should be rejected
```

## What this doesn't cover

If `pnpm install` doesn't run during container startup, the postinstall hook won't fire. This PR assumes the container entrypoint (or `start-worktree-container.sh` once built) runs `pnpm install`. If it doesn't, a follow-up will need to explicitly invoke `lefthook install --force --reset-hooks-path` via `docker exec` in the start script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)