### PR TITLE
chore(ci): I2b Tauri type-identifier lint + drop kikan-tauri from deny.toml exclude

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -590,6 +590,8 @@ jobs:
         run: bash scripts/check-i1-domain-purity.sh
       - name: I2 — adapter boundary (source)
         run: bash scripts/check-i2-adapter-boundary.sh
+      - name: I2b — adapter boundary (Tauri type identifiers)
+        run: bash scripts/check-i2b-tauri-type-ids.sh
       - name: I3 — headless server zero-tauri (deps)
         run: bash scripts/check-i3-headless.sh
       - name: I4 — dependency DAG

--- a/deny.toml
+++ b/deny.toml
@@ -5,9 +5,9 @@
 # CI: runs in the security job of .github/workflows/quality.yml
 
 [graph]
-# Match the workspace — exclude Tauri crates since they pull platform-specific
-# system deps that vary by host and are checked separately in desktop-e2e.
-exclude = ["mokumo-desktop", "kikan-tauri"]
+# Exclude mokumo-desktop: pulls Tauri + platform-specific system deps that vary
+# by host OS and are checked separately in the desktop-e2e job.
+exclude = ["mokumo-desktop"]
 
 # ──────────────────────────────────────────────────────────────────────
 # Advisories — deny crates with known vulnerabilities

--- a/scripts/check-i2b-tauri-type-ids.sh
+++ b/scripts/check-i2b-tauri-type-ids.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# I2b — Adapter boundary (Tauri type identifiers).
+#
+# Extends I2 to catch PascalCase Tauri type identifiers (e.g. TauriManager,
+# TauriApp) that escape the tauri:: path pattern. Defense-in-depth. See:
+#   - adr-workspace-split-kikan (I2)
+#
+# Allows override of TARGET dir for fixture self-tests.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/rg-check.sh
+source "${HERE}/lib/rg-check.sh"
+
+TARGET="${1:-crates/kikan/src}"
+
+PATTERN='\bTauri[A-Z]\w*\b'
+
+rg_no_match_or_die "I2b" "$PATTERN" "$TARGET"
+echo "I2b ok: ${TARGET} contains no Tauri type identifiers"

--- a/scripts/check-i2b-tauri-type-ids.sh
+++ b/scripts/check-i2b-tauri-type-ids.sh
@@ -16,5 +16,5 @@ TARGET="${1:-crates/kikan/src}"
 
 PATTERN='\bTauri[A-Z]\w*\b'
 
-rg_no_match_or_die "I2b" "$PATTERN" "$TARGET"
+rg_no_match_or_die "I2b" "$PATTERN" -t rust "$TARGET"
 echo "I2b ok: ${TARGET} contains no Tauri type identifiers"

--- a/scripts/test/fixtures/i2b-violation/src/lib.rs
+++ b/scripts/test/fixtures/i2b-violation/src/lib.rs
@@ -1,0 +1,5 @@
+use std::sync::Arc;
+
+pub fn use_tauri_type(manager: Arc<dyn TauriManager>) {
+    let _ = manager;
+}

--- a/scripts/test/run-self-tests.sh
+++ b/scripts/test/run-self-tests.sh
@@ -38,6 +38,7 @@ cd "$ROOT"
 # Real-tree must pass.
 assert_exit "I1 real-tree pass" 0 bash scripts/check-i1-domain-purity.sh
 assert_exit "I2 real-tree pass" 0 bash scripts/check-i2-adapter-boundary.sh
+assert_exit "I2b real-tree pass" 0 bash scripts/check-i2b-tauri-type-ids.sh
 assert_exit "I3 real-tree pass" 0 bash scripts/check-i3-headless.sh
 assert_exit "I4 real-tree pass" 0 bash scripts/check-i4-dag.sh
 assert_exit "I5 real-tree pass" 0 bash scripts/check-i5-features.sh
@@ -61,6 +62,7 @@ rm -f "$R13_FIX"
 # Fixtures must fail.
 assert_exit "I1 fixture fail"   1 bash scripts/check-i1-domain-purity.sh "${FIX}/i1-violation/src"
 assert_exit "I2 fixture fail"   1 bash scripts/check-i2-adapter-boundary.sh "${FIX}/i2-violation/src"
+assert_exit "I2b fixture fail"  1 bash scripts/check-i2b-tauri-type-ids.sh  "${FIX}/i2b-violation/src"
 assert_exit "I5 fixture fail"   1 bash scripts/check-i5-features.sh        "${FIX}/i5-violation/Cargo.toml"
 
 echo


### PR DESCRIPTION
## Summary

- Closes #552 — adds `scripts/check-i2b-tauri-type-ids.sh` to catch PascalCase Tauri type identifiers (`TauriManager`, `TauriApp`, etc.) that escape the existing `tauri::` path pattern in I2. Wired into the `kikan-invariants` GHA job. Fixture + self-test pair added.
- Closes #553 — removes `kikan-tauri` from `deny.toml [graph] exclude`. It was a spike-era remnant; removing it makes cargo-deny coverage honest.

## What changed

### #552 — I2b script

- `scripts/check-i2b-tauri-type-ids.sh` (new) — pattern `\bTauri[A-Z]\w*\b`, same `rg_no_match_or_die` idiom as I2a
- `scripts/test/fixtures/i2b-violation/src/lib.rs` (new) — fixture containing `TauriManager` to validate the failure path
- `scripts/test/run-self-tests.sh` — `I2b real-tree pass` + `I2b fixture fail` assertions added
- `.github/workflows/quality.yml` — I2b step inserted after I2 in `kikan-invariants` job (shellcheck glob already covers it)

### #553 — deny.toml

- `exclude = ["mokumo-desktop", "kikan-tauri"]` → `exclude = ["mokumo-desktop"]`
- Updated comment to reflect `mokumo-desktop`-only exclusion rationale

## Test plan

- [x] `bash scripts/test/run-self-tests.sh` — 12/12 passed (including I2b real-tree + fixture)
- [ ] CI `kikan-invariants` job — I2b step green
- [ ] CI `security` / `dependency-review` job — `cargo deny check` green after exclude change

🤖 Generated with [Claude Code](https://claude.com/claude-code)