### PR TITLE
Stage 3 V1 — Graft trait shape

### DIFF
--- a/crates/kikan/src/engine.rs
+++ b/crates/kikan/src/engine.rs
@@ -8,6 +8,9 @@ use crate::migrations;
 use crate::migrations::Migration;
 use crate::tenancy::Tenancy;
 
+#[derive(Clone, Default)]
+pub struct EngineContext;
+
 pub struct Engine<G: Graft> {
     config: BootConfig,
     tenancy: Tenancy,
@@ -51,7 +54,7 @@ impl<G: Graft> Engine<G> {
         &self.config
     }
 
-    pub async fn run(&self) -> Result<(), EngineError> {
-        todo!("wired in Stage 1c")
+    pub fn context(&self) -> EngineContext {
+        EngineContext
     }
 }

--- a/crates/kikan/src/graft.rs
+++ b/crates/kikan/src/graft.rs
@@ -1,7 +1,7 @@
+use crate::engine::EngineContext;
 use crate::error::EngineError;
 use crate::migrations::bootstrap::BootstrapMigrations;
 use crate::migrations::{GraftId, Migration};
-use crate::tenancy::Tenancy;
 
 #[trait_variant::make(Send)]
 pub trait Graft: Sized + 'static {
@@ -9,8 +9,8 @@ pub trait Graft: Sized + 'static {
 
     fn id() -> GraftId;
     fn migrations(&self) -> Vec<Box<dyn Migration>>;
-    async fn build_state(&self, tenancy: &Tenancy) -> Result<Self::AppState, EngineError>;
-    async fn run(&self, state: Self::AppState) -> Result<(), EngineError>;
+    async fn build_state(&self, ctx: &EngineContext) -> Result<Self::AppState, EngineError>;
+    fn data_plane_routes(state: &Self::AppState) -> axum::Router<Self::AppState>;
 }
 
 #[async_trait::async_trait]

--- a/crates/kikan/src/lib.rs
+++ b/crates/kikan/src/lib.rs
@@ -9,7 +9,7 @@ pub mod tenancy;
 
 pub use app_handle::AppHandleShim;
 pub use boot::{BootConfig, DeploymentMode};
-pub use engine::Engine;
+pub use engine::{Engine, EngineContext};
 pub use error::{AppHandleError, DagError, EngineError, MigrationError, TenancyError};
 pub use graft::{Graft, SelfGraft, SubGraft};
 pub use migrations::{GraftId, Migration, MigrationRef, MigrationTarget};

--- a/crates/kikan/tests/support/stub_graft.rs
+++ b/crates/kikan/tests/support/stub_graft.rs
@@ -1,7 +1,7 @@
 use kikan::migrations::conn::MigrationConn;
 use kikan::{
-    BootConfig, Engine, EngineError, Graft, GraftId, Migration, MigrationRef, MigrationTarget,
-    Tenancy,
+    BootConfig, Engine, EngineContext, EngineError, Graft, GraftId, Migration, MigrationRef,
+    MigrationTarget, Tenancy,
 };
 use std::sync::Arc;
 
@@ -44,12 +44,12 @@ impl Graft for StubGraft {
             .collect()
     }
 
-    async fn build_state(&self, _tenancy: &Tenancy) -> Result<Self::AppState, EngineError> {
+    async fn build_state(&self, _ctx: &EngineContext) -> Result<Self::AppState, EngineError> {
         Ok(())
     }
 
-    async fn run(&self, _state: Self::AppState) -> Result<(), EngineError> {
-        Ok(())
+    fn data_plane_routes(_state: &Self::AppState) -> axum::Router<Self::AppState> {
+        axum::Router::new()
     }
 }
 
@@ -115,6 +115,6 @@ impl Migration for SimpleMigration {
 fn _assert_graft_build_state_is_send() {
     fn require_send<T: Send>(_t: T) {}
     let graft = StubGraft::diamond();
-    let tenancy = Tenancy::new(std::path::PathBuf::from("/tmp"));
-    require_send(graft.build_state(&tenancy));
+    let ctx = EngineContext;
+    require_send(graft.build_state(&ctx));
 }

--- a/services/api/src/graft_bridge.rs
+++ b/services/api/src/graft_bridge.rs
@@ -1,5 +1,5 @@
 use kikan::migrations::conn::MigrationConn;
-use kikan::{EngineError, Graft, GraftId, Migration, MigrationRef, MigrationTarget, Tenancy};
+use kikan::{EngineContext, EngineError, Graft, GraftId, Migration, MigrationRef, MigrationTarget};
 use mokumo_db::migration::Migrator;
 use sea_orm_migration::MigratorTrait;
 use sea_orm_migration::sea_orm::DbErr;
@@ -49,12 +49,12 @@ impl Graft for MokumoGraftBridge {
             .collect()
     }
 
-    async fn build_state(&self, _tenancy: &Tenancy) -> Result<Self::AppState, EngineError> {
+    async fn build_state(&self, _ctx: &EngineContext) -> Result<Self::AppState, EngineError> {
         Ok(())
     }
 
-    async fn run(&self, _state: Self::AppState) -> Result<(), EngineError> {
-        Ok(())
+    fn data_plane_routes(_state: &Self::AppState) -> axum::Router<Self::AppState> {
+        axum::Router::new()
     }
 }
 


### PR DESCRIPTION
## Summary

First of 15 sessions in the Stage 3 garment-extraction rollout (#507). Amends the `Graft` trait to the shape the rest of the plan depends on.

- `Graft::build_state` now takes `&EngineContext` (was `&Tenancy`).
- New `Graft::data_plane_routes(&AppState) -> Router<AppState>`.
- `Graft::run` removed; `Engine::run` stub (`todo!("wired in Stage 1c")`) deleted.
- `EngineContext` introduced as a zero-field placeholder — S0.2 expands it with pool, tenancy, activity writer, sessions.
- `MokumoGraftBridge` and `StubGraft` migrated to the new shape; `data_plane_routes` returns an empty `Router::new()` since real routes continue to flow through `build_app_inner` until S2.1–S2.5.

Depends on nothing; foundation for V2–V8.

## Test plan

- [x] `cargo check -p kikan` green
- [x] `cargo check --workspace --exclude mokumo-desktop` green (desktop has a pre-existing `apps/web/scripts/demo.db` fixture issue unrelated to this change)
- [x] `cargo check -p kikan --tests` green
- [x] `bash scripts/check-i1-domain-purity.sh` exit 0
- [x] `bash scripts/check-i2-adapter-boundary.sh` exit 0
- [x] `bash scripts/check-i4-dag.sh` exit 0
- [x] `bash scripts/check-i5-features.sh` exit 0

Refs #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)