### PR TITLE
chore(db): make mmap_size PRAGMA platform-conditional (#457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Release profile tuning**: Applied `lto = true`, `codegen-units = 1`, `strip = true`, `opt-level = 3` to `[profile.release]`. Expected 20–40% binary size reduction and improved cold-start via cross-crate inlining. `panic = "abort"` omitted — Axum runs inside the Tauri process so any abort kills the desktop window. CI release job timeout increased to 60 minutes to accommodate longer LTO compile times. (#489)
 
+### Changed
+
+- **`mmap_size` PRAGMA is now platform-conditional**: enabled at 256 MB on Linux (where it provides clear read-throughput gains) and disabled on Windows and macOS. On Windows, the kernel cannot truncate memory-mapped files, so enabling mmap caused `incremental_vacuum` to silently fail to shrink the database file. On macOS, the unified buffer cache already handles the I/O coalescing mmap would add, making the benefit negligible. `mokumo doctor` now reports the effective `mmap_size` for the running platform. (#457)
+
 ### Fixed
 
 - **Customer form sheet now shows safe error messages**: unknown or security-sensitive API errors (e.g. `internal_error`) display a user-friendly fallback message instead of raw backend text; known safe codes continue to surface the server message verbatim. (#529)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -29,9 +29,28 @@ pub fn known_migration_names() -> Vec<String> {
         .collect()
 }
 
+/// Effective `mmap_size` for the SQLite connection pool, selected at compile time by
+/// target platform.
+///
+/// - **Linux**: 256 MB — mmap delivers clear read-throughput gains on Linux's page
+///   cache model.
+/// - **Windows**: 0 (disabled) — the Windows kernel cannot truncate memory-mapped
+///   files, so enabling mmap causes `incremental_vacuum` to silently fail to shrink
+///   the database file.
+/// - **macOS**: 0 (disabled) — the macOS unified buffer cache already provides the
+///   I/O coalescing that mmap would add, so the benefit is negligible per the SQLite
+///   developers. Disabling keeps behavior consistent with Windows and avoids historic
+///   macOS mmap edge cases.
+pub const CONFIGURED_MMAP_SIZE: i64 = if cfg!(target_os = "linux") {
+    268_435_456
+} else {
+    0
+};
+
 /// Standard PRAGMAs applied to every SQLite connection pool in Mokumo.
 ///
 /// WAL mode, normal synchronous, 5s busy timeout, foreign keys enforced, 64MB cache.
+/// `mmap_size` is set to [`CONFIGURED_MMAP_SIZE`] — non-zero on Linux only.
 fn configure_sqlite_connection(
     conn: &mut SqliteConnection,
 ) -> Pin<Box<dyn Future<Output = Result<(), sqlx::Error>> + Send + '_>> {
@@ -51,10 +70,7 @@ fn configure_sqlite_connection(
         sqlx::query("PRAGMA cache_size=-64000")
             .execute(&mut *conn)
             .await?;
-        // 256 MB memory-mapped I/O for read performance. Per-connection PRAGMA.
-        // Caveat: on Windows, mmap prevents file truncation which makes
-        // incremental_vacuum unable to shrink the file. See #457.
-        sqlx::query("PRAGMA mmap_size=268435456")
+        sqlx::query(&format!("PRAGMA mmap_size={CONFIGURED_MMAP_SIZE}"))
             .execute(&mut *conn)
             .await?;
         Ok(())

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -42,7 +42,7 @@ pub fn known_migration_names() -> Vec<String> {
 ///   developers. Disabling keeps behavior consistent with Windows and avoids historic
 ///   macOS mmap edge cases.
 pub const CONFIGURED_MMAP_SIZE: i64 = if cfg!(target_os = "linux") {
-    268_435_456
+    256 * 1024 * 1024
 } else {
     0
 };

--- a/crates/db/tests/database_init.rs
+++ b/crates/db/tests/database_init.rs
@@ -60,7 +60,9 @@ async fn pragmas_are_set_correctly() {
         .await
         .unwrap()
         .get(0);
-    assert_eq!(mmap_size, 268_435_456); // 256 MB
+    // mmap_size is platform-conditional: 256 MB on Linux, disabled (0) elsewhere.
+    // See CONFIGURED_MMAP_SIZE in crates/db/src/lib.rs.
+    assert_eq!(mmap_size, mokumo_db::CONFIGURED_MMAP_SIZE);
 
     drop(db);
 }

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -257,6 +257,13 @@ async fn main() {
 
             println!("Database: {}", db_path.display());
             println!("  auto_vacuum:  {auto_vacuum_label} ({})", diag.auto_vacuum);
+            let mmap_mb = mokumo_db::CONFIGURED_MMAP_SIZE / (1024 * 1024);
+            let mmap_label = if mokumo_db::CONFIGURED_MMAP_SIZE == 0 {
+                "disabled (not beneficial on this platform)".to_string()
+            } else {
+                format!("{mmap_mb} MB")
+            };
+            println!("  mmap_size:    {mmap_label}");
             println!("  page_size:    {} bytes", diag.page_size);
             println!(
                 "  page_count:   {} ({} KB)",

--- a/services/api/src/main.rs
+++ b/services/api/src/main.rs
@@ -263,7 +263,7 @@ async fn main() {
             } else {
                 format!("{mmap_mb} MB")
             };
-            println!("  mmap_size:    {mmap_label}");
+            println!("  configured mmap_size: {mmap_label}");
             println!("  page_size:    {} bytes", diag.page_size);
             println!(
                 "  page_count:   {} ({} KB)",


### PR DESCRIPTION
## Summary

- Introduces `CONFIGURED_MMAP_SIZE` constant (256 MB on Linux, 0 elsewhere) as the single source of truth for the `mmap_size` PRAGMA
- On Windows: disabled — the kernel cannot truncate memory-mapped files, causing `incremental_vacuum` to silently fail to shrink the database
- On macOS: disabled — the unified buffer cache already provides equivalent I/O coalescing, making mmap negligible per SQLite developers
- `mokumo doctor` now reports the effective `mmap_size` for the running platform
- `pragmas_are_set_correctly` test updated to assert the platform-conditional expected value

Closes #457

## Test Plan

- [ ] `cargo test -p mokumo-db --test database_init` passes on Linux (asserts 256 MB)
- [ ] Same test would pass on Windows/macOS (asserts 0)
- [ ] `mokumo doctor` output includes `mmap_size` line
- [ ] `moon run api:lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)