### PR TITLE
fix(api,db): address review findings — silent failures, TOCTOU, read-only open, doc accuracy

### DIFF
--- a/apps/web/src/lib/types/ServerStartupError.ts
+++ b/apps/web/src/lib/types/ServerStartupError.ts
@@ -8,14 +8,17 @@
  * `backup_path` (when `Some`) points to the pre-migration backup that was taken
  * before the failure — the shop owner can use it to restore their data.
  */
-export type ServerStartupError = {
-  "code": "migration_failed";
-  path: string;
-  message: string;
-  backup_path: string | null;
-} | {
-  "code": "schema_incompatible";
-  path: string;
-  unknown_migrations: Array<string>;
-  backup_path: string | null;
-} | { "code": "not_mokumo_database"; path: string };
+export type ServerStartupError =
+  | {
+      code: "migration_failed";
+      path: string;
+      message: string;
+      backup_path: string | null;
+    }
+  | {
+      code: "schema_incompatible";
+      path: string;
+      unknown_migrations: Array<string>;
+      backup_path: string | null;
+    }
+  | { code: "not_mokumo_database"; path: string };

--- a/apps/web/src/lib/types/ServerStartupError.ts
+++ b/apps/web/src/lib/types/ServerStartupError.ts
@@ -8,17 +8,14 @@
  * `backup_path` (when `Some`) points to the pre-migration backup that was taken
  * before the failure — the shop owner can use it to restore their data.
  */
-export type ServerStartupError =
-  | {
-      code: "migration_failed";
-      path: string;
-      message: string;
-      backup_path: string | null;
-    }
-  | {
-      code: "schema_incompatible";
-      path: string;
-      unknown_migrations: Array<string>;
-      backup_path: string | null;
-    }
-  | { code: "not_mokumo_database"; path: string };
+export type ServerStartupError = {
+  "code": "migration_failed";
+  path: string;
+  message: string;
+  backup_path: string | null;
+} | {
+  "code": "schema_incompatible";
+  path: string;
+  unknown_migrations: Array<string>;
+  backup_path: string | null;
+} | { "code": "not_mokumo_database"; path: string };

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -262,20 +262,33 @@ pub struct DbDiagnostics {
     pub wal_size_bytes: u64,
 }
 
+impl DbDiagnostics {
+    /// Returns `true` when more than 20 % of pages are free (unfragmented space
+    /// reclaimed by deletions). Threshold is defined here so all callers stay in sync.
+    pub fn vacuum_needed(&self) -> bool {
+        self.page_count > 0
+            && (self.freelist_count as f64 / self.page_count as f64) > 0.20
+    }
+}
+
 /// Collect disk-level diagnostics for a SQLite database file.
 ///
-/// Opens the file with rusqlite (read-only sufficient), reads the four
-/// key PRAGMAs, and measures the WAL file size via `fs::metadata`.
+/// Opens the file read-only (SQLITE_OPEN_READ_ONLY | SQLITE_OPEN_NO_MUTEX), reads
+/// the four key PRAGMAs, and measures the WAL file size via `fs::metadata`.
+/// Read-only mode avoids contending for write locks on a WAL-mode database and
+/// prevents accidental file creation when the path does not yet exist.
 ///
 /// # Errors
 ///
 /// Returns `rusqlite::Error` if the file cannot be opened or a PRAGMA
 /// query fails. Callers should treat errors as "unknown" diagnostics rather
-/// than a hard failure (the database may be in WAL mode and locked by the
-/// server process — rusqlite opens in read-only shared mode so concurrent
-/// access is safe).
+/// than a hard failure.
 pub fn diagnose_database(db_path: &std::path::Path) -> Result<DbDiagnostics, rusqlite::Error> {
-    let conn = rusqlite::Connection::open(db_path)?;
+    use rusqlite::OpenFlags;
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
 
     fn get_pragma<T: rusqlite::types::FromSql>(
         conn: &rusqlite::Connection,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -266,8 +266,7 @@ impl DbDiagnostics {
     /// Returns `true` when more than 20 % of pages are free (unfragmented space
     /// reclaimed by deletions). Threshold is defined here so all callers stay in sync.
     pub fn vacuum_needed(&self) -> bool {
-        self.page_count > 0
-            && (self.freelist_count as f64 / self.page_count as f64) > 0.20
+        self.page_count > 0 && (self.freelist_count as f64 / self.page_count as f64) > 0.20
     }
 }
 

--- a/services/api/src/auth/mod.rs
+++ b/services/api/src/auth/mod.rs
@@ -381,11 +381,14 @@ async fn auto_login(
     }
 }
 
-/// Combined middleware: demo auto-login + login-required check.
+/// Combined middleware: 423 boot guard + demo auto-login + login-required check.
 ///
-/// In demo mode: if no user is authenticated, automatically log in the demo admin.
-/// In all modes: reject the request with 401 if no user is authenticated after
-/// the auto-login attempt.
+/// Execution order (all modes):
+/// 1. **Boot guard** — if `demo_install_ok` is false and the path is not
+///    `DEMO_RESET_PATH`, return 423 `DemoSetupRequired`. This guard is only active
+///    in Demo profile; Production always boots with `demo_install_ok=true`.
+/// 2. **Demo auto-login** — in Demo mode, if no session exists, log in the demo admin.
+/// 3. **Login-required check** — reject with 401 if still unauthenticated.
 ///
 /// This replaces the separate `login_required!` + demo auto-login layers because
 /// `login_required!` checks the user from the incoming request, which doesn't
@@ -399,10 +402,8 @@ pub async fn require_auth_with_demo_auto_login(
     use mokumo_core::setup::SetupMode;
 
     // Boot guard: reject all protected routes while demo installation is incomplete.
-    // Only active when the server is running in Demo profile — after setup switches
-    // the active profile to Production, the flag is no longer relevant and the guard
-    // is skipped entirely (the Production path always boots with demo_install_ok=true
-    // but may transiently observe false if setup runs before the first profile write).
+    // Only active in Demo profile — Production always boots with demo_install_ok=true
+    // and the guard is skipped entirely when Production is active.
     // Exception: /api/demo/reset is the recovery mechanism — it must bypass the entire
     // auth chain (both the 423 guard and the demo auto-login) so it can be called even
     // when admin@demo.local is missing from the database.

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -63,9 +63,14 @@ pub async fn demo_reset(
             // The connection pool is already closed and the file has been replaced.
             // The server cannot serve demo-profile requests in this state. Schedule
             // a restart so the process recovers, then return an error to the caller.
+            // If the sentinel write fails, do NOT schedule shutdown — stopping the
+            // server without restarting it would leave the shop with no running server.
             let sentinel = state.data_dir.join(".restart");
             if let Err(se) = std::fs::write(&sentinel, b"reset") {
                 tracing::error!("Demo reset: also failed to write restart sentinel: {se}");
+                return Err(AppError::InternalError(
+                    "Failed to schedule automatic restart after demo reset; please restart Mokumo manually.".into(),
+                ));
             }
             let shutdown = state.shutdown.clone();
             tokio::spawn(async move {

--- a/services/api/src/demo.rs
+++ b/services/api/src/demo.rs
@@ -10,9 +10,10 @@ use crate::error::AppError;
 
 /// POST /api/demo/reset — reset the demo database to its original sidecar state.
 ///
-/// Guards: demo mode only. Authentication is enforced by the
-/// `require_auth_with_demo_auto_login` route layer — this handler is only
-/// reachable by authenticated users.
+/// Guards: demo mode only. In normal operation, authentication is enforced by the
+/// `require_auth_with_demo_auto_login` route layer. Exception: when `demo_install_ok`
+/// is false, the middleware bypasses the auth chain for this path so the recovery
+/// mechanism can be called even when `admin@demo.local` is missing from the database.
 pub async fn demo_reset(
     State(state): State<SharedState>,
 ) -> Result<Json<DemoResetResponse>, AppError> {
@@ -59,8 +60,20 @@ pub async fn demo_reset(
             state
                 .demo_install_ok
                 .store(false, std::sync::atomic::Ordering::Release);
+            // The connection pool is already closed and the file has been replaced.
+            // The server cannot serve demo-profile requests in this state. Schedule
+            // a restart so the process recovers, then return an error to the caller.
+            let sentinel = state.data_dir.join(".restart");
+            if let Err(se) = std::fs::write(&sentinel, b"reset") {
+                tracing::error!("Demo reset: also failed to write restart sentinel: {se}");
+            }
+            let shutdown = state.shutdown.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                shutdown.cancel();
+            });
             return Err(AppError::InternalError(
-                "Failed to initialize demo database after reset".into(),
+                "Failed to initialize demo database after reset; server will restart".into(),
             ));
         }
     }

--- a/services/api/src/diagnostics.rs
+++ b/services/api/src/diagnostics.rs
@@ -74,8 +74,10 @@ pub async fn collect(state: &SharedState) -> Result<DiagnosticsResponse, AppErro
 
 /// Returns `true` when available disk space for the data directory is below the threshold.
 ///
-/// Threshold is read from `MOKUMO_DISK_WARNING_THRESHOLD_BYTES` (default: 500 MB).
-/// Returns `false` when no disk volume can be found — not a blocking condition.
+/// Threshold is read from `MOKUMO_DISK_WARNING_THRESHOLD_BYTES` (default: 500 MiB).
+/// Set to `0` to disable the warning entirely — the `u64` comparison `available < 0`
+/// is never true. Returns `false` when no disk volume can be found (not a blocking
+/// condition).
 pub fn compute_disk_warning(data_dir: &Path) -> bool {
     let threshold: u64 = std::env::var("MOKUMO_DISK_WARNING_THRESHOLD_BYTES")
         .ok()
@@ -134,24 +136,20 @@ async fn read_profile_diagnostics(
     let file_size_bytes = tokio::fs::metadata(db_path).await.ok().map(|m| m.len());
 
     let db_path_owned = db_path.to_path_buf();
-    let disk_diag =
-        tokio::task::spawn_blocking(move || mokumo_db::diagnose_database(&db_path_owned))
+    let (wal_size_bytes, vacuum_needed) =
+        match tokio::task::spawn_blocking(move || mokumo_db::diagnose_database(&db_path_owned))
             .await
-            .unwrap_or_else(|e| {
+        {
+            Ok(Ok(d)) => (d.wal_size_bytes, d.vacuum_needed()),
+            Ok(Err(e)) => {
+                tracing::warn!(db = %db_path.display(), "diagnose_database failed: {e}");
+                (0, false)
+            }
+            Err(e) => {
                 tracing::warn!("spawn_blocking for diagnose_database panicked: {e}");
-                Err(rusqlite::Error::QueryReturnedNoRows)
-            });
-
-    let (wal_size_bytes, vacuum_needed) = match disk_diag {
-        Ok(d) => {
-            let vn = d.page_count > 0 && (d.freelist_count as f64 / d.page_count as f64) > 0.20;
-            (d.wal_size_bytes, vn)
-        }
-        Err(e) => {
-            tracing::warn!(db = %db_path.display(), "diagnose_database failed: {e}");
-            (0, false)
-        }
-    };
+                (0, false)
+            }
+        };
 
     Ok(ProfileDbDiagnostics {
         schema_version: rt.schema_version,

--- a/services/api/src/diagnostics.rs
+++ b/services/api/src/diagnostics.rs
@@ -7,7 +7,6 @@ use mokumo_types::diagnostics::{
     AppDiagnostics, DatabaseDiagnostics, DiagnosticsResponse, OsDiagnostics, ProfileDbDiagnostics,
     RuntimeDiagnostics, SystemDiagnostics,
 };
-use rusqlite;
 use sysinfo::{Disks, System};
 
 use crate::{SharedState, error::AppError};

--- a/services/api/src/lib.rs
+++ b/services/api/src/lib.rs
@@ -121,7 +121,9 @@ pub struct AppState {
     /// Prevents concurrent restore operations. Set to true while a restore is in-flight.
     pub restore_in_progress: Arc<AtomicBool>,
     /// True when the demo database has a fully-seeded admin account (admin@demo.local with
-    /// non-empty password_hash). Set at boot; always true for Production profile.
+    /// non-empty password_hash). Set at boot; re-validated after demo reset and on profile
+    /// switch to Demo. When Production is the active profile, callers must gate on
+    /// `active_profile` first — do not read this flag without checking the active profile.
     /// Protected routes return 423 DEMO_SETUP_REQUIRED when this is false.
     pub demo_install_ok: Arc<AtomicBool>,
     /// Rate limiter for restore attempts (5 per hour, shared across validate + restore).
@@ -1420,11 +1422,15 @@ async fn health(
     mokumo_db::health_check(state.db_for(SetupMode::Demo)).await?;
     mokumo_db::health_check(state.db_for(SetupMode::Production)).await?;
 
+    // Read the active profile once — both install_ok and db_path must agree on the
+    // same profile snapshot to avoid a TOCTOU race with a concurrent profile switch.
+    let active = *state.active_profile.read();
+
     // install_ok is only meaningful in Demo profile. In Production the flag is
     // permanently true (set at boot by resolve_demo_install_ok), but we re-derive
     // it from the active profile here so that a cold-start server which later runs
     // setup (switching from Demo→Production) reports install_ok=true immediately.
-    let install_ok = if *state.active_profile.read() == SetupMode::Production {
+    let install_ok = if active == SetupMode::Production {
         true
     } else {
         state
@@ -1432,18 +1438,14 @@ async fn health(
             .load(std::sync::atomic::Ordering::Acquire)
     };
 
-    // storage_ok: disk pressure + fragmentation check on the active profile database.
-    let active = *state.active_profile.read();
+    // storage_ok: disk pressure on the data directory's filesystem volume +
+    // fragmentation check on the active profile database file.
     let db_path = state.data_dir.join(active.as_dir_name()).join("mokumo.db");
     let disk_warning = crate::diagnostics::compute_disk_warning(&state.data_dir);
     let diag_result =
         tokio::task::spawn_blocking(move || mokumo_db::diagnose_database(&db_path)).await;
     let storage_ok = match diag_result {
-        Ok(Ok(diag)) => {
-            let vacuum_needed =
-                diag.page_count > 0 && (diag.freelist_count as f64 / diag.page_count as f64) > 0.20;
-            !disk_warning && !vacuum_needed
-        }
+        Ok(Ok(diag)) => !disk_warning && !diag.vacuum_needed(),
         Ok(Err(e)) => {
             tracing::warn!("diagnose_database failed in health handler: {e}");
             false

--- a/services/api/src/profile_switch.rs
+++ b/services/api/src/profile_switch.rs
@@ -160,7 +160,7 @@ pub async fn profile_switch(
     // Step 8: Logout and login.
     //
     // On failure, roll back the in-memory active_profile and make a best-effort attempt to
-    // restore the disk file. We log rollback errors but do not propagate them — the original
+    // restore the disk file. Rollback errors are logged but not propagated — the original
     // failure is what the caller needs to see.
     if let Err(e) = auth_session.logout().await {
         tracing::error!(
@@ -169,10 +169,12 @@ pub async fn profile_switch(
             "Profile switch: logout failed — rolling back active_profile: {e}"
         );
         *state.active_profile.write() = previous_profile;
-        let path = profile_path.clone();
-        tokio::spawn(async move {
-            let _ = tokio::fs::write(&path, previous_profile.as_str()).await;
-        });
+        if let Err(re) = tokio::fs::write(&profile_path, previous_profile.as_str()).await {
+            tracing::error!(
+                path = %profile_path.display(),
+                "Profile switch: rollback disk write failed — on-disk profile may be inconsistent: {re}"
+            );
+        }
         return Err(AppError::InternalError(
             "Failed to invalidate current session".into(),
         ));
@@ -184,10 +186,12 @@ pub async fn profile_switch(
             "Profile switch: login failed — rolling back active_profile: {e}"
         );
         *state.active_profile.write() = previous_profile;
-        let path = profile_path.clone();
-        tokio::spawn(async move {
-            let _ = tokio::fs::write(&path, previous_profile.as_str()).await;
-        });
+        if let Err(re) = tokio::fs::write(&profile_path, previous_profile.as_str()).await {
+            tracing::error!(
+                path = %profile_path.display(),
+                "Profile switch: rollback disk write failed — on-disk profile may be inconsistent: {re}"
+            );
+        }
         return Err(AppError::InternalError(
             "Failed to create new session".into(),
         ));

--- a/services/api/src/profile_switch.rs
+++ b/services/api/src/profile_switch.rs
@@ -169,7 +169,12 @@ pub async fn profile_switch(
             "Profile switch: logout failed — rolling back active_profile: {e}"
         );
         *state.active_profile.write() = previous_profile;
-        if let Err(re) = tokio::fs::write(&profile_path, previous_profile.as_str()).await {
+        if let Err(re) = async {
+            tokio::fs::write(&profile_tmp, previous_profile.as_str()).await?;
+            tokio::fs::rename(&profile_tmp, &profile_path).await
+        }
+        .await
+        {
             tracing::error!(
                 path = %profile_path.display(),
                 "Profile switch: rollback disk write failed — on-disk profile may be inconsistent: {re}"
@@ -186,7 +191,12 @@ pub async fn profile_switch(
             "Profile switch: login failed — rolling back active_profile: {e}"
         );
         *state.active_profile.write() = previous_profile;
-        if let Err(re) = tokio::fs::write(&profile_path, previous_profile.as_str()).await {
+        if let Err(re) = async {
+            tokio::fs::write(&profile_tmp, previous_profile.as_str()).await?;
+            tokio::fs::rename(&profile_tmp, &profile_path).await
+        }
+        .await
+        {
             tracing::error!(
                 path = %profile_path.display(),
                 "Profile switch: rollback disk write failed — on-disk profile may be inconsistent: {re}"

--- a/services/api/tests/bdd_world/health_steps.rs
+++ b/services/api/tests/bdd_world/health_steps.rs
@@ -218,6 +218,29 @@ async fn get_without_credentials(w: &mut ApiWorld, path: String) {
     w.response = Some(w.server.get(&path).await);
 }
 
+#[when(expr = "I POST to {string} without credentials")]
+async fn post_without_credentials(w: &mut ApiWorld, path: String) {
+    w.response = Some(w.server.post(&path).await);
+}
+
+#[then(expr = "the response status should not be {int}")]
+async fn response_status_not(w: &mut ApiWorld, status: u16) {
+    let resp = w.response.as_ref().expect("no response recorded");
+    let actual = resp.status_code().as_u16();
+    assert_ne!(actual, status, "Expected status != {status}, got {actual}");
+}
+
+#[then(expr = "a subsequent GET {string} returns install_ok as true")]
+async fn subsequent_get_install_ok_true(w: &mut ApiWorld, path: String) {
+    let resp = w.server.get(&path).await;
+    let body: serde_json::Value = resp.json();
+    let install_ok = body["install_ok"].as_bool().unwrap_or(false);
+    assert!(
+        install_ok,
+        "Expected install_ok=true in {path} response, got: {body}"
+    );
+}
+
 // --- Storage-health step definitions ---
 
 /// Set threshold to 0 → any available space satisfies it → disk_warning = false.

--- a/services/api/tests/bdd_world/health_steps.rs
+++ b/services/api/tests/bdd_world/health_steps.rs
@@ -232,7 +232,14 @@ async fn response_status_not(w: &mut ApiWorld, status: u16) {
 
 #[then(expr = "a subsequent GET {string} returns install_ok as true")]
 async fn subsequent_get_install_ok_true(w: &mut ApiWorld, path: String) {
-    let resp = w.server.get(&path).await;
+    w.response = Some(w.server.get(&path).await);
+    let resp = w.response.as_ref().expect("no response captured");
+    assert_eq!(
+        resp.status_code().as_u16(),
+        200,
+        "Expected 200 from {path}, got {}",
+        resp.status_code().as_u16()
+    );
     let body: serde_json::Value = resp.json();
     let install_ok = body["install_ok"].as_bool().unwrap_or(false);
     assert!(

--- a/services/api/tests/features/demo_install_guard.feature
+++ b/services/api/tests/features/demo_install_guard.feature
@@ -50,6 +50,13 @@ Feature: Demo installation guard
     And the json path "message" should not be empty
     And the json path "details" should be null
 
+  # --- Reset endpoint bypass ---
+
+  Scenario: Demo reset endpoint is accessible when installation is incomplete
+    Given the server started with a demo database that has no admin account
+    When I POST to "/api/demo/reset" without credentials
+    Then the response status should not be 423
+
   # --- Reset clears the degraded state ---
 
   Scenario: Server re-evaluates installation after a demo reset

--- a/services/api/tests/features/profile_switch.feature
+++ b/services/api/tests/features/profile_switch.feature
@@ -137,3 +137,10 @@ Feature: Profile switch endpoint
     When I POST to "/api/profile/switch" with body {"profile": "production"}
     Then the response status is 500
     And the user's original session remains valid
+
+  Scenario: Switching to demo updates demo_install_ok
+    Given I am logged in as a production user
+    And the demo database is correctly seeded
+    When I POST to "/api/profile/switch" with body {"profile": "demo"}
+    Then the response status is 200
+    And a subsequent GET "/api/health" returns install_ok as true

--- a/services/api/tests/server_startup.rs
+++ b/services/api/tests/server_startup.rs
@@ -12,7 +12,9 @@ async fn test_app(name: &str) -> (Router, tempfile::TempDir) {
     let tmp = tempfile::tempdir().unwrap();
     let data_dir = tmp.path().join(name);
     ensure_data_dirs(&data_dir).unwrap();
-    let db_path = data_dir.join("mokumo.db");
+    // Use the production subdir so the health handler's db_path computation
+    // (data_dir/production/mokumo.db) resolves to the actual database file.
+    let db_path = data_dir.join("production").join("mokumo.db");
     let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
     let pool = mokumo_db::initialize_database(&database_url).await.unwrap();
     let config = ServerConfig {
@@ -56,7 +58,7 @@ async fn full_startup_flow_with_temp_dirs() {
 
     ensure_data_dirs(&config.data_dir).unwrap();
 
-    let db_path = data_dir.join("mokumo.db");
+    let db_path = data_dir.join("production").join("mokumo.db");
     let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
     let pool = mokumo_db::initialize_database(&database_url).await.unwrap();
 
@@ -99,7 +101,7 @@ async fn health_endpoint_returns_500_error_body_on_db_failure() {
     let data_dir = tmp.path().join("health_503_test");
     ensure_data_dirs(&data_dir).unwrap();
 
-    let db_path = data_dir.join("mokumo.db");
+    let db_path = data_dir.join("production").join("mokumo.db");
     let database_url = format!("sqlite:{}?mode=rwc", db_path.display());
     let db = mokumo_db::initialize_database(&database_url).await.unwrap();
 


### PR DESCRIPTION
## Summary

Addresses critical and important findings from the PR review of health endpoint PRs #342 + #411.

**Critical fixes:**
- `profile_switch.rs` — rollback disk writes were fire-and-forget (`let _ = tokio::spawn(...).await`) with no logging; replaced with awaited writes that log on failure
- `demo_reset` — the `initialize_database` Err branch left the server in an irrecoverable state (pool closed, file replaced, but no restart scheduled); now schedules restart before returning the error
- `health()` — two independent `active_profile.read()` calls created a TOCTOU race with a concurrent profile switch; consolidated to one read
- `diagnose_database` — used `Connection::open()` (read-write + create) despite the doc claiming read-only; changed to `Connection::open_with_flags(READ_ONLY | NO_MUTEX)` to prevent silent empty-file creation

**Maintenance:**
- Extract `DbDiagnostics::vacuum_needed()` method — 20% threshold was duplicated across `lib.rs` and `diagnostics.rs`; single source prevents drift
- Simplify `spawn_blocking` match in `diagnostics.rs` to three arms — removes the fabricated `QueryReturnedNoRows` error that produced misleading second log line on panic

**Documentation:**
- `demo.rs` doc incorrectly stated auth is "always enforced" — the middleware explicitly bypasses auth for this path when `demo_install_ok` is false
- `auth/mod.rs` — add 423 guard to function doc; remove bogus transient-false parenthetical
- `diagnostics.rs` — document threshold=0 as a valid "disable" sentinel
- `lib.rs` — fix `demo_install_ok` field and `storage_ok` inline comments

**Tests:**
- New step defs: `I POST to {path} without credentials`, `status should not be {int}`, `subsequent GET returns install_ok as true`
- `demo_install_guard.feature` — add scenario directly asserting that `/api/demo/reset` returns non-423 when the server is degraded (critical recovery bypass path was never directly tested)
- `profile_switch.feature` — add scenario asserting `demo_install_ok` is updated after switching to demo

Closes #342
Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic database maintenance detection to identify when optimization is beneficial.
  * Enhanced demo reset capability with automatic recovery and restart functionality.

* **Bug Fixes**
  * Fixed potential timing issue in health checks during concurrent profile switches.
  * Improved error handling and rollback reliability during profile changes.

* **Tests**
  * Added test coverage for demo reset access in degraded installation states.
  * Expanded profile switching validation to include installation status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->