### PR TITLE
fix(kikan): Stage 1b PR #548 review follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Kikan Stage 1b review follow-up**: pre-migration backup now progresses at ~40 MB/s instead of ~80 KB/s (page batch 5→100, inter-step delay 250 ms→10 ms) — removes the multi-minute startup stall on mature shop databases. Legacy-migration backfill now uses `OnConflict::do_nothing()` instead of string-patching the generated SQL, and flat→production database migration uses atomic `fs::rename` instead of copy+remove so a mid-move crash can no longer leave two divergent database files. (#506)
 - **Customer form sheet now shows safe error messages**: unknown or security-sensitive API errors (e.g. `internal_error`) display a user-friendly fallback message instead of raw backend text; known safe codes continue to surface the server message verbatim. (#529)
 - **Profile switcher now shows server error messages**: rate-limited and other known API errors display the backend's message verbatim in a toast instead of a generic fallback. Both the direct switch and the unsaved-changes confirmation path are fixed. (#469)
 - **QR code on Connect Your Team card now renders correctly**: replaced `onMount` with a reactive `$effect` so the QR code re-renders when the IP URL loads asynchronously. Added null guard, loading placeholder, and error fallback state. (#470)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Underlying tools: `cargo` (Rust), `pnpm` (SvelteKit). Use directly only when dia
 | Frontend | SvelteKit (Svelte 5 runes) + Tailwind v4 + shadcn-svelte | UI, static SPA via adapter-static |
 | Backend | Rust (Axum) | API server, binary distribution |
 | Database | SQLite (embedded, per-shop) | Zero infrastructure, shop owns the file |
-| ORM | SeaORM 2.0 RC (pinned `=2.0.0-rc.37`) | Entity CRUD, migrations, schema management |
+| ORM | SeaORM 2.0 RC (pinned `=2.0.0-rc.38`) | Entity CRUD, migrations, schema management |
 | Raw queries | SQLx (compile-time checked) | Complex/reporting queries verified against schema |
 | Type sharing | ts-rs crate | Rust structs auto-generate TypeScript interfaces |
 | Monorepo | Moon | Polyglot orchestration (Rust + Node) |
@@ -172,7 +172,7 @@ session branches ──PR──→ main ──release──→ GitHub Releases (
 - No eslint — use `oxlint` for linting and `oxfmt` for formatting (OXC toolchain). Prettier only for `.svelte` files. Never install, configure, or run eslint.
 - No SeaORM entities in `crates/core/` — entity structs with `DeriveEntityModel` are infrastructure types, not domain types
 - No non-transactional SeaORM migrations — every migration must use `use_transaction() -> Some(true)`
-- No caret/tilde version ranges on SeaORM RC — use exact pin `"=2.0.0-rc.37"` in Cargo.toml
+- No caret/tilde version ranges on SeaORM RC — use exact pin `"=2.0.0-rc.38"` in Cargo.toml
 
 ## Private Knowledge
 

--- a/crates/kikan/src/migrations/runner.rs
+++ b/crates/kikan/src/migrations/runner.rs
@@ -179,7 +179,7 @@ pub async fn backfill_seaql_if_present(
 
     let mut count = 0;
     for row in &rows {
-        use sea_orm::sea_query::{Alias, Expr, Query, SqliteQueryBuilder};
+        use sea_orm::sea_query::{Alias, Expr, OnConflict, Query, SqliteQueryBuilder};
 
         let insert = Query::insert()
             .into_table(Alias::new("kikan_migrations"))
@@ -193,11 +193,14 @@ pub async fn backfill_seaql_if_present(
                 Value::from(row.version.as_str()).into(),
                 Expr::val(row.applied_at),
             ])
+            .on_conflict(
+                OnConflict::columns([Alias::new("graft_id"), Alias::new("name")])
+                    .do_nothing()
+                    .to_owned(),
+            )
             .to_owned();
 
         let sql = insert.to_string(SqliteQueryBuilder);
-        debug_assert!(sql.starts_with("INSERT INTO"));
-        let sql = sql.replacen("INSERT INTO", "INSERT OR IGNORE INTO", 1);
         pool.execute_unprepared(&sql).await?;
         count += 1;
     }

--- a/crates/kikan/src/tenancy/guards.rs
+++ b/crates/kikan/src/tenancy/guards.rs
@@ -197,7 +197,7 @@ pub async fn pre_migration_backup(
         let src = rusqlite::Connection::open(&source)?;
         let mut dst = rusqlite::Connection::open(&backup_clone)?;
         let backup = rusqlite::backup::Backup::new(&src, &mut dst)?;
-        backup.run_to_completion(5, std::time::Duration::from_millis(250), None)?;
+        backup.run_to_completion(100, std::time::Duration::from_millis(10), None)?;
         Ok(())
     })
     .await

--- a/crates/kikan/src/tenancy/layout.rs
+++ b/crates/kikan/src/tenancy/layout.rs
@@ -14,14 +14,14 @@ pub fn migrate_flat_layout(data_dir: &Path) -> Result<(), TenancyError> {
         return Ok(());
     }
 
-    copy_flat_to_production(&flat_db, &production_db, &production_dir)?;
+    move_flat_to_production(&flat_db, &production_db, &production_dir)?;
     write_active_profile(&profile_path, flat_exists)?;
-    remove_flat_files(data_dir, &flat_db)?;
+    remove_flat_sidecars(data_dir);
 
     Ok(())
 }
 
-fn copy_flat_to_production(
+fn move_flat_to_production(
     flat_db: &Path,
     production_db: &Path,
     production_dir: &Path,
@@ -34,10 +34,10 @@ fn copy_flat_to_production(
         && let Err(e) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
     {
         tracing::warn!(
-            "WAL checkpoint failed during flat DB migration (proceeding with copy): {e}"
+            "WAL checkpoint failed during flat DB migration (proceeding with rename): {e}"
         );
     }
-    std::fs::copy(flat_db, production_db)?;
+    std::fs::rename(flat_db, production_db)?;
     tracing::info!("Migrated flat database to {}", production_db.display());
     Ok(())
 }
@@ -50,9 +50,7 @@ fn write_active_profile(profile_path: &Path, flat_exists: bool) -> Result<(), Te
     Ok(())
 }
 
-fn remove_flat_files(data_dir: &Path, flat_db: &Path) -> Result<(), TenancyError> {
-    std::fs::remove_file(flat_db)?;
+fn remove_flat_sidecars(data_dir: &Path) {
     let _ = std::fs::remove_file(data_dir.join("mokumo.db-wal"));
     let _ = std::fs::remove_file(data_dir.join("mokumo.db-shm"));
-    Ok(())
 }


### PR DESCRIPTION
## Summary

Follow-up to #548 addressing the three gemini-code-assist review findings that remained after merge. The other two (backfill scope, unsafe Send/Sync) were already fixed in `0a6f24b` pre-merge.

- **runner.rs** — replace brittle `str::replacen("INSERT INTO", "INSERT OR IGNORE INTO")` with idiomatic `sea_query::OnConflict::columns([graft_id, name]).do_nothing()`. Output format of the query builder is not a stable API.
- **guards.rs** — raise `pre_migration_backup` pacing from `(5 pages, 250 ms)` to `(100 pages, 10 ms)`. Previous settings capped backup throughput at ~80 KB/s, adding multi-minute startup stalls on mature shop databases.
- **layout.rs** — replace copy+remove with atomic `fs::rename` for flat→production database migration. Same `data_dir` guarantees same filesystem, so no EXDEV risk; a crash mid-migrate can no longer leave two divergent database files.
- **CLAUDE.md** — correct SeaORM pin reference `rc.37` → `rc.38` (matches actual workspace `Cargo.toml`).

## Test plan

- [x] `cargo test -p kikan` — 76 tests pass
- [x] `cargo test -p mokumo-api --test schema_equivalence` — 2/2 pass (byte-identical schema preserved)
- [x] `cargo clippy --workspace --exclude mokumo-desktop --exclude kikan-tauri --all-targets -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] CI validates full workspace including desktop-e2e (which was cancelled on #548 at merge-time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration startup performance by optimizing backup throughput and timing parameters to prevent multi-minute stalls on mature databases.
  * Enhanced database migration safety by switching from copy-and-remove to atomic file operations, preventing corruption from interrupted migrations.
  * Fixed duplicate entry prevention in migration records.

* **Documentation**
  * Updated dependency reference in project guidance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->