### PR TITLE
chore: rename Moon task prefix api:* → shop:* [#568]

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint + format
-        run: moon run api:lint api:fmt
+        run: moon run shop:lint shop:fmt
 
   test-rust:
     needs: [changes]
@@ -126,7 +126,7 @@ jobs:
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
       - name: Unit + integration tests
-        run: moon run api:test
+        run: moon run shop:test
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -135,7 +135,7 @@ jobs:
           path: target/nextest/ci/junit.xml
           if-no-files-found: ignore
       - name: BDD acceptance tests
-        run: moon run api:test-bdd api:test-bdd-api
+        run: moon run shop:test-bdd shop:test-bdd-api
 
   coverage-rust:
     needs: [changes]
@@ -164,7 +164,7 @@ jobs:
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
       - name: Coverage
-        run: moon run api:coverage
+        run: moon run shop:coverage
       - name: Upload coverage report
         if: success() || failure()
         uses: actions/upload-artifact@v4
@@ -323,7 +323,7 @@ jobs:
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
       - name: Build server
-        run: cargo build -p mokumo-server && moon run api:build
+        run: cargo build -p mokumo-server && moon run shop:build
       - name: Run seed script
         run: moon run web:seed-demo
       - name: Verify demo.db exists
@@ -383,7 +383,7 @@ jobs:
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
       - name: CRAP quality gate
-        run: moon run api:crap
+        run: moon run shop:crap
       - name: Upload LCOV
         if: always()
         uses: actions/upload-artifact@v4
@@ -436,7 +436,7 @@ jobs:
           # Cold-start suite only: server boots in setup-required mode (no admin user),
           # so all routes except health and login return 503 until setup is complete.
           # Authenticated + post-setup tests (me-unauthenticated, not-found, list-unauthenticated)
-          # are deferred to the api:smoke-authed task once seed credentials are stable.
+          # are deferred to the shop:smoke-authed task once seed credentials are stable.
           hurl --variables-file tests/api/envs/ci.env --test \
             tests/api/health/health.hurl \
             tests/api/auth/login-bad-credentials.hurl
@@ -506,9 +506,9 @@ jobs:
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
       - name: Verify ts-rs bindings in sync
-        run: moon run api:bindings-check
+        run: moon run shop:bindings-check
       - name: Verify entity-schema alignment
-        run: moon run api:entity-check
+        run: moon run shop:entity-check
 
   desktop-e2e:
     needs: [changes]

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ lefthook-local.yml
 # Pipeline state (transient, per-session)
 # ts-rs default output (canonical path is apps/web/src/lib/types/ via Moon)
 **/bindings/
-# SQLx offline cache (.sqlx/) — commit after running: moon run api:db-prepare
+# SQLx offline cache (.sqlx/) — commit after running: moon run shop:db-prepare
 mutants.out/
 mutants.out.old/
 # ts-rs export artifacts in crate dirs

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,11 +1,7 @@
 $schema: https://moonrepo.dev/schemas/workspace.json
 projects:
   web: apps/web
-  # `api` project retargeted from services/api → crates/mokumo-shop in PR 4c (#512).
-  # services/api is retired; mokumo-shop owns the BDD harness and workspace-level
-  # Rust tasks that services/api/moon.yml used to host. The Moon prefix rename
-  # (`api:*` → `server:*`) is tracked separately in #568.
-  api: crates/mokumo-shop
+  shop: crates/mokumo-shop
   mokumo-desktop: apps/mokumo-desktop
   mokumo-server: apps/mokumo-server
   kikan: crates/kikan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Repo Context
 
-- Architecture: Moon monorepo with `apps/web` (SvelteKit), `apps/mokumo-server` (headless Axum binary), `apps/mokumo-desktop` (Tauri), and Rust crates under `crates/` (`kikan`, `mokumo-shop`, `kikan-cli`, `kikan-socket`, etc.). The Moon `api:` project points at `crates/mokumo-shop`.
-- Testing: prefer repo tasks over ad hoc commands. `moon check --all` is the broadest validation path; `moon run web:test` covers frontend tests; `moon run api:test` covers backend unit + integration tests; `moon run api:test-bdd api:test-bdd-api` covers both shop and HTTP BDD harnesses. BDD suites live under `crates/kikan/tests/` and `crates/mokumo-shop/tests/`; Playwright BDD coverage lives under `apps/web/tests`.
+- Architecture: Moon monorepo with `apps/web` (SvelteKit), `apps/mokumo-server` (headless Axum binary), `apps/mokumo-desktop` (Tauri), and Rust crates under `crates/` (`kikan`, `mokumo-shop`, `kikan-cli`, `kikan-socket`, etc.). The Moon `shop:` project points at `crates/mokumo-shop`.
+- Testing: prefer repo tasks over ad hoc commands. `moon check --all` is the broadest validation path; `moon run web:test` covers frontend tests; `moon run shop:test` covers backend unit + integration tests; `moon run shop:test-bdd shop:test-bdd-api` covers both shop and HTTP BDD harnesses. BDD suites live under `crates/kikan/tests/` and `crates/mokumo-shop/tests/`; Playwright BDD coverage lives under `apps/web/tests`.
 - Quality context: `COVERAGE.md` documents `cargo-llvm-cov`; `tools/bdd-lint` enforces BDD spec and step-definition hygiene.
 - Safety: do not push directly to `main`, do not modify `.github/workflows/*` unless the task clearly requires CI changes, and keep private operational state in `ops`, not this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,18 +17,18 @@ moon run web:build        # Build SvelteKit frontend (adapter-static)
 moon run web:test         # Frontend tests (Vitest)
 moon run web:check        # SvelteKit type-check (svelte-check)
 moon run web:preview      # Preview production build
-moon run api:dev          # Axum backend with auto-reload (depends on web:build)
-moon run api:build        # Build Rust backend (depends on web:build)
-moon run api:test         # Backend tests (cargo test)
-moon run api:lint         # Clippy lints
-moon run api:fmt          # Check Rust formatting (cargo fmt --check)
-moon run api:fmt-write    # Apply Rust formatting (cargo fmt)
-moon run api:gen-types    # Generate TypeScript from Rust structs (ts-rs)
-moon run api:coverage     # Rust coverage report (JSON, used by CI)
-moon run api:coverage-report  # Rust coverage report (HTML, local dev)
-moon run api:smoke            # Hurl HTTP smoke tests (requires running server + hurl CLI)
-moon run api:db-prepare   # Prepare SQLx offline cache (CI)
-moon run api:deny         # Supply-chain audit (advisories, licenses, sources)
+moon run shop:dev          # Axum backend with auto-reload (depends on web:build)
+moon run shop:build        # Build Rust backend (depends on web:build)
+moon run shop:test         # Backend tests (cargo test)
+moon run shop:lint         # Clippy lints
+moon run shop:fmt          # Check Rust formatting (cargo fmt --check)
+moon run shop:fmt-write    # Apply Rust formatting (cargo fmt)
+moon run shop:gen-types    # Generate TypeScript from Rust structs (ts-rs)
+moon run shop:coverage     # Rust coverage report (JSON, used by CI)
+moon run shop:coverage-report  # Rust coverage report (HTML, local dev)
+moon run shop:smoke            # Hurl HTTP smoke tests (requires running server + hurl CLI)
+moon run shop:db-prepare   # Prepare SQLx offline cache (CI)
+moon run shop:deny         # Supply-chain audit (advisories, licenses, sources)
 moon check --all          # Full CI: lint, test, typecheck, build across all projects
 ```
 
@@ -40,7 +40,7 @@ Underlying tools: `cargo` (Rust), `pnpm` (SvelteKit). Use directly only when dia
 - **Container sessions (cmux/Docker)**: the container **is** the worktree — do NOT run `claude --worktree`, `EnterWorktree`, or `git worktree add` inside `/workspace`. Git writes the new worktree's metadata with container-only paths (e.g. `gitdir: /workspace/...`) into the bind-mounted `.git/worktrees/`, the host sees those entries as `prunable`, and any host `git worktree prune` wipes them — silently breaking every git-backed tool (`moon`, `lefthook`, `gh`) in whichever container was using that metadata. Parallelism inside a container uses sub-agents that share the same `/workspace`; for a genuinely separate workspace, stop and spin up a second host-created worktree in its own container.
 - **Never push to main directly** — always branch + PR
 - **Commit+push after every logical chunk** — never leave work local-only
-- **Run `moon run api:deny` after touching Cargo.toml or Cargo.lock** — catches advisory, license, and supply-chain issues before CI
+- **Run `moon run shop:deny` after touching Cargo.toml or Cargo.lock** — catches advisory, license, and supply-chain issues before CI
 - **Update CHANGELOG.md** — add user-facing changes (`feat`, `fix`, `perf`) to the `## Unreleased` section in each PR
 - **New API endpoints require a `.hurl` file** — add `tests/api/<domain>/<endpoint>.hurl` in the same PR. Error shape is `{"code": "...", "message": "...", "details": null}` — assert on `$.code`, not `$.error`
 - Read-only sessions do not need a worktree
@@ -153,7 +153,7 @@ crates/kikan/src/
 3. **Hybrid ORM + raw SQL** — SeaORM for entity CRUD operations, `sqlx::query!()` / `sqlx::query_as!()` for complex joins, reporting, and aggregate queries. Never string-concatenated SQL in either approach.
 4. **Svelte 5 runes only** — `$state`, `$derived`, `$effect`, `$props`. Never Svelte 4 stores or `export let`.
 5. **Axum patterns** — standard Axum server setup, SQLite PRAGMAs (WAL, foreign_keys, busy_timeout), `thiserror` + `IntoResponse` error handling, repository traits with `Send + Sync` bounds. Route builders per module return `Router<SomeRouterDeps>` with singleton deps only; per-request state comes from extractors (see §Architecture).
-6. **ts-rs type sharing** — API DTOs live in `crates/kikan-types/` and derive `TS` + `Serialize` for TypeScript generation. SeaORM entity types are infrastructure, not shared. Run `moon run api:gen-types` to regenerate TypeScript bindings.
+6. **ts-rs type sharing** — API DTOs live in `crates/kikan-types/` and derive `TS` + `Serialize` for TypeScript generation. SeaORM entity types are infrastructure, not shared. Run `moon run shop:gen-types` to regenerate TypeScript bindings.
 7. **Error handling** — two layers: `ControlPlaneError` (narrow, handler-level; in `crates/kikan/src/error/`) for admin surface handler signatures, and `AppError` (wider; in `crates/kikan/src/app_error.rs`) for HTTP transport rendering. HTTP adapters convert via `From<ControlPlaneError> for AppError`. UDS adapters render `ControlPlaneError` directly. Both paths produce the same `(ErrorCode, http_status)` tuple — that equality is pinned by `control_plane_error_variants.feature`.
 8. **No raw SQL injection** — parameterized queries only.
 9. **URL state** — filters, search, pagination in URL query params. Svelte `$state` for ephemeral UI state only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,18 +17,18 @@ moon run web:build        # Build SvelteKit frontend (adapter-static)
 moon run web:test         # Frontend tests (Vitest)
 moon run web:check        # SvelteKit type-check (svelte-check)
 moon run web:preview      # Preview production build
-moon run shop:dev          # Axum backend with auto-reload (depends on web:build)
-moon run shop:build        # Build Rust backend (depends on web:build)
-moon run shop:test         # Backend tests (cargo test)
-moon run shop:lint         # Clippy lints
-moon run shop:fmt          # Check Rust formatting (cargo fmt --check)
-moon run shop:fmt-write    # Apply Rust formatting (cargo fmt)
-moon run shop:gen-types    # Generate TypeScript from Rust structs (ts-rs)
-moon run shop:coverage     # Rust coverage report (JSON, used by CI)
-moon run shop:coverage-report  # Rust coverage report (HTML, local dev)
-moon run shop:smoke            # Hurl HTTP smoke tests (requires running server + hurl CLI)
-moon run shop:db-prepare   # Prepare SQLx offline cache (CI)
-moon run shop:deny         # Supply-chain audit (advisories, licenses, sources)
+moon run shop:dev         # Axum backend with auto-reload (depends on web:build)
+moon run shop:build       # Build Rust backend (depends on web:build)
+moon run shop:test        # Backend tests (cargo test)
+moon run shop:lint        # Clippy lints
+moon run shop:fmt         # Check Rust formatting (cargo fmt --check)
+moon run shop:fmt-write   # Apply Rust formatting (cargo fmt)
+moon run shop:gen-types   # Generate TypeScript from Rust structs (ts-rs)
+moon run shop:coverage    # Rust coverage report (JSON, used by CI)
+moon run shop:coverage-report # Rust coverage report (HTML, local dev)
+moon run shop:smoke           # Hurl HTTP smoke tests (requires running server + hurl CLI)
+moon run shop:db-prepare  # Prepare SQLx offline cache (CI)
+moon run shop:deny        # Supply-chain audit (advisories, licenses, sources)
 moon check --all          # Full CI: lint, test, typecheck, build across all projects
 ```
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -6,10 +6,10 @@ Rust workspace coverage via [cargo-llvm-cov](https://github.com/taiki-e/cargo-ll
 
 ```bash
 # JSON report (used by CI)
-moon run api:coverage
+moon run shop:coverage
 
 # HTML report (local dev — open coverage/rust/html/index.html)
-moon run api:coverage-report
+moon run shop:coverage-report
 ```
 
 Both commands run unit tests only (`--lib`). Integration and BDD tests are excluded intentionally at M0 — add `--tests` when domain logic in `crates/core/` warrants full-stack coverage.
@@ -72,7 +72,7 @@ Enforcement via `cargo llvm-cov` `--fail-under-lines` flag added to the CI cover
 
 ## CI Integration
 
-The `coverage-rust` job in `.github/workflows/quality.yml` runs `moon run api:coverage` and uploads `coverage.json` as an artifact (`rust-coverage`). This job only runs on pushes to `main` (not on PRs). Download from any main-branch CI run's Artifacts tab.
+The `coverage-rust` job in `.github/workflows/quality.yml` runs `moon run shop:coverage` and uploads `coverage.json` as an artifact (`rust-coverage`). This job only runs on pushes to `main` (not on PRs). Download from any main-branch CI run's Artifacts tab.
 
 ## Interpreting the Report
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Prerequisites: Rust, Node.js 22+, pnpm, [Moon](https://moonrepo.dev)
 ```bash
 pnpm install                  # Install JS dependencies
 moon run web:dev              # SvelteKit dev server
-moon run api:dev              # Axum backend with auto-reload
-moon run api:test             # Backend tests
+moon run shop:dev             # Axum backend with auto-reload
+moon run shop:test            # Backend tests
 moon run web:test             # Frontend tests
 moon check --all              # Full CI suite
 ```

--- a/apps/web/moon.yml
+++ b/apps/web/moon.yml
@@ -133,7 +133,7 @@ tasks:
     script: pnpm exec bddgen && pnpm exec playwright test --project app --project profile --project welcome-restore
     deps:
     - ~:build
-    - api:build
+    - shop:build
     inputs:
     - '@group(sources)'
     - '@group(tests)'
@@ -152,7 +152,7 @@ tasks:
     script: pnpm exec playwright test --project e2e-lan --pass-with-no-tests
     deps:
     - ~:build
-    - api:build
+    - shop:build
     inputs:
     - '@group(sources)'
     - '@group(tests)'
@@ -162,15 +162,15 @@ tasks:
   seed-demo:
     script: pnpm tsx scripts/seed-demo.ts
     deps:
-    - api:build
-    - api:gen-types
+    - shop:build
+    - shop:gen-types
     options:
       cache: false
   demo-captures:
     script: pnpm exec playwright test --project demo-captures
     deps:
     - ~:build
-    - api:build
+    - shop:build
     inputs:
     - '@group(sources)'
     - '@group(tests)'

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -190,10 +190,10 @@ tasks:
     # External HTTP smoke tests against a running server.
     # Boots the server, runs .hurl files in tests/api/, then stops the server.
     # Requires: hurl CLI (brew install hurl).
-    # Local run: moon run api:smoke
+    # Local run: moon run shop:smoke
     # Env file: copy tests/api/envs/local.env.example → tests/api/envs/local.env (gitignored)
     # Note: authenticated-endpoint tests (list, create, get) are excluded here — they require
-    # seed credentials. Add a separate api:smoke-authed task when demo seed data is stable.
+    # seed credentials. Add a separate shop:smoke-authed task when demo seed data is stable.
     script: |
       set -euo pipefail
       cp -n tests/api/envs/ci.env.example tests/api/envs/ci.env 2>/dev/null || true

--- a/crates/mokumo-shop/src/types/mod.rs
+++ b/crates/mokumo-shop/src/types/mod.rs
@@ -1,7 +1,7 @@
 //! API DTO types for the Mokumo shop vertical.
 //!
 //! Wire shapes consumed by the SvelteKit frontend. ts-rs bindings are emitted
-//! into `apps/web/src/lib/types/shop/` via the `api:gen-types-shop` Moon task.
+//! into `apps/web/src/lib/types/shop/` via the `shop:gen-types-shop` Moon task.
 
 pub mod customer;
 pub mod error;

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -50,4 +50,4 @@ pre-push:
       env:
         RUSTC_WRAPPER: ""
         CARGO_TARGET_DIR: /tmp/mokumo-target
-      run: moon run api:lint
+      run: moon run shop:lint

--- a/tests/api/bind/ephemeral-loopback.hurl
+++ b/tests/api/bind/ephemeral-loopback.hurl
@@ -3,7 +3,7 @@
 # Verifies the server is reachable when bound to an OS-assigned loopback port.
 # Run with: hurl --variable host=127.0.0.1:PORT tests/api/bind/ephemeral-loopback.hurl
 #
-# In CI, `moon run api:smoke` uses host=localhost:6565 (mokumo-server fixed port).
+# In CI, `moon run shop:smoke` uses host=localhost:6565 (mokumo-server fixed port).
 # For desktop ephemeral-port verification, override the host variable with the
 # actual port reported at startup:
 #   hurl --variable host=127.0.0.1:<ephemeral_port> tests/api/bind/ephemeral-loopback.hurl


### PR DESCRIPTION
## Summary

- Retires the historical `api:` Moon project alias. The alias pointed at `crates/mokumo-shop` after Stage 8 retired `services/api`, but `api:*` task names were a misnomer — the tasks host the shop vertical's Rust workspace surface (build, test, lint, coverage, bindings-check, entity-check, BDD harnesses), not just HTTP API concerns.
- `shop:*` names the Moon project after the crate that owns the tasks. Every call site in CI, lefthook, cross-project deps, and documentation moves in the same commit — Moon caches are keyed by project+task, so a partial rename would produce "task not found" at call sites.
- Mechanical rename across 12 files: `.moon/workspace.yml` (alias), `crates/mokumo-shop/moon.yml` (comments), `apps/web/moon.yml` (cross-project deps), `.github/workflows/quality.yml`, `lefthook.yml`, `CLAUDE.md`, `AGENTS.md`, `COVERAGE.md`, `README.md`, `.gitignore`, a doc comment in `crates/mokumo-shop/src/types/mod.rs`, and a comment in `tests/api/bind/ephemeral-loopback.hurl`.

## Test plan

- [x] Local `moon task shop:build`, `moon task shop:test-bdd`, `moon task shop:test-bdd-api` all resolve
- [x] `moon run shop:fmt` runs cleanly end-to-end locally
- [ ] CI green on `lint-rust`, `test-rust`, `test-bdd`, `api-smoke`, `seam-check`, `crap-rust`, `bindings-check` — all call sites updated
- [ ] `grep -rn 'moon run api:'` returns zero matches post-merge

Closes #568. Epic #505 continues with the remaining non-blocking sub-issues (#582, #560, #609, #558, #521).

🤖 Generated with [Claude Code](https://claude.com/claude-code)