### PR TITLE
chore: dormant daily data-plane QA routine scaffolding [#607]

### DIFF
--- a/.claude/routines/daily-qa/PROMPT.md
+++ b/.claude/routines/daily-qa/PROMPT.md
@@ -1,0 +1,161 @@
+# Daily Data-Plane QA Routine Prompt
+
+> **Source of truth.** Paste this into the Anthropic Routines web UI at activation time.
+> Keep this file in sync with what's in the web UI — the repo copy is authoritative.
+
+---
+
+You are a QA agent for Mokumo, a production management SaaS for decorated apparel shops.
+Your job: drive agent-browser against today's assigned data-plane scope, run the declared
+scenarios, and produce a reviewable artifact (PR or tracking-issue comment) with clear findings.
+
+## Inputs
+
+- `text` input from the Actions trigger: `"scope: <slug>"` (e.g. `"scope: customers"`)
+- Repo at the workspace root (path provided by the Anthropic Routines cloud environment)
+- Seeded `demo.db` at `apps/web/scripts/demo.db` (produced by setup script)
+- Server running at `http://localhost:6565`
+- Test credentials: `admin@demo.local` / `demo1234`
+
+## Step 1 — Parse scope
+
+Extract the slug from the `text` input:
+
+```
+text = "scope: customers"
+slug = "customers"
+```
+
+Read `.claude/routines/daily-qa/pages.yaml`. Find the entry where `slug == <slug>`.
+
+If no matching entry exists → **abort-and-flag** (see Output C below).
+If the entry has `enabled: false` → **abort-and-flag** with message:
+"Scope `<slug>` is disabled in pages.yaml — not yet activated."
+
+## Step 2 — Run scenarios
+
+For each scenario listed under the scope's `scenarios:` key:
+
+1. Use agent-browser to navigate to the scope's `route` (and each `subroute` if listed).
+2. Take an accessibility-tree snapshot at each page.
+3. Execute the scenario steps. Record: pass / fail / observation.
+4. If a scenario fails: capture the snapshot, note the exact symptom and reproduction steps.
+5. After all scenarios: classify findings:
+   - **In-scope finding**: a bug or regression fixable within this scope's files
+   - **Cross-cutting finding**: a bug that requires editing files outside this scope
+   - **Observation**: something noticed but not a failing scenario (document, don't fix)
+   - **Tie-break rule**: if a single run produces both an in-scope finding and a cross-cutting
+     finding, treat the whole run as Output C. Do not attempt a partial fix. Document both
+     findings in the tracking issue comment.
+
+## Step 3 — Determine output case
+
+### Output A — All scenarios pass (green run)
+
+Post a comment on the rolling tracking issue
+(search for open issue with label `automation:daily-qa` and title containing "rolling tracker"):
+
+```
+## customers: green — 2026-04-28
+
+All 3 scenarios passed. No findings.
+
+| Scenario | Result |
+|----------|--------|
+| list page loads and renders seeded customers | ✓ pass |
+| search/filter narrows results correctly | ✓ pass |
+| create flow round-trips and appears in list | ✓ pass |
+
+_Routine run · scope: customers · epoch day 20573_
+```
+
+Do NOT open a PR for a green run.
+
+### Output B — In-scope finding (fixable within this scope)
+
+1. Create a branch: `claude/abrowser-qa-YYYYMMDD-<slug>` (e.g. `claude/abrowser-qa-20260428-customers`)
+   - No `+` in the branch name.
+2. Make the minimal fix. Do not edit files outside the scope's route folder and its
+   backing service/handler unless the fix is trivially contained (e.g. a typo in a shared util
+   referenced only by this scope).
+3. Open a PR targeting `main`. PR body MUST include all of these sections:
+
+```markdown
+## Scope
+customers (2026-04-28 cycle)
+
+## Scenario Results
+| Scenario | Result |
+|----------|--------|
+| list page loads and renders seeded customers | ✓ pass |
+| search/filter narrows results correctly | ✗ fail — see Finding |
+| create flow round-trips and appears in list | ✓ pass |
+
+## Finding
+[What broke — include the exact snapshot or error message]
+
+## Fix Rationale
+[What was changed, why this specific change, what it does NOT attempt to fix]
+
+## Observations (out of scope — not fixed)
+[Things noticed outside today's scope. Empty if none.]
+
+## Human Review Checklist
+- [ ] Scenarios ran cleanly (no infra flake)
+- [ ] Fix is minimal and justified
+- [ ] No tests were loosened to pass
+- [ ] Out-of-scope observations have been read and triaged
+```
+
+4. Post a short comment on the rolling tracking issue:
+   "Opened PR #<n> for scope `customers` — 1 finding. See PR for details."
+
+### Output C — Cross-cutting finding (fix requires out-of-scope edits)
+
+Do NOT open a PR. Post a comment on the rolling tracking issue:
+
+```
+## customers: abort-and-flag — 2026-04-28
+
+Scenario `search/filter narrows results correctly` failed with a symptom that requires
+editing files outside today's scope.
+
+**Scope**: customers
+**Symptom**: [exact error or snapshot]
+**Reproducer**: [step-by-step]
+**Files involved**: [list files outside the scope that would need to change]
+**Suggested expansion**: Run this scope again after [prerequisite fix], or expand scope
+to include [related module] in a follow-up routine run.
+
+_Routine run · scope: customers · epoch day 20573_
+```
+
+## Discipline constraints (non-negotiable)
+
+1. **No merge authority.** Open PRs only — never merge.
+2. **Justified changes.** Every edited line in a PR body has a "why" in Fix Rationale.
+   Bare diffs without rationale are a build failure for this routine.
+3. **Scope boundary.** If a fix is clean only because you reached outside the scope, it's
+   cross-cutting — use Output C instead.
+4. **Green runs still report.** Always post to the tracking issue, even if all scenarios pass.
+5. **Single rolling issue.** One tracking issue per repo lifetime. Search for it; do not create
+   a new one if it already exists.
+
+## Cloud env setup (reference — configured in web UI, not here)
+
+```bash
+# Cached across runs
+pnpm install --frozen-lockfile
+cargo build --release -p mokumo-server
+pnpm --filter @mokumo/web build
+npm i -g agent-browser
+agent-browser install
+agent-browser skills get core dogfood  # network fetch — not hermetic; may vary if upstream changes
+npx playwright install chromium --with-deps
+
+# Per-run (not cached)
+pnpm tsx apps/web/scripts/seed-demo.ts   # writes apps/web/scripts/demo.db
+# Start server — uses --data-dir (not --db). Place seeded DB at $DATA_DIR/demo/mokumo.db
+# or let the server copy the sidecar at first launch (verify exact layout at activation).
+MOKUMO_DATA_DIR=/tmp/mokumo-qa ./target/release/mokumo-server serve --mode loopback --port 6565 &
+```

--- a/.claude/routines/daily-qa/README.md
+++ b/.claude/routines/daily-qa/README.md
@@ -1,0 +1,72 @@
+# Daily Data-Plane QA Routine
+
+Dormant scaffolding for a daily Claude Routine that cycles through Mokumo's data-plane sidebar
+routes one-per-day, drives agent-browser scenarios, and opens human-reviewable PRs.
+
+**Status: DORMANT** — All scopes are `enabled: false`. Activate only after the
+[activation gate](../../../../ops/decisions/mokumo/adr-daily-data-plane-qa-routine.md#dormant-on-land)
+closes (first M0 dataplane route + seed-demo.ts extension + manual dry-run green).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `pages.yaml` | Rotation manifest — 9 sidebar scopes, each `enabled: false` until M0 routes land |
+| `PROMPT.md` | Source of truth for the routine prompt (paste into Anthropic web UI at activation) |
+| `README.md` | This file — setup docs and activation checklist |
+
+## agent-browser Setup
+
+agent-browser is **not** committed to this repo. Use upstream's own distribution:
+
+```bash
+npm i -g agent-browser
+agent-browser install
+agent-browser skills get core dogfood
+```
+
+Run this once on your local dev machine and once in the routine's cloud environment setup script.
+See [agent-browser upstream docs](https://github.com/vercel-labs/agent-browser) for full reference.
+
+## Local Dev Quick-Start (once a dataplane route exists)
+
+```bash
+# 1. Install agent-browser (if not already)
+npm i -g agent-browser && agent-browser install && agent-browser skills get core dogfood
+
+# 2. Seed the demo DB and start the server
+cd apps/web && pnpm tsx scripts/seed-demo.ts
+cargo run -p mokumo-server -- serve --port 6565 --db apps/web/scripts/demo.db
+
+# 3. In another terminal — run agent-browser against a specific scope
+# (replace 'customers' with the scope you want to test)
+agent-browser navigate http://localhost:6565/customers
+```
+
+Test credentials (seeded by `seed-demo.ts`):
+- Email: `admin@demo.local`
+- Password: `demo1234`
+- Shop: `Mokumo Prints`
+
+## GitHub Actions
+
+`.github/workflows/daily-qa-routine.yml` fires the routine via `workflow_dispatch`.
+The `schedule:` block is commented out — uncomment it at activation.
+
+## Activation Checklist
+
+Before enabling the schedule and unpausing the routine:
+
+- [ ] At least one M0 dataplane route is implemented and reachable via `pnpm dev`
+- [ ] `seed-demo.ts` extended for that route's entity fixtures
+- [ ] Routine created in Anthropic web UI (paste `PROMPT.md`, configure cloud env)
+- [ ] `CLAUDE_ROUTINE_TOKEN` + `CLAUDE_ROUTINE_FIRE_URL` set as repo secrets
+- [ ] Manual `workflow_dispatch` dry-run passes end-to-end
+- [ ] Christopher reviews first output, confirms format is useful signal
+- [ ] Enable corresponding scope in `pages.yaml` (`enabled: true`)
+- [ ] Uncomment `schedule:` block in `daily-qa-routine.yml`
+
+## ADR + Pipeline Note
+
+- ADR: `ops/decisions/mokumo/adr-daily-data-plane-qa-routine.md` (status: Proposed)
+- Pipeline note: `ops/pipelines/mokumo/mokumo-20260419-daily-qa-routine-spike.md`

--- a/.claude/routines/daily-qa/pages.yaml
+++ b/.claude/routines/daily-qa/pages.yaml
@@ -1,0 +1,93 @@
+# Daily data-plane QA rotation manifest.
+#
+# All scopes start `enabled: false`. Enable a scope only after:
+#   1. The corresponding M0 dataplane route is implemented
+#   2. seed-demo.ts is extended for that route's entity fixtures
+#   3. A manual workflow_dispatch dry-run passes end-to-end
+#
+# Rotation order: alphabetical over enabled scopes, index = (epoch_day % count).
+# See .github/workflows/daily-qa-routine.yml for the trigger logic.
+
+cycle: dataplane
+
+pages:
+  - slug: artwork
+    enabled: false
+    route: /artwork
+    subroutes: []
+    scenarios:
+      - list page loads and displays expected columns
+      - new artwork button opens creation flow
+      - edit flow validates required fields before submit
+
+  - slug: customers
+    enabled: false
+    route: /customers
+    subroutes: []
+    scenarios:
+      - list page loads and renders seeded customers
+      - search/filter narrows results correctly
+      - create flow round-trips and appears in list
+
+  - slug: garments
+    enabled: false
+    route: /garments
+    subroutes: []
+    scenarios:
+      - list page loads and displays expected columns
+      - new garment button opens creation flow
+      - edit flow persists changes and shows confirmation
+
+  - slug: invoices
+    enabled: false
+    route: /invoices
+    subroutes: []
+    scenarios:
+      - list page loads and displays expected columns
+      - invoice detail view renders line items
+      - status transitions are surfaced correctly
+
+  - slug: orders
+    enabled: false
+    route: /orders
+    subroutes: []
+    scenarios:
+      - list page loads and displays expected columns
+      - order detail view renders correctly
+      - status badge reflects current order state
+
+  - slug: production
+    enabled: false
+    route: /production
+    subroutes: []
+    scenarios:
+      - production board loads and renders job cards
+      - job status can be advanced through workflow steps
+      - filters narrow the visible job set
+
+  - slug: quotes
+    enabled: false
+    route: /quotes
+    subroutes: []
+    scenarios:
+      - list page loads and displays expected columns
+      - new quote button opens creation flow
+      - quote detail view renders line items and totals
+
+  - slug: settings
+    enabled: false
+    route: /settings
+    subroutes: []
+    scenarios:
+      - settings page loads without error
+      - shop name field is editable and persists on save
+      - navigation between settings sections works
+
+  - slug: shipping
+    enabled: false
+    route: /shipping
+    subroutes: []
+    scenarios:
+      - list page loads and displays expected columns
+      - shipment detail view renders correctly
+      - carrier/tracking fields are present and editable

--- a/.github/workflows/daily-qa-routine.yml
+++ b/.github/workflows/daily-qa-routine.yml
@@ -1,0 +1,89 @@
+name: Daily Data-Plane QA Routine
+
+on:
+  # ACTIVATION GATE — uncomment the schedule block below only after ALL of the following are true:
+  #   1. At least one M0 dataplane route exists and is reachable via `pnpm dev`
+  #   2. seed-demo.ts is extended for that route's entity fixtures
+  #   3. The routine has been created in the Anthropic web UI (paste PROMPT.md)
+  #   4. CLAUDE_ROUTINE_TOKEN + CLAUDE_ROUTINE_FIRE_URL are set as repo secrets
+  #   5. A manual workflow_dispatch dry-run has passed end-to-end
+  #   6. Christopher has reviewed the first output and confirmed format is useful signal
+  #   7. The corresponding scope is set to `enabled: true` in pages.yaml
+  #   8. Uncomment the schedule: block below to activate the daily trigger
+  #
+  # schedule:
+  #   - cron: '0 12 * * *'   # 07:00 EST (UTC-5) / 08:00 EDT (UTC-4) — DST drift documented, not solved
+
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: >-
+          Scope slug to test (e.g. "customers"). Overrides alphabetical rotation.
+          Leave blank to use today's computed scope.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  fire-routine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Compute scope
+        id: scope
+        env:
+          MANUAL_SCOPE: ${{ inputs.scope }}
+        run: |
+          if [ -n "$MANUAL_SCOPE" ]; then
+            echo "Selected scope (manual override): $MANUAL_SCOPE"
+            { echo 'scope<<GH_EOF'; echo "$MANUAL_SCOPE"; echo 'GH_EOF'; } >> "$GITHUB_OUTPUT"
+          else
+            SELECTED=$(python3 - <<'EOF'
+          import yaml, sys, time
+
+          with open(".claude/routines/daily-qa/pages.yaml") as f:
+              data = yaml.safe_load(f)
+
+          enabled = sorted(p["slug"] for p in data["pages"] if p.get("enabled", False))
+
+          if not enabled:
+              print("NO_ENABLED_SCOPES", end="")
+              sys.exit(0)
+
+          epoch_day = int(time.time() / 86400)
+          idx = epoch_day % len(enabled)
+          print(enabled[idx], end="")
+          EOF
+          )
+            if [ "$SELECTED" = "NO_ENABLED_SCOPES" ]; then
+              echo "No enabled scopes in pages.yaml — nothing to fire."
+              echo "scope=" >> "$GITHUB_OUTPUT"
+            else
+              echo "Selected scope (rotation): $SELECTED"
+              { echo 'scope<<GH_EOF'; echo "$SELECTED"; echo 'GH_EOF'; } >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Fire routine
+        if: steps.scope.outputs.scope != ''
+        env:
+          CLAUDE_ROUTINE_FIRE_URL: ${{ secrets.CLAUDE_ROUTINE_FIRE_URL }}
+          CLAUDE_ROUTINE_TOKEN: ${{ secrets.CLAUDE_ROUTINE_TOKEN }}
+          SCOPE: ${{ steps.scope.outputs.scope }}
+        run: |
+          echo "Firing routine for scope: $SCOPE"
+          PAYLOAD=$(jq -n --arg scope "$SCOPE" '{"text": ("scope: " + $scope)}')
+          curl -f -X POST "$CLAUDE_ROUTINE_FIRE_URL" \
+            -H "Authorization: Bearer $CLAUDE_ROUTINE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ apps/web/build/
 .claude/*
 !.claude/rules/
 !.claude/rules/**
+!.claude/routines/
+!.claude/routines/**
 # OS
 .DS_Store
 Thumbs.db

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -39,8 +39,16 @@ tasks:
     inputs:
     - '@group(sources)'
     - '@group(tests)'
+  sidebar-sync:
+    command: pnpm tsx ../../scripts/check-pages-yaml-sync.ts
+    inputs:
+    - src/routes/**
+    - /.claude/routines/daily-qa/pages.yaml
+    - /scripts/check-pages-yaml-sync.ts
   lint:
     command: pnpm oxlint --config ../../.oxlintrc.json src/
+    deps:
+    - sidebar-sync
     inputs:
     - '@group(sources)'
     - /.oxlintrc.json

--- a/scripts/check-pages-yaml-sync.ts
+++ b/scripts/check-pages-yaml-sync.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env tsx
+/**
+ * Lint: pages.yaml ↔ (app) route folder sync.
+ *
+ * Fails if:
+ *   - A folder under apps/web/src/routes/(app)/ has no matching slug in pages.yaml
+ *   - A slug in pages.yaml has no matching folder under apps/web/src/routes/(app)/
+ *
+ * Usage: pnpm --filter @mokumo/web exec tsx ../../scripts/check-pages-yaml-sync.ts
+ *        (or: pnpm tsx scripts/check-pages-yaml-sync.ts from apps/web/)
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const ROUTES_DIR = join(REPO_ROOT, "apps/web/src/routes/(app)");
+const PAGES_YAML = join(REPO_ROOT, ".claude/routines/daily-qa/pages.yaml");
+
+// ── Route slugs from filesystem ──────────────────────────────────────────────
+
+let routeSlugs: Set<string>;
+try {
+  routeSlugs = new Set(
+    readdirSync(ROUTES_DIR).filter((name) =>
+      statSync(join(ROUTES_DIR, name)).isDirectory()
+    )
+  );
+} catch {
+  console.error(`Route directory not found: ${ROUTES_DIR}`);
+  console.error("Expected: apps/web/src/routes/(app)/");
+  process.exit(1);
+}
+
+// ── Slugs from pages.yaml (regex parse — we control the format) ──────────────
+//
+// Matches YAML lines of the form:
+//   "  - slug: customers"
+// Indentation and trailing whitespace are trimmed.
+
+let yamlContent: string;
+try {
+  yamlContent = readFileSync(PAGES_YAML, "utf-8");
+} catch {
+  console.error(`pages.yaml not found: ${PAGES_YAML}`);
+  console.error("Expected: .claude/routines/daily-qa/pages.yaml");
+  process.exit(1);
+}
+const yamlSlugs = new Set(
+  [...yamlContent.matchAll(/^\s+-\s+slug:\s+(\S+)/gm)].map((m) => m[1])
+);
+
+// ── Diff ─────────────────────────────────────────────────────────────────────
+
+const onlyInRoutes = [...routeSlugs]
+  .filter((s) => !yamlSlugs.has(s))
+  .sort();
+
+const onlyInYaml = [...yamlSlugs]
+  .filter((s) => !routeSlugs.has(s))
+  .sort();
+
+let hasError = false;
+
+if (onlyInRoutes.length > 0) {
+  console.error(
+    `\nRoute folders missing from pages.yaml (${onlyInRoutes.length}):\n` +
+      onlyInRoutes.map((s) => `  - ${s}`).join("\n")
+  );
+  console.error(
+    "\nAdd each missing scope to .claude/routines/daily-qa/pages.yaml with enabled: false\n"
+  );
+  hasError = true;
+}
+
+if (onlyInYaml.length > 0) {
+  console.error(
+    `\npages.yaml slugs with no matching route folder (${onlyInYaml.length}):\n` +
+      onlyInYaml.map((s) => `  - ${s}`).join("\n")
+  );
+  console.error(
+    "\nRemove these slugs from pages.yaml or create the matching route folders\n"
+  );
+  hasError = true;
+}
+
+if (!hasError) {
+  const count = routeSlugs.size;
+  console.log(`pages.yaml sync OK — ${count} scope${count === 1 ? "" : "s"} matched`);
+  console.log([...routeSlugs].sort().map((s) => `  ✓ ${s}`).join("\n"));
+}
+
+process.exit(hasError ? 1 : 0);


### PR DESCRIPTION
## Summary

- Ships dormant scaffolding for a daily agent-browser QA routine over Mokumo's 9 data-plane sidebar routes — nothing fires until each scope is explicitly enabled and the activation checklist is cleared
- agent-browser distributed via upstream npm (`npm i -g agent-browser && agent-browser install && agent-browser skills get core dogfood`), not committed to repo
- `web:sidebar-sync` Moon task wired as dep of `web:lint` so the pages.yaml ↔ route-folder sync check runs automatically in CI

## Deliverables

| File | Purpose |
|------|---------|
| `.claude/routines/daily-qa/README.md` | Install docs + activation checklist |
| `.claude/routines/daily-qa/pages.yaml` | 9-scope rotation manifest (all `enabled: false`) |
| `.claude/routines/daily-qa/PROMPT.md` | 3-case routine prompt (green / in-scope PR / abort-and-flag) |
| `.github/workflows/daily-qa-routine.yml` | Trigger workflow (`schedule:` commented out; `workflow_dispatch` enabled) |
| `scripts/check-pages-yaml-sync.ts` | CI lint: `(app)/` route folders ↔ `pages.yaml` slugs |
| `apps/web/moon.yml` | `web:sidebar-sync` task + dep on `web:lint` |
| `.gitignore` | `!.claude/routines/` exception |

## Activation gate

All 9 scopes start `enabled: false`. Activation requires:
1. An M0 dataplane route is reachable via the compiled binary
2. `seed-demo.ts` is extended for that route's fixtures
3. Routine pasted into Anthropic web UI (use `PROMPT.md`)
4. `CLAUDE_ROUTINE_TOKEN` + `CLAUDE_ROUTINE_FIRE_URL` set as repo secrets
5. Manual `workflow_dispatch` dry-run passes end-to-end
6. First output reviewed and format confirmed useful
7. Scope set to `enabled: true` in `pages.yaml`
8. `schedule:` block uncommented in `daily-qa-routine.yml`

Rolling QA tracker: #610 (cannot pin — repo at 3-pin limit)

## Test plan

- [x] Smoke test: added `fake-test-route/` dir → `check-pages-yaml-sync.ts` exits 1; removed → exits 0
- [x] `web:sidebar-sync` task runs cleanly via `pnpm tsx ../../scripts/check-pages-yaml-sync.ts`
- [x] Workflow `${{ inputs.scope }}` routed through `env:` vars (security hook passed)
- [x] `jq` used to build curl JSON payload (no shell injection via scope value)
- [x] `$GITHUB_OUTPUT` writes use heredoc delimiter pattern (no newline injection)

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)