### PR TITLE
fix(web): route customer-form non-validation errors through toastApiError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Customer form sheet now shows safe error messages**: unknown or security-sensitive API errors (e.g. `internal_error`) display a user-friendly fallback message instead of raw backend text; known safe codes continue to surface the server message verbatim. (#529)
 - **Profile switcher now shows server error messages**: rate-limited and other known API errors display the backend's message verbatim in a toast instead of a generic fallback. Both the direct switch and the unsaved-changes confirmation path are fixed. (#469)
 - **QR code on Connect Your Team card now renders correctly**: replaced `onMount` with a reactive `$effect` so the QR code re-renders when the IP URL loads asynchronously. Added null guard, loading placeholder, and error fallback state. (#470)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2207,7 +2207,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5438,7 +5438,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5982,7 +5982,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6039,7 +6039,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6050,9 +6050,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7101,7 +7101,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -7879,7 +7878,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/apps/web/src/lib/components/customer-form-sheet.svelte
+++ b/apps/web/src/lib/components/customer-form-sheet.svelte
@@ -29,6 +29,7 @@
   import type { CustomerResponse } from "$lib/types/CustomerResponse";
   import type { ErrorBody } from "$lib/types/ErrorBody";
   import { formDirty } from "$lib/actions/form-dirty";
+  import { toastApiError } from "$lib/utils/error-toast";
   import { buildUpdatePayload } from "$lib/utils/update-payload";
   import Loader2 from "@lucide/svelte/icons/loader-circle";
 
@@ -102,7 +103,7 @@
         ),
       );
     } else {
-      toast.error(error.message);
+      toastApiError(error, "Failed to save customer. Please try again.");
     }
   }
 

--- a/apps/web/src/lib/components/customer-form-sheet.test.ts
+++ b/apps/web/src/lib/components/customer-form-sheet.test.ts
@@ -131,4 +131,30 @@ describe("CustomerFormSheet — applyApiErrors", () => {
       expect(mockToastApiError).toHaveBeenCalledWith(apiError, expect.any(String));
     });
   });
+
+  // ── Validation error (details present) ───────────────────────────────────
+  //
+  // When the API returns field-level details, applyApiErrors should populate
+  // inline fieldErrors — NOT call toastApiError. Verifies the if/else guard
+  // isn't accidentally removed or inverted.
+
+  it("populates field errors from details without calling toastApiError on create", async () => {
+    const apiError = {
+      code: "validation_error" as const,
+      message: "Validation failed",
+      details: { display_name: ["Display name is required"] },
+    };
+    mockCreateCustomer.mockResolvedValue({ ok: false, status: 422, error: apiError });
+
+    render(CustomerFormSheet, { open: true, onClose: vi.fn() });
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/display name/i), "Acme Corp");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockToastApiError).not.toHaveBeenCalled();
+      expect(screen.getByText("Display name is required")).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/lib/components/customer-form-sheet.test.ts
+++ b/apps/web/src/lib/components/customer-form-sheet.test.ts
@@ -4,14 +4,15 @@ import { render, screen, waitFor } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
-const { mockToastApiError } = vi.hoisted(() => ({
+const { mockToastApiError, mockToastError } = vi.hoisted(() => ({
   mockToastApiError: vi.fn(),
+  mockToastError: vi.fn(),
 }));
 
 vi.mock("$app/environment", () => ({ browser: true, dev: false, building: false }));
 vi.mock("$lib/utils/error-toast", () => ({ toastApiError: mockToastApiError }));
 vi.mock("$lib/components/toast", () => ({
-  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+  toast: { success: vi.fn(), info: vi.fn(), error: mockToastError },
 }));
 vi.mock("$lib/api/customers", () => ({
   createCustomer: vi.fn(),
@@ -63,6 +64,7 @@ function makeCustomer(overrides: Partial<CustomerResponse> = {}): CustomerRespon
 describe("CustomerFormSheet — applyApiErrors", () => {
   beforeEach(() => {
     mockToastApiError.mockClear();
+    mockToastError.mockClear();
     mockCreateCustomer.mockClear();
     mockUpdateCustomer.mockClear();
   });
@@ -85,6 +87,7 @@ describe("CustomerFormSheet — applyApiErrors", () => {
 
     await waitFor(() => {
       expect(mockToastApiError).toHaveBeenCalledWith(apiError, expect.any(String));
+      expect(mockToastError).not.toHaveBeenCalled();
     });
   });
 
@@ -105,6 +108,7 @@ describe("CustomerFormSheet — applyApiErrors", () => {
     await waitFor(() => {
       const [, fallback] = mockToastApiError.mock.calls[0] as [unknown, string];
       expect(fallback.length).toBeGreaterThan(0);
+      expect(mockToastError).not.toHaveBeenCalled();
     });
   });
 
@@ -129,6 +133,7 @@ describe("CustomerFormSheet — applyApiErrors", () => {
 
     await waitFor(() => {
       expect(mockToastApiError).toHaveBeenCalledWith(apiError, expect.any(String));
+      expect(mockToastError).not.toHaveBeenCalled();
     });
   });
 
@@ -154,6 +159,7 @@ describe("CustomerFormSheet — applyApiErrors", () => {
 
     await waitFor(() => {
       expect(mockToastApiError).not.toHaveBeenCalled();
+      expect(mockToastError).not.toHaveBeenCalled();
       expect(screen.getByText("Display name is required")).toBeInTheDocument();
     });
   });

--- a/apps/web/src/lib/components/customer-form-sheet.test.ts
+++ b/apps/web/src/lib/components/customer-form-sheet.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const { mockToastApiError } = vi.hoisted(() => ({
+  mockToastApiError: vi.fn(),
+}));
+
+vi.mock("$app/environment", () => ({ browser: true, dev: false, building: false }));
+vi.mock("$lib/utils/error-toast", () => ({ toastApiError: mockToastApiError }));
+vi.mock("$lib/components/toast", () => ({
+  toast: { success: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+vi.mock("$lib/api/customers", () => ({
+  createCustomer: vi.fn(),
+  updateCustomer: vi.fn(),
+}));
+vi.mock("$lib/actions/form-dirty", () => ({
+  formDirty: () => ({ destroy: () => {} }),
+}));
+
+import { createCustomer, updateCustomer } from "$lib/api/customers";
+import CustomerFormSheet from "./customer-form-sheet.svelte";
+import type { CustomerResponse } from "$lib/types/CustomerResponse";
+
+const mockCreateCustomer = vi.mocked(createCustomer);
+const mockUpdateCustomer = vi.mocked(updateCustomer);
+
+function makeCustomer(overrides: Partial<CustomerResponse> = {}): CustomerResponse {
+  return {
+    id: "cust-1",
+    display_name: "Acme Corp",
+    company_name: null,
+    email: null,
+    phone: null,
+    address_line1: null,
+    address_line2: null,
+    city: null,
+    state: null,
+    postal_code: null,
+    country: null,
+    notes: null,
+    portal_enabled: false,
+    portal_user_id: null,
+    tax_exempt: false,
+    tax_exemption_certificate_path: null,
+    tax_exemption_expires_at: null,
+    payment_terms: null,
+    credit_limit_cents: null,
+    stripe_customer_id: null,
+    quickbooks_customer_id: null,
+    lead_source: null,
+    tags: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe("CustomerFormSheet — applyApiErrors", () => {
+  beforeEach(() => {
+    mockToastApiError.mockClear();
+    mockCreateCustomer.mockClear();
+    mockUpdateCustomer.mockClear();
+  });
+
+  // ── Create mode ───────────────────────────────────────────────────────────
+
+  it("routes non-validation error through toastApiError on create (not raw toast.error)", async () => {
+    const apiError = {
+      code: "internal_error" as const,
+      message: "panic at src/handlers/customers.rs:42 — index out of bounds",
+      details: null,
+    };
+    mockCreateCustomer.mockResolvedValue({ ok: false, status: 500, error: apiError });
+
+    render(CustomerFormSheet, { open: true, onClose: vi.fn() });
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/display name/i), "Acme Corp");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockToastApiError).toHaveBeenCalledWith(apiError, expect.any(String));
+    });
+  });
+
+  it("passes a non-empty user-readable fallback to toastApiError on create", async () => {
+    const apiError = {
+      code: "internal_error" as const,
+      message: "raw internal error",
+      details: null,
+    };
+    mockCreateCustomer.mockResolvedValue({ ok: false, status: 500, error: apiError });
+
+    render(CustomerFormSheet, { open: true, onClose: vi.fn() });
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/display name/i), "Acme Corp");
+    await user.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => {
+      const [, fallback] = mockToastApiError.mock.calls[0] as [unknown, string];
+      expect(fallback.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Edit mode ─────────────────────────────────────────────────────────────
+
+  it("routes non-validation error through toastApiError on update (not raw toast.error)", async () => {
+    const apiError = {
+      code: "internal_error" as const,
+      message: "raw server error",
+      details: null,
+    };
+    mockUpdateCustomer.mockResolvedValue({ ok: false, status: 500, error: apiError });
+
+    const customer = makeCustomer({ display_name: "Acme Corp" });
+    render(CustomerFormSheet, { open: true, customer, onClose: vi.fn() });
+    const user = userEvent.setup();
+
+    const nameInput = screen.getByLabelText(/display name/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Acme Corp Updated");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockToastApiError).toHaveBeenCalledWith(apiError, expect.any(String));
+    });
+  });
+});

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,14 +22,18 @@ pre-commit:
     oxlint:
       glob: "apps/web/**/*.{ts,svelte,js}"
       root: "apps/web/"
-      run: oxlint --config ../../.oxlintrc.json {staged_files}
+      # Use `node ./node_modules/oxlint/bin/oxlint` instead of bare `oxlint`
+      # because node_modules/.bin is not on PATH in container hook environments.
+      run: node ./node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json {staged_files}
       timeout: 30s
     # Explicit --config required: oxfmt misidentifies vite.config.ts as config
     # when running under Node without native TS module support (e.g. Node 22).
     oxfmt-check:
       glob: "apps/web/**/*.{ts,js,css,json,md,html}"
       root: "apps/web/"
-      run: oxfmt --config ../../.oxfmtrc.json --check {staged_files}
+      # Use `node ./node_modules/oxfmt/bin/oxfmt` instead of bare `oxfmt`
+      # because node_modules/.bin is not on PATH in container hook environments.
+      run: node ./node_modules/oxfmt/bin/oxfmt --config ../../.oxfmtrc.json --check {staged_files}
       timeout: 30s
     prettier-svelte:
       glob: "apps/web/**/*.svelte"


### PR DESCRIPTION
## Summary

- Replaces unconditional `toast.error(error.message)` in `customer-form-sheet.svelte`'s `applyApiErrors()` with `toastApiError(error, fallback)` — the same allow-list utility introduced in PR #526 for the profile switcher
- Unknown/security-sensitive error codes (e.g. `internal_error`, `unauthorized`) now show a safe fallback message; allow-listed codes continue to surface the server message verbatim
- Also fixes `oxlint`/`oxfmt` pre-commit hooks that were failing in container environments due to `node_modules/.bin` not being on PATH

## Test Plan

- [x] 4 new component tests in `customer-form-sheet.test.ts`: create-mode non-validation error, fallback string non-empty, update-mode non-validation error, field-errors-present path (details branch)
- [x] `moon run web:test` — 252/252 passing
- [x] `moon run web:check` — 0 errors, 0 warnings
- [x] All pre-commit hooks green (oxlint, oxfmt, prettier, gitleaks)

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the customer form to display user-friendly fallback messages for sensitive errors instead of exposing raw backend details. Known safe error codes continue to display server messages as usual.

* **Tests**
  * Added comprehensive test coverage for customer form error handling behavior.

* **Chores**
  * Updated build tool configurations for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->