### PR TITLE
feat(ci): enforce kikan workspace boundary (I1-I5)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,6 +21,7 @@ jobs:
       tooling: ${{ steps.filter.outputs.tooling }}
       smoke: ${{ steps.filter.outputs.smoke }}
       mokumo-desktop: ${{ steps.filter.outputs.mokumo-desktop }}
+      kikan: ${{ steps.filter.outputs.kikan }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -34,6 +35,19 @@ jobs:
               - 'Cargo.lock'
               - '.cargo/**'
               - 'crap4rs.toml'
+            kikan:
+              - 'crates/kikan/**'
+              - 'crates/kikan-*/**'
+              - 'crates/mokumo-garment/**'
+              - 'apps/mokumo-server/**'
+              - 'apps/mokumo-desktop/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'deny.toml'
+              - 'scripts/check-i*.sh'
+              - 'scripts/lib/**'
+              - 'scripts/test/**'
+              - '.github/workflows/quality.yml'
             smoke:
               - 'tests/api/**'
             web:
@@ -523,10 +537,64 @@ jobs:
       - name: Run desktop E2E tests
         run: xvfb-run --auto-servernum moon run desktop-tests:test
 
+  kikan-invariants:
+    needs: [changes]
+    if: needs.changes.outputs.kikan == 'true'
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        run: shellcheck scripts/check-i*.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
+      - uses: moonrepo/setup-rust@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "mokumo-rust"
+          save-if: "false"
+      - name: Self-tests (script contracts)
+        run: bash scripts/test/run-self-tests.sh
+      - name: I1 — domain purity (source)
+        run: bash scripts/check-i1-domain-purity.sh
+      - name: I2 — adapter boundary (source)
+        run: bash scripts/check-i2-adapter-boundary.sh
+      - name: I3 — headless server zero-tauri (deps)
+        run: bash scripts/check-i3-headless.sh
+      - name: I4 — dependency DAG
+        run: bash scripts/check-i4-dag.sh
+      - name: I5 — feature gate ownership
+        run: bash scripts/check-i5-features.sh
+
+  kikan-musl-build:
+    needs: [changes]
+    if: needs.changes.outputs.kikan == 'true'
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
+    steps:
+      - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
+        with:
+          cache: false
+      - name: Add musl target
+        run: rustup target add x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "mokumo-rust-musl"
+          key: musl
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install musl-tools
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
+      - name: Build mokumo-server (musl)
+        # rusqlite uses `bundled` so no system sqlite is needed.
+        run: cargo build -p mokumo-server --release --target x86_64-unknown-linux-musl
+
   verdict:
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, lint-rust, test-rust, quality-ts, seam-check, demo-smoke, crap-rust, api-smoke, security, dependency-review, secret-scan, bdd-lint, test-storybook]
+    needs: [changes, lint-rust, test-rust, quality-ts, seam-check, demo-smoke, crap-rust, api-smoke, security, dependency-review, secret-scan, bdd-lint, test-storybook, kikan-invariants, kikan-musl-build]
     steps:
       - name: Check upstream results
         env:
@@ -542,9 +610,11 @@ jobs:
           SECRET_SCAN: ${{ needs.secret-scan.result }}
           BDD_LINT: ${{ needs.bdd-lint.result }}
           TEST_STORYBOOK: ${{ needs.test-storybook.result }}
+          KIKAN_INVARIANTS: ${{ needs.kikan-invariants.result }}
+          KIKAN_MUSL_BUILD: ${{ needs.kikan-musl-build.result }}
         run: |
           # Jobs that were skipped due to path filtering are fine
-          for job in LINT_RUST TEST_RUST QUALITY_TS SEAM_CHECK DEMO_SMOKE CRAP_RUST API_SMOKE SECURITY DEPENDENCY_REVIEW SECRET_SCAN BDD_LINT TEST_STORYBOOK; do
+          for job in LINT_RUST TEST_RUST QUALITY_TS SEAM_CHECK DEMO_SMOKE CRAP_RUST API_SMOKE SECURITY DEPENDENCY_REVIEW SECRET_SCAN BDD_LINT TEST_STORYBOOK KIKAN_INVARIANTS KIKAN_MUSL_BUILD; do
             result=$(eval echo "\$$job")
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "Job $job failed with result: $result"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -545,6 +545,8 @@ jobs:
       CARGO_TARGET_DIR: target    # Override .cargo/config.toml's absolute path
     steps:
       - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ripgrep
       - name: shellcheck
         run: shellcheck -x --source-path=SCRIPTDIR scripts/check-i*.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
       - uses: moonrepo/setup-rust@v1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -546,7 +546,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck
-        run: shellcheck scripts/check-i*.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
+        run: shellcheck -x scripts/check-i*.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
       - uses: moonrepo/setup-rust@v1
         with:
           cache: false

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -546,7 +546,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck
-        run: shellcheck -x scripts/check-i*.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
+        run: shellcheck -x --source-path=SCRIPTDIR scripts/check-i*.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
       - uses: moonrepo/setup-rust@v1
         with:
           cache: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+
+- **CI**: enforce kikan workspace boundary (I1-I5) — `kikan-invariants` and `kikan-musl-build` jobs in `quality.yml` plant tripwires for the kikan/garment/Tauri boundary. Backed by `scripts/check-i*.sh` with self-tests under `scripts/test/`. Includes the `cargo-deny`-tauri-ban behaviour from #543. (#513, #543)
+
 ### Added
 
 - **`kikan-events` crate**: typed event bus over `tokio::sync::broadcast` with `BroadcastEventBus`, 4 event types (Lifecycle, Health, Migration, Profile), and full BDD coverage (#517)

--- a/crates/kikan/CLAUDE.md
+++ b/crates/kikan/CLAUDE.md
@@ -1,0 +1,16 @@
+# kikan — boundary enforcement
+
+`kikan` is the platform crate. It must remain garment-domain-agnostic and
+adapter-shell-agnostic. CI enforces the boundary on every PR via
+`scripts/check-i*.sh`; the same checks pass locally with `bash scripts/check-iN-*.sh`.
+
+What is forbidden inside this crate (see `adr-workspace-split-kikan`):
+
+- **I1 Domain purity** — no garment-vertical identifiers (`customer`, `garment`, `quote`, `invoice`, `print_job`, etc.) in `src/` or `Cargo.toml`. Garment language belongs in `mokumo-garment`.
+- **I2 Adapter boundary** — no `tauri::` paths, no `#[tauri::command]` attributes. Tauri lives in `kikan-tauri`.
+- **I4 DAG direction** — no dependency on `mokumo-garment`, `mokumo-server`, `mokumo-desktop`, `kikan-tauri`, `kikan-socket`, or `kikan-cli`. Dependencies flow toward kikan, never away from it.
+- **I5 Feature gates** — no Cargo feature may pull a Tauri-tagged crate.
+
+If you need to add code that triggers any of these checks, the answer is almost
+always to put it in a different crate. If it's truly the boundary that needs to
+move, update the ADR first, then the checks, then the code.

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,12 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 multiple-versions = "warn"
 wildcards = "allow"        # workspace path deps use wildcards by convention
 
+# Note: kikan workspace boundary invariants (I1, I4) are enforced by
+# scripts/check-i*.sh, not by cargo-deny `bans.deny`. cargo-deny `wrappers`
+# semantics are "ban this crate UNLESS direct parent is in the list" — the
+# inverse of "ban this edge ONLY when consumer is X" that we need. See
+# scripts/check-i1-domain-purity.sh and scripts/check-i4-dag.sh.
+
 # ──────────────────────────────────────────────────────────────────────
 # Sources — supply chain protection
 # ──────────────────────────────────────────────────────────────────────

--- a/scripts/check-i1-domain-purity.sh
+++ b/scripts/check-i1-domain-purity.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# I1 — Domain purity (source side).
+#
+# kikan platform crate must contain zero references to garment-vertical
+# domain language. Enforces the boundary stated in:
+#   - adr-workspace-split-kikan (I1)
+#   - adr-workspace-ci-testing
+#
+# Allows override of TARGET dir for fixture self-tests.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/rg-check.sh
+source "${HERE}/lib/rg-check.sh"
+
+TARGET="${1:-crates/kikan/src}"
+
+# Whole-word match — narrow, low false-positive rate. If a future kikan use
+# legitimately needs one of these words (e.g. "order_by"), tighten the regex
+# rather than broaden the deny-list.
+PATTERN='\b(customer|garment|print_job|quote|invoice|decorator|embroidery|dtf|screen.print|apparel)\b'
+
+rg_no_match_or_die "I1" "$PATTERN" "$TARGET"
+echo "I1 ok: ${TARGET} contains no garment-domain identifiers"

--- a/scripts/check-i2-adapter-boundary.sh
+++ b/scripts/check-i2-adapter-boundary.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# I2 — Adapter boundary (source side).
+#
+# kikan platform must not reference Tauri types or commands. Tauri integration
+# lives in kikan-tauri (the OS-capability adapter shell). See:
+#   - adr-workspace-split-kikan (I2)
+#   - adr-control-plane-data-plane-split
+#
+# Allows override of TARGET dir for fixture self-tests.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/rg-check.sh
+source "${HERE}/lib/rg-check.sh"
+
+TARGET="${1:-crates/kikan/src}"
+
+PATTERN='\btauri::|#\[tauri::command\]'
+
+rg_no_match_or_die "I2" "$PATTERN" "$TARGET"
+echo "I2 ok: ${TARGET} contains no Tauri references"

--- a/scripts/check-i3-headless.sh
+++ b/scripts/check-i3-headless.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# I3a — Headless server has zero Tauri / webview deps.
+#
+# mokumo-server must compile and link without dragging in Tauri, webkit2gtk,
+# or wry — they would block container/musl deployment. See:
+#   - adr-workspace-split-kikan (I3)
+#   - adr-kikan-binary-topology
+#
+# I3b (musl cross-compile) is a separate CI job; see kikan-musl-build.
+set -euo pipefail
+
+PKG="${1:-mokumo-server}"
+
+# Capture cargo tree separately so `set -e` doesn't abort on grep no-match.
+tree="$(env -u RUSTC_WRAPPER cargo tree -p "$PKG" --edges normal,build --prefix none 2>/dev/null || true)"
+
+if [[ -z "$tree" ]]; then
+    echo "::error::I3 script error: cargo tree -p ${PKG} produced no output" >&2
+    exit 2
+fi
+
+if echo "$tree" | grep -iE '\b(tauri|tauri-build|webkit2gtk|wry)\b' >/tmp/i3-hits.$$; then
+    echo "::error::I3 violated: ${PKG} transitively depends on Tauri/webview crates" >&2
+    echo "Offending entries:" >&2
+    sort -u /tmp/i3-hits.$$ >&2
+    rm -f /tmp/i3-hits.$$
+    exit 1
+fi
+rm -f /tmp/i3-hits.$$
+
+echo "I3 ok: ${PKG} has no Tauri/webview transitive deps"

--- a/scripts/check-i4-dag.sh
+++ b/scripts/check-i4-dag.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# I4 — Dependency direction (DAG enforcement).
+#
+# Forbidden edges per ADR adr-workspace-split-kikan §I4:
+#   - kikan must not depend on any of its consumers, the garment vertical,
+#     or any adapter shell.
+#   - mokumo-garment must not depend on any adapter or binary.
+#
+# This is enforced via `cargo tree` — kikan's dep tree must contain none of
+# the forbidden downstream crate names, and mokumo-garment's must contain no
+# adapter/binary names.
+#
+# Why not cargo-deny `bans.deny`? `wrappers` semantics is "ban this crate
+# UNLESS the parent is in the wrapper list" — the inverse of "ban this edge
+# only when consumer is X". cargo-deny also silently no-ops `wrappers` for
+# crates listed in `[graph] exclude` (kikan-tauri, mokumo-desktop).
+#
+# Note: I4.a's check that kikan does not depend on mokumo-garment is also the
+# dependency-side enforcement of I1 (domain purity) — kikan cannot acquire
+# garment vocabulary by linking the garment crate.
+set -euo pipefail
+
+# Returns 1 (violation) if any forbidden crate appears in the dep tree of $1.
+check_no_forbidden_deps() {
+    local pkg="$1"
+    shift
+    local forbidden_pattern
+    forbidden_pattern="\\b($(IFS='|'; echo "$*"))\\b"
+
+    local tree
+    tree="$(env -u RUSTC_WRAPPER cargo tree -p "$pkg" --edges normal,build --prefix none 2>/dev/null || true)"
+    if [[ -z "$tree" ]]; then
+        echo "::error::I4 script error: cargo tree -p ${pkg} produced no output" >&2
+        exit 2
+    fi
+
+    if echo "$tree" | grep -E "$forbidden_pattern" >/tmp/i4-hits.$$; then
+        echo "::error::I4 violated: ${pkg} transitively depends on a forbidden downstream crate" >&2
+        echo "Offending entries:" >&2
+        sort -u /tmp/i4-hits.$$ >&2
+        rm -f /tmp/i4-hits.$$
+        return 1
+    fi
+    rm -f /tmp/i4-hits.$$
+    return 0
+}
+
+fail=0
+
+# I4.a — kikan must not depend on its consumers, the garment vertical, or any adapter.
+check_no_forbidden_deps kikan \
+    mokumo-garment \
+    mokumo-server \
+    mokumo-desktop \
+    kikan-tauri \
+    kikan-socket \
+    kikan-cli \
+    || fail=1
+
+# I4.b — mokumo-garment must not depend on adapters or binaries.
+check_no_forbidden_deps mokumo-garment \
+    kikan-tauri \
+    mokumo-desktop \
+    mokumo-server \
+    || fail=1
+
+if [[ $fail -ne 0 ]]; then
+    exit 1
+fi
+
+echo "I4 ok: dependency DAG holds (kikan, mokumo-garment have no forbidden downstream deps)"

--- a/scripts/check-i5-features.sh
+++ b/scripts/check-i5-features.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# I5 — Feature gate ownership.
+#
+# kikan/Cargo.toml must not reference Tauri at all — no direct dep, no feature
+# pulling Tauri transitively. See:
+#   - adr-workspace-split-kikan (I5)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/rg-check.sh
+source "${HERE}/lib/rg-check.sh"
+
+TARGET="${1:-crates/kikan/Cargo.toml}"
+
+# Plain word `tauri` — covers `tauri = ...`, `tauri-plugin-...`, and
+# `["tauri/something"]` feature activations.
+PATTERN='\btauri\b'
+
+rg_no_match_or_die "I5" "$PATTERN" "$TARGET"
+echo "I5 ok: ${TARGET} has no Tauri references"

--- a/scripts/lib/rg-check.sh
+++ b/scripts/lib/rg-check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Shared rg "no match = success" idiom for invariant checks.
+#
+# rg exit codes: 0 = match found, 1 = no match, 2+ = real error.
+# `set -euo pipefail` makes naive `if rg ...; then` swallow exit 2 silently.
+# This wrapper propagates exit 2+ as a script error, treats 0 as the violation,
+# and treats 1 as success.
+#
+# Usage:
+#   rg_no_match_or_die "<invariant-id>" "<pattern>" <target...>
+
+rg_no_match_or_die() {
+    local invariant="$1"
+    local pattern="$2"
+    shift 2
+    local rc=0
+
+    set +e
+    rg -n --color=never "$pattern" "$@"
+    rc=$?
+    set -e
+
+    case "$rc" in
+        0)
+            echo "::error::${invariant} violated: pattern '${pattern}' matched in $* (see file:line above)" >&2
+            exit 1
+            ;;
+        1)
+            return 0
+            ;;
+        *)
+            echo "::error::${invariant} script error: rg exited ${rc}" >&2
+            exit "$rc"
+            ;;
+    esac
+}

--- a/scripts/test/fixtures/i1-violation/src/lib.rs
+++ b/scripts/test/fixtures/i1-violation/src/lib.rs
@@ -1,0 +1,2 @@
+pub struct Quote;
+pub fn customer() {}

--- a/scripts/test/fixtures/i2-violation/src/lib.rs
+++ b/scripts/test/fixtures/i2-violation/src/lib.rs
@@ -1,0 +1,6 @@
+#[tauri::command]
+pub fn touch() {}
+
+pub fn use_tauri() {
+    let _ = tauri::Manager;
+}

--- a/scripts/test/fixtures/i5-violation/Cargo.toml
+++ b/scripts/test/fixtures/i5-violation/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "fake"
+[dependencies]
+tauri = "2"

--- a/scripts/test/run-self-tests.sh
+++ b/scripts/test/run-self-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Self-tests for invariant-check scripts.
+#
+# Validates each script's contract:
+#   1. real-tree run → exit 0 (currently passes organically)
+#   2. fixture run → exit 1 (planted violation)
+#
+# I3/I4 fixtures are not feasible (would require synthetic Cargo workspaces);
+# they're covered by the in-PR plant-and-revert acceptance verification.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../.." && pwd)"
+FIX="${HERE}/fixtures"
+
+pass=0
+fail=0
+
+assert_exit() {
+    local label="$1"
+    local want="$2"
+    shift 2
+    set +e
+    "$@" >/dev/null 2>&1
+    local got=$?
+    set -e
+    if [[ "$got" -eq "$want" ]]; then
+        echo "ok   ${label} (exit ${got})"
+        pass=$((pass+1))
+    else
+        echo "FAIL ${label}: want exit ${want}, got ${got}"
+        fail=$((fail+1))
+    fi
+}
+
+cd "$ROOT"
+
+# Real-tree must pass.
+assert_exit "I1 real-tree pass" 0 bash scripts/check-i1-domain-purity.sh
+assert_exit "I2 real-tree pass" 0 bash scripts/check-i2-adapter-boundary.sh
+assert_exit "I3 real-tree pass" 0 bash scripts/check-i3-headless.sh
+assert_exit "I4 real-tree pass" 0 bash scripts/check-i4-dag.sh
+assert_exit "I5 real-tree pass" 0 bash scripts/check-i5-features.sh
+
+# Fixtures must fail.
+assert_exit "I1 fixture fail"   1 bash scripts/check-i1-domain-purity.sh "${FIX}/i1-violation/src"
+assert_exit "I2 fixture fail"   1 bash scripts/check-i2-adapter-boundary.sh "${FIX}/i2-violation/src"
+assert_exit "I5 fixture fail"   1 bash scripts/check-i5-features.sh        "${FIX}/i5-violation/Cargo.toml"
+
+echo
+echo "self-tests: ${pass} passed, ${fail} failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Plant CI tripwires for the kikan/garment/Tauri workspace boundary defined in `adr-workspace-split-kikan` — five invariants (I1-I5) enforced by shell scripts under `scripts/check-i*.sh`, with self-tests under `scripts/test/`.
- New `kikan-invariants` job in `quality.yml` runs shellcheck, the self-tests, and each invariant as a separate step (so failures point to the specific invariant violated).
- New `kikan-musl-build` job builds `mokumo-server` against `x86_64-unknown-linux-musl` as a structural proof that the headless server links without GTK/WebKit.

## Invariants

| ID | Mechanism | What it forbids |
|----|-----------|-----------------|
| I1 | rg over `crates/kikan/src` | garment vocabulary (`customer`, `garment`, `quote`, `invoice`, `print_job`, `decorator`, `embroidery`, `dtf`, `screen.print`, `apparel`) |
| I2 | rg over `crates/kikan/src` | `tauri::` paths and `#[tauri::command]` |
| I3 | `cargo tree -p mokumo-server` + grep | `tauri`, `tauri-build`, `webkit2gtk`, `wry` in the headless server's dep tree |
| I4 | `cargo tree -p {kikan,mokumo-garment}` + grep | forbidden downstream edges in either direction |
| I5 | rg over `crates/kikan/Cargo.toml` | any `tauri` reference (direct dep or feature activation) |

Both jobs are path-gated via `dorny/paths-filter` (only run when kikan-related files change) and added to the `verdict` aggregator.

## Why not cargo-deny?

`bans.deny` with `wrappers` semantics is "ban this crate UNLESS the parent is in the list" — the inverse of "ban this edge only when the consumer is X" that I4 needs. cargo-deny also silently no-ops `wrappers` for crates listed in `[graph] exclude` (which we use for `kikan-tauri` and `mokumo-desktop`). Documented in `deny.toml` and `scripts/check-i4-dag.sh`.

## Test plan

- [x] `bash scripts/test/run-self-tests.sh` — 8/8 assertions pass locally (5 real-tree exit 0, 3 fixture exit 1)
- [x] Plant-and-revert acceptance for I3 (mokumo-desktop tree showed 23 tauri/wry/webkit2gtk hits as expected)
- [x] Plant-and-revert acceptance for I4 (mokumo-garment → kikan-tauri detected and rejected)
- [ ] CI: kikan-invariants job runs and passes
- [ ] CI: kikan-musl-build job builds mokumo-server cleanly against musl

Closes #513
Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)