### PR TITLE
perf(mokumo-shop): composite index activity_log(created_at DESC, id DESC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Performance
+
+- **Composite index on `activity_log(created_at DESC, id DESC)`**: Eliminates filesort on paginated activity-log reads. `created_at` is stored at second precision, so batch inserts within the same second produce identical timestamps; the composite index gives the `ORDER BY created_at DESC, id DESC` tie-breaker an O(log n) path. (#567)
+
 ### Security
 
 - **Login timing side-channel closed**: `verify_credentials` now runs argon2 against a reference hash on the unknown-email and inactive-account paths, so response time no longer reveals whether an email is registered. (#508)

--- a/crates/mokumo-shop/src/migrations/m20260324_000001_customers_and_activity.rs
+++ b/crates/mokumo-shop/src/migrations/m20260324_000001_customers_and_activity.rs
@@ -128,8 +128,13 @@ mod tests {
         .unwrap();
         assert_eq!(activity.0, 1, "activity_log table should exist after up");
 
-        // Roll back 6 migrations: login_lockout → shop_settings → set_pragmas → users_and_roles → customers_deleted_at_index → customers_and_activity
-        crate::migrations::Migrator::down(&db, Some(6))
+        let migrations = crate::migrations::Migrator::migrations();
+        let idx = migrations
+            .iter()
+            .position(|m| m.name() == "m20260324_000001_customers_and_activity")
+            .expect("migration must be in migrator list");
+        let steps = (migrations.len() - idx) as u32;
+        crate::migrations::Migrator::down(&db, Some(steps))
             .await
             .unwrap();
 

--- a/crates/mokumo-shop/src/migrations/m20260327_000000_users_and_roles.rs
+++ b/crates/mokumo-shop/src/migrations/m20260327_000000_users_and_roles.rs
@@ -112,8 +112,13 @@ mod tests {
         .unwrap();
         assert_eq!(users.0, 1, "users table should exist after up");
 
-        // Roll back 4 migrations: login_lockout → shop_settings → set_pragmas → users_and_roles
-        crate::migrations::Migrator::down(&db, Some(4))
+        let migrations = crate::migrations::Migrator::migrations();
+        let idx = migrations
+            .iter()
+            .position(|m| m.name() == "m20260327_000000_users_and_roles")
+            .expect("migration must be in migrator list");
+        let steps = (migrations.len() - idx) as u32;
+        crate::migrations::Migrator::down(&db, Some(steps))
             .await
             .unwrap();
 

--- a/crates/mokumo-shop/src/migrations/m20260418_000000_activity_log_composite_index.rs
+++ b/crates/mokumo-shop/src/migrations/m20260418_000000_activity_log_composite_index.rs
@@ -8,7 +8,7 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let conn = manager.get_connection();
         conn.execute_unprepared(
-            "CREATE INDEX IF NOT EXISTS idx_activity_log_created_at_id \
+            "CREATE INDEX idx_activity_log_created_at_id \
              ON activity_log(created_at DESC, id DESC)",
         )
         .await?;
@@ -21,6 +21,7 @@ impl MigrationTrait for Migration {
         let conn = manager.get_connection();
         conn.execute_unprepared("DROP INDEX IF EXISTS idx_activity_log_created_at_id")
             .await?;
+        conn.execute_unprepared("PRAGMA user_version = 9").await?;
         Ok(())
     }
 

--- a/crates/mokumo-shop/src/migrations/m20260418_000000_activity_log_composite_index.rs
+++ b/crates/mokumo-shop/src/migrations/m20260418_000000_activity_log_composite_index.rs
@@ -1,0 +1,30 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared(
+            "CREATE INDEX IF NOT EXISTS idx_activity_log_created_at_id \
+             ON activity_log(created_at DESC, id DESC)",
+        )
+        .await?;
+        // Diagnostic schema stamp (user_version is secondary to seaql_migrations).
+        conn.execute_unprepared("PRAGMA user_version = 10").await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared("DROP INDEX IF EXISTS idx_activity_log_created_at_id")
+            .await?;
+        Ok(())
+    }
+
+    fn use_transaction(&self) -> Option<bool> {
+        Some(true)
+    }
+}

--- a/crates/mokumo-shop/src/migrations/mod.rs
+++ b/crates/mokumo-shop/src/migrations/mod.rs
@@ -7,6 +7,7 @@ pub mod m20260327_000000_users_and_roles;
 pub mod m20260404_000000_set_pragmas;
 pub mod m20260411_000000_shop_settings;
 pub mod m20260416_000000_login_lockout;
+pub mod m20260418_000000_activity_log_composite_index;
 
 use sea_orm_migration::prelude::*;
 
@@ -24,6 +25,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260404_000000_set_pragmas::Migration),
             Box::new(m20260411_000000_shop_settings::Migration),
             Box::new(m20260416_000000_login_lockout::Migration),
+            Box::new(m20260418_000000_activity_log_composite_index::Migration),
         ]
     }
 }

--- a/crates/mokumo-shop/tests/platform_schema_conventions.rs
+++ b/crates/mokumo-shop/tests/platform_schema_conventions.rs
@@ -304,6 +304,39 @@ async fn deleted_at_columns_have_partial_index() {
 }
 
 // ---------------------------------------------------------------------------
+// Index: activity_log composite index (created_at DESC, id DESC)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn activity_log_has_composite_index_on_created_at_id() {
+    let (pool, _dir) = migrated_pool().await;
+    let indexes = index_list(&pool, "activity_log").await;
+    assert!(
+        indexes
+            .iter()
+            .any(|i| i.name == "idx_activity_log_created_at_id"),
+        "idx_activity_log_created_at_id must exist on activity_log after migration"
+    );
+}
+
+#[tokio::test]
+async fn activity_log_composite_index_covers_correct_columns_in_order() {
+    let (pool, _dir) = migrated_pool().await;
+    let sql = index_sql(&pool, "idx_activity_log_created_at_id")
+        .await
+        .expect("idx_activity_log_created_at_id must exist");
+    let sql_upper = sql.to_uppercase();
+    assert!(
+        sql_upper.contains("CREATED_AT DESC"),
+        "index must include created_at DESC, got: {sql}"
+    );
+    assert!(
+        sql_upper.contains("ID DESC"),
+        "index must include id DESC, got: {sql}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Convention: created_at and updated_at columns have ISO 8601 defaults
 // ---------------------------------------------------------------------------
 

--- a/crates/mokumo-shop/tests/platform_startup_guards.rs
+++ b/crates/mokumo-shop/tests/platform_startup_guards.rs
@@ -223,8 +223,8 @@ async fn user_version_matches_latest_migration() {
     // Stamp is set by the most-recent migration that writes PRAGMA user_version.
     // Bump this when adding a migration that updates the stamp.
     assert_eq!(
-        user_version, 9,
-        "user_version should be 9 after login_lockout migration"
+        user_version, 10,
+        "user_version should be 10 after activity_log_composite_index migration"
     );
 }
 

--- a/services/api/src/graft.rs
+++ b/services/api/src/graft.rs
@@ -49,6 +49,7 @@ impl Graft for MokumoApp {
             "m20260404_000000_set_pragmas",
             "m20260411_000000_shop_settings",
             "m20260416_000000_login_lockout",
+            "m20260418_000000_activity_log_composite_index",
         ];
 
         seaorm_migrations


### PR DESCRIPTION
## Summary

- Adds `idx_activity_log_created_at_id ON activity_log(created_at DESC, id DESC)` to eliminate filesort on paginated activity-log reads
- `created_at` is stored at second precision, so batch inserts produce identical timestamps; `ORDER BY created_at DESC, id DESC` needs the composite index for an O(log n) tie-breaker path
- Bumps `PRAGMA user_version` diagnostic stamp 9 → 10
- Two schema-convention tests added: index existence + column order correctness

## Review findings addressed

- `down()` now resets `PRAGMA user_version = 9` to keep the diagnostic stamp consistent after rollback (mirrors the pattern in `m20260416_login_lockout`)
- Removed `IF NOT EXISTS` from `CREATE INDEX` — SeaORM never re-runs applied migrations; the guard suppressed shape-mismatch errors on pre-existing indexes
- Added `activity_log_has_composite_index_on_created_at_id` and `activity_log_composite_index_covers_correct_columns_in_order` tests to `platform_schema_conventions.rs`

## Test plan

- [ ] `user_version_matches_latest_migration` asserts `user_version == 10` after full migration run
- [ ] `all_migrations_use_transaction_returns_some_true` covers the new migration automatically
- [ ] `activity_log_has_composite_index_on_created_at_id` — index exists post-migration
- [ ] `activity_log_composite_index_covers_correct_columns_in_order` — columns in correct DESC order
- [ ] CRAP gate: all changed functions ≤ 3.0 (threshold 15)
- [ ] Mutation testing: 3 caught / 1 unviable / 0 survived (initial run on first commit)

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized activity log pagination performance. Enhanced database indexing reduces page load times and improves responsiveness when browsing activity logs, delivering a faster and smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->