### PR TITLE
chore: purge stage-narrative comments in Cargo.toml [#624]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,11 +136,11 @@ local-ip-address = "0.6"
 zip = "8"
 sysinfo = "0.38"
 
-# Internal crates — legacy (migrate into kikan / mokumo-shop in Stages 1-3)
+# Internal crates — leaf utility crates
 mokumo-core = { path = "crates/core" }
 kikan-types = { path = "crates/kikan-types" }
 
-# Internal crates — kikan platform + mokumo-shop vertical (Stage 0 stubs)
+# Internal crates — kikan platform + mokumo-shop vertical
 kikan = { path = "crates/kikan" }
 kikan-tauri = { path = "crates/kikan-tauri" }
 kikan-socket = { path = "crates/kikan-socket" }


### PR DESCRIPTION
## Summary

- Rewrite the two internal-crate group headers in `Cargo.toml` (L139, L143) to drop stage / phase / wave narrative per CLAUDE.md rule 18.
- Comment-only diff. No dependency changes, no reordering.

Closes #624. Fast-follow to #621 / PR #625.

## Why this is its own PR

Editing `Cargo.toml` triggers the `moon run shop:deny` supply-chain audit gate (CLAUDE.md §Session Startup). #621 was a docs-only PR — keeping this diff out preserved that purity for reviewers.

## Test plan

- [x] `cargo deny check` clean: `advisories ok, bans ok, licenses ok, sources ok`
- [x] Diff is exactly the two comment lines; no other Cargo.toml content changed
- [x] No dependency-block reordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation comments for workspace dependency metadata to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->