### PR TITLE
chore(release): tune [profile.release] for binary size and cold-start (#489)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             rust_targets: ''
 
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 60
     env:
       CARGO_TARGET_DIR: target
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Performance
+
+- **Release profile tuning**: Applied `lto = true`, `codegen-units = 1`, `strip = true`, `opt-level = 3` to `[profile.release]`. Expected 20–40% binary size reduction and improved cold-start via cross-crate inlining. `panic = "abort"` omitted — Axum runs inside the Tauri process so any abort kills the desktop window. CI release job timeout increased to 60 minutes to accommodate longer LTO compile times. (#489)
+
 ### Fixed
 
 - **Customer form sheet now shows safe error messages**: unknown or security-sensitive API errors (e.g. `internal_error`) display a user-friendly fallback message instead of raw backend text; known safe codes continue to surface the server message verbatim. (#529)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,12 @@ mokumo-garment = { path = "crates/mokumo-garment" }
 
 [profile.dev.package.argon2]
 opt-level = 3
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true
+# panic = "abort" omitted: Axum runs inside the Tauri process — an abort-on-panic would
+# kill the entire desktop window with no recovery on any handler or background-task panic.
+# Re-evaluate if the headless server is ever split into a fully separate process.


### PR DESCRIPTION
## Summary

- Adds `[profile.release]` block with `lto = true`, `codegen-units = 1`, `strip = true`, `opt-level = 3` — expected 20–40% binary size reduction
- Omits `panic = "abort"`: Axum runs embedded inside the Tauri process; any abort kills the desktop window with no recovery path (documented in Cargo.toml comment)
- Adds `timeout-minutes: 60` to the release CI build job to budget for 3–5x longer LTO compile times

## Test Plan

- [ ] Cargo.toml parses correctly (`cargo metadata` verified locally)
- [ ] CI quality checks pass (no source files changed)
- [ ] First tagged release run captures before/after binary size and build time inline on #489

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized release build with link-time optimization, reduced codegen units, and symbol stripping.

* **Chores**
  * Increased CI release job timeout to 60 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->