### PR TITLE
ci(kikan): audit I3 under --no-default-features [#554]

### DIFF
--- a/scripts/check-i3-headless.sh
+++ b/scripts/check-i3-headless.sh
@@ -30,8 +30,12 @@ check_tree() {
         return 2
     fi
 
+    # Anchor to line start so forbidden names only match at the crate-name
+    # position. `cargo tree --prefix none` emits `crate vX.Y.Z (/abs/path)`
+    # for workspace members — an unanchored pattern false-positives when the
+    # repo is cloned under a path containing `tauri`/`wry`/etc.
     local hits
-    hits="$(echo "$tree" | grep -iE "$FORBIDDEN" | sort -u || true)"
+    hits="$(echo "$tree" | grep -iE "^$FORBIDDEN" | sort -u || true)"
     if [[ -n "$hits" ]]; then
         echo "::error::I3 violated (${label}): ${PKG} transitively depends on Tauri/webview crates" >&2
         echo "Offending entries:" >&2

--- a/scripts/check-i3-headless.sh
+++ b/scripts/check-i3-headless.sh
@@ -6,26 +6,45 @@
 #   - adr-workspace-split-kikan (I3)
 #   - adr-kikan-binary-topology
 #
+# The check runs cargo tree under two feature configurations:
+#   - default features: production path; what the release binary links
+#   - no-default features: guards against a future default feature masking
+#     a Tauri-bearing dep. If a feature becomes non-default but still pulls
+#     Tauri, the default-only audit would miss it as the feature surface
+#     grows (#554).
+#
 # I3b (musl cross-compile) is a separate CI job; see kikan-musl-build.
 set -euo pipefail
 
 PKG="${1:-mokumo-server}"
+FORBIDDEN='\b(tauri|tauri-build|webkit2gtk|wry)\b'
 
-# Capture cargo tree separately so `set -e` doesn't abort on grep no-match.
-tree="$(env -u RUSTC_WRAPPER cargo tree -p "$PKG" --edges normal,build --prefix none 2>/dev/null || true)"
+check_tree() {
+    local label="$1"
+    shift
+    local tree
+    tree="$(env -u RUSTC_WRAPPER cargo tree -p "$PKG" "$@" --edges normal,build --prefix none 2>/dev/null || true)"
 
-if [[ -z "$tree" ]]; then
-    echo "::error::I3 script error: cargo tree -p ${PKG} produced no output" >&2
-    exit 2
-fi
+    if [[ -z "$tree" ]]; then
+        echo "::error::I3 script error: cargo tree ${label} for ${PKG} produced no output" >&2
+        return 2
+    fi
 
-if echo "$tree" | grep -iE '\b(tauri|tauri-build|webkit2gtk|wry)\b' >/tmp/i3-hits.$$; then
-    echo "::error::I3 violated: ${PKG} transitively depends on Tauri/webview crates" >&2
-    echo "Offending entries:" >&2
-    sort -u /tmp/i3-hits.$$ >&2
-    rm -f /tmp/i3-hits.$$
-    exit 1
-fi
-rm -f /tmp/i3-hits.$$
+    local hits
+    hits="$(echo "$tree" | grep -iE "$FORBIDDEN" | sort -u || true)"
+    if [[ -n "$hits" ]]; then
+        echo "::error::I3 violated (${label}): ${PKG} transitively depends on Tauri/webview crates" >&2
+        echo "Offending entries:" >&2
+        echo "$hits" >&2
+        return 1
+    fi
+    echo "I3 ok (${label}): ${PKG} has no Tauri/webview transitive deps"
+    return 0
+}
 
-echo "I3 ok: ${PKG} has no Tauri/webview transitive deps"
+rc=0
+check_tree "default features" || rc=$?
+if [[ "$rc" -ne 0 ]]; then exit "$rc"; fi
+
+check_tree "no-default features" --no-default-features || rc=$?
+exit "$rc"

--- a/scripts/test/run-self-tests.sh
+++ b/scripts/test/run-self-tests.sh
@@ -39,7 +39,9 @@ cd "$ROOT"
 assert_exit "I1 real-tree pass" 0 bash scripts/check-i1-domain-purity.sh
 assert_exit "I2 real-tree pass" 0 bash scripts/check-i2-adapter-boundary.sh
 assert_exit "I2b real-tree pass" 0 bash scripts/check-i2b-tauri-type-ids.sh
-assert_exit "I3 real-tree pass" 0 bash scripts/check-i3-headless.sh
+# I3 covers both default and no-default features configurations internally;
+# a single pass assertion validates mokumo-server is Tauri-free under each (#554).
+assert_exit "I3 real-tree pass (default + no-default features)" 0 bash scripts/check-i3-headless.sh
 assert_exit "I4 real-tree pass" 0 bash scripts/check-i4-dag.sh
 assert_exit "I5 real-tree pass" 0 bash scripts/check-i5-features.sh
 assert_exit "R13 real-tree pass" 0 bash scripts/check-r13-action-strings.sh


### PR DESCRIPTION
## Summary

- Extend the I3 headless-server check to run `cargo tree` under two feature configurations — default features **and** `--no-default-features` — and fail if either drags Tauri/webview crates into `mokumo-server`.
- The feature surface is tiny today (`mokumo-server` has no features), so both runs produce the same tree. The dual audit becomes load-bearing as features are added: if a future default feature masks a Tauri-bearing transitive dep, the `--no-default-features` pass is what catches it.
- Self-test covers both modes via the single real-tree assertion — the script loops internally and fails fast on any violation. Label updated to make dual coverage explicit.

## Acceptance criteria (from #554)

- [x] `scripts/check-i3-headless.sh` adds a `--no-default-features` variant (in-script loop over both modes)
- [x] Self-test covers both default and no-default-features trees
- [x] Script comments document why both are needed

## Test plan

- [x] `bash scripts/check-i3-headless.sh` prints both "ok" lines locally
- [x] `bash scripts/check-i3-headless.sh mokumo-desktop` fails fast on default-features mode (confirms the violation path)
- [x] `bash scripts/test/run-self-tests.sh` — 12 passed, 0 failed
- [x] CI `kikan-invariants` job green

Closes #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)