### PR TITLE
chore(kikan): data-plane polish (#633, #634, #636)

### DIFF
--- a/crates/kikan/src/data_plane/config.rs
+++ b/crates/kikan/src/data_plane/config.rs
@@ -132,21 +132,33 @@ pub enum HostPatternError {
     ContainsScheme,
     ContainsWildcard,
     NonAscii,
+    /// Input is structurally invalid in a way none of the other variants
+    /// describes (e.g. a bracketed IPv6 literal missing its closing bracket).
+    /// `reason` is a static string naming the specific defect.
+    Malformed {
+        reason: &'static str,
+    },
 }
 
 impl std::fmt::Display for HostPatternError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let msg = match self {
-            Self::Empty => "host pattern is empty",
-            Self::ContainsWhitespace => "host pattern contains whitespace",
-            Self::ContainsNul => "host pattern contains NUL byte",
-            Self::ContainsPathSeparator => "host pattern contains path separator (/ or \\)",
-            Self::ContainsPort => "host pattern must not include a port (strip `:PORT`)",
-            Self::ContainsScheme => "host pattern must not include a scheme (strip `http(s)://`)",
-            Self::ContainsWildcard => "host pattern must not include wildcards (`*`)",
-            Self::NonAscii => "host pattern contains non-ASCII characters",
-        };
-        f.write_str(msg)
+        match self {
+            Self::Empty => f.write_str("host pattern is empty"),
+            Self::ContainsWhitespace => f.write_str("host pattern contains whitespace"),
+            Self::ContainsNul => f.write_str("host pattern contains NUL byte"),
+            Self::ContainsPathSeparator => {
+                f.write_str("host pattern contains path separator (/ or \\)")
+            }
+            Self::ContainsPort => {
+                f.write_str("host pattern must not include a port (strip `:PORT`)")
+            }
+            Self::ContainsScheme => {
+                f.write_str("host pattern must not include a scheme (strip `http(s)://`)")
+            }
+            Self::ContainsWildcard => f.write_str("host pattern must not include wildcards (`*`)"),
+            Self::NonAscii => f.write_str("host pattern contains non-ASCII characters"),
+            Self::Malformed { reason } => write!(f, "host pattern is malformed: {reason}"),
+        }
     }
 }
 
@@ -190,8 +202,11 @@ impl HostPattern {
             match lower.find(']') {
                 // `[::1]` — no port. `[::1]:6565` — has port.
                 Some(idx) => idx + 1 < lower.len(),
-                // `[::1` with no closing bracket — treat as malformed.
-                None => return Err(HostPatternError::ContainsPathSeparator),
+                None => {
+                    return Err(HostPatternError::Malformed {
+                        reason: "unclosed bracket",
+                    });
+                }
             }
         } else {
             lower.contains(':')
@@ -379,6 +394,29 @@ mod tests {
         assert_eq!(
             HostPattern::parse("shöp.example.com"),
             Err(HostPatternError::NonAscii)
+        );
+    }
+
+    #[test]
+    fn host_pattern_rejects_unclosed_ipv6_bracket_as_malformed() {
+        // The unclosed-bracket case is structurally invalid but contains no
+        // path separator — it must not borrow `ContainsPathSeparator`'s name.
+        assert_eq!(
+            HostPattern::parse("[::1"),
+            Err(HostPatternError::Malformed {
+                reason: "unclosed bracket"
+            })
+        );
+    }
+
+    #[test]
+    fn host_pattern_malformed_display_includes_reason() {
+        let err = HostPatternError::Malformed {
+            reason: "unclosed bracket",
+        };
+        assert_eq!(
+            err.to_string(),
+            "host pattern is malformed: unclosed bracket"
         );
     }
 }

--- a/crates/kikan/src/data_plane/csrf_layer.rs
+++ b/crates/kikan/src/data_plane/csrf_layer.rs
@@ -171,8 +171,15 @@ fn extract_csrf_cookie<B>(req: &Request<B>) -> Option<String> {
             continue;
         };
         for pair in raw.split(';') {
-            let pair = pair.trim();
-            if let Some(value) = pair.strip_prefix(&format!("{CSRF_COOKIE_NAME}=")) {
+            // Strip the name, then the `=`. Splitting the prefix check in two
+            // avoids allocating `"name="` on every pair, and the `=` step
+            // rejects bare-name cookies (`csrf_token; other=...`) that would
+            // otherwise pass the name check with no value.
+            if let Some(value) = pair
+                .trim()
+                .strip_prefix(CSRF_COOKIE_NAME)
+                .and_then(|rest| rest.strip_prefix('='))
+            {
                 return Some(value.to_owned());
             }
         }

--- a/crates/kikan/src/data_plane/csrf_layer.rs
+++ b/crates/kikan/src/data_plane/csrf_layer.rs
@@ -317,6 +317,38 @@ mod tests {
         b.body(()).unwrap()
     }
 
+    fn request_with_raw_cookie(raw: &str) -> Request<()> {
+        Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .header(COOKIE, raw)
+            .body(())
+            .unwrap()
+    }
+
+    #[test]
+    fn extract_csrf_cookie_requires_exact_name_and_equals() {
+        // Happy path: the CSRF pair is one of many, surrounded by whitespace.
+        let req = request_with_raw_cookie("csrf_token=tok; other=1");
+        assert_eq!(extract_csrf_cookie(&req), Some("tok".to_owned()));
+
+        // Bare name with no `=` must not match — otherwise an attacker could
+        // satisfy the cookie-presence check without a value and the
+        // double-submit comparison would fall to the `None` branch, which is
+        // already rejected. Belt-and-braces: reject here too.
+        let req = request_with_raw_cookie("csrf_token; other=1");
+        assert_eq!(extract_csrf_cookie(&req), None);
+
+        // Name prefix match (`csrf_token_extra=...`) must not match — the
+        // `=` anchor after the exact name is what rules this out.
+        let req = request_with_raw_cookie("csrf_token_extra=tok; other=1");
+        assert_eq!(extract_csrf_cookie(&req), None);
+
+        // Leading whitespace around each pair is trimmed (RFC 6265 allows it).
+        let req = request_with_raw_cookie("  other=1;   csrf_token=tok2  ");
+        assert_eq!(extract_csrf_cookie(&req), Some("tok2".to_owned()));
+    }
+
     #[tokio::test]
     async fn lan_mode_is_pass_through() {
         let layer = CsrfLayer::for_mode(DeploymentMode::Lan, vec![]);

--- a/crates/kikan/src/data_plane/session_layer.rs
+++ b/crates/kikan/src/data_plane/session_layer.rs
@@ -36,28 +36,106 @@ pub fn session_layer_for_mode(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use http::header::SET_COOKIE;
+    use http::{Request, Response, StatusCode};
+    use std::convert::Infallible;
+    use tower::{ServiceBuilder, ServiceExt};
+    use tower_sessions::Session;
 
-    // SessionManagerLayer doesn't expose its cookie config for inspection, so
-    // these tests lock the per-mode branch at the function boundary only. The
-    // composition test in `tests/data_plane_modes.rs` covers the observable
-    // Set-Cookie output.
+    // `SessionManagerLayer` doesn't expose its cookie config for inspection,
+    // so each test exercises the layer end-to-end: touch the session in a
+    // downstream handler so the store flushes, then inspect the `Set-Cookie`
+    // header on the outgoing response. The invariants pinned here are:
+    //
+    // - `HttpOnly` is always set (JS must never read the session cookie).
+    // - `Secure` and `SameSite` vary by mode per the doc comment above.
+    //
+    // Without `store.migrate()` below, the backing table wouldn't exist, the
+    // flush would error, no `Set-Cookie` would be emitted, and every
+    // substring assertion would trivially pass — masking regressions.
+    async fn sessions_for_test() -> Sessions {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let store = SqliteStore::new(pool);
+        store.migrate().await.unwrap();
+        Sessions::new(store)
+    }
 
-    #[test]
-    fn all_three_modes_build_without_panic() {
-        // Build a throwaway store so we can exercise the builder.
-        use tokio::runtime::Runtime;
-        let rt = Runtime::new().unwrap();
-        rt.block_on(async {
-            let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-            let store = SqliteStore::new(pool);
-            let sessions = Sessions::new(store);
-            for mode in [
-                DeploymentMode::Lan,
-                DeploymentMode::Internet,
-                DeploymentMode::ReverseProxy,
-            ] {
-                let _ = session_layer_for_mode(&sessions, mode);
-            }
-        });
+    async fn touch_handler(req: Request<Body>) -> Result<Response<Body>, Infallible> {
+        let session = req
+            .extensions()
+            .get::<Session>()
+            .expect("session extension missing — layer stack is wrong");
+        session
+            .insert("touch", true)
+            .await
+            .expect("session insert into in-memory store must not fail");
+        Ok(Response::new(Body::empty()))
+    }
+
+    async fn set_cookie_for(mode: DeploymentMode) -> String {
+        let sessions = sessions_for_test().await;
+        let layer = session_layer_for_mode(&sessions, mode);
+        let svc = ServiceBuilder::new().layer(layer).service_fn(touch_handler);
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+        let resp = svc.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        resp.headers()
+            .get(SET_COOKIE)
+            .expect("touch handler modified session — Set-Cookie must be present")
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    #[tokio::test]
+    async fn lan_mode_emits_insecure_lax_httponly_cookie() {
+        let set_cookie = set_cookie_for(DeploymentMode::Lan).await;
+        assert!(
+            set_cookie.contains("HttpOnly"),
+            "HttpOnly invariant: cookie must be HttpOnly in every mode; got: {set_cookie}"
+        );
+        assert!(
+            !set_cookie.contains("Secure"),
+            "Lan runs HTTP; Secure would break the cookie on a plain-HTTP LAN; got: {set_cookie}"
+        );
+        assert!(
+            set_cookie.contains("SameSite=Lax"),
+            "Lan uses SameSite=Lax so mDNS-shared / bookmarked links keep working; got: {set_cookie}"
+        );
+    }
+
+    #[tokio::test]
+    async fn internet_mode_emits_secure_strict_httponly_cookie() {
+        let set_cookie = set_cookie_for(DeploymentMode::Internet).await;
+        assert!(
+            set_cookie.contains("HttpOnly"),
+            "HttpOnly invariant: cookie must be HttpOnly in every mode; got: {set_cookie}"
+        );
+        assert!(
+            set_cookie.contains("Secure"),
+            "Internet mode assumes HTTPS at the socket; Secure must be set; got: {set_cookie}"
+        );
+        assert!(
+            set_cookie.contains("SameSite=Strict"),
+            "Internet mode uses SameSite=Strict; got: {set_cookie}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reverse_proxy_mode_emits_secure_strict_httponly_cookie() {
+        let set_cookie = set_cookie_for(DeploymentMode::ReverseProxy).await;
+        assert!(
+            set_cookie.contains("HttpOnly"),
+            "HttpOnly invariant: cookie must be HttpOnly in every mode; got: {set_cookie}"
+        );
+        assert!(
+            set_cookie.contains("Secure"),
+            "ReverseProxy assumes HTTPS at the proxy; Secure must be set; got: {set_cookie}"
+        );
+        assert!(
+            set_cookie.contains("SameSite=Strict"),
+            "ReverseProxy uses SameSite=Strict; got: {set_cookie}"
+        );
     }
 }

--- a/crates/kikan/src/data_plane/session_layer.rs
+++ b/crates/kikan/src/data_plane/session_layer.rs
@@ -51,14 +51,33 @@ mod tests {
     // - `HttpOnly` is always set (JS must never read the session cookie).
     // - `Secure` and `SameSite` vary by mode per the doc comment above.
     //
-    // Without `store.migrate()` below, the backing table wouldn't exist, the
-    // flush would error, no `Set-Cookie` would be emitted, and every
-    // substring assertion would trivially pass — masking regressions.
+    // `store.migrate()` creates the `tower_sessions` table the session flush
+    // writes into. `max_connections(1)` pins the pool to a single connection
+    // so migrate + flush share the same `sqlite::memory:` database — without
+    // it, SQLite hands each connection its own private in-memory DB and the
+    // flush hits a "no such table" error on a different connection than
+    // migrate ran on.
     async fn sessions_for_test() -> Sessions {
-        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
         let store = SqliteStore::new(pool);
         store.migrate().await.unwrap();
         Sessions::new(store)
+    }
+
+    /// Split a `Set-Cookie` header into its attribute tokens, skipping the
+    /// opaque `name=value` pair. Whole-token comparison prevents a false pass
+    /// from the session ID happening to contain `Secure` or `HttpOnly` as a
+    /// substring. Attribute names are matched case-insensitively per RFC 6265.
+    fn has_cookie_attr(set_cookie: &str, expected: &str) -> bool {
+        set_cookie
+            .split(';')
+            .skip(1)
+            .map(str::trim)
+            .any(|attr| attr.eq_ignore_ascii_case(expected))
     }
 
     async fn touch_handler(req: Request<Body>) -> Result<Response<Body>, Infallible> {
@@ -92,15 +111,15 @@ mod tests {
     async fn lan_mode_emits_insecure_lax_httponly_cookie() {
         let set_cookie = set_cookie_for(DeploymentMode::Lan).await;
         assert!(
-            set_cookie.contains("HttpOnly"),
+            has_cookie_attr(&set_cookie, "HttpOnly"),
             "HttpOnly invariant: cookie must be HttpOnly in every mode; got: {set_cookie}"
         );
         assert!(
-            !set_cookie.contains("Secure"),
+            !has_cookie_attr(&set_cookie, "Secure"),
             "Lan runs HTTP; Secure would break the cookie on a plain-HTTP LAN; got: {set_cookie}"
         );
         assert!(
-            set_cookie.contains("SameSite=Lax"),
+            has_cookie_attr(&set_cookie, "SameSite=Lax"),
             "Lan uses SameSite=Lax so mDNS-shared / bookmarked links keep working; got: {set_cookie}"
         );
     }
@@ -109,15 +128,15 @@ mod tests {
     async fn internet_mode_emits_secure_strict_httponly_cookie() {
         let set_cookie = set_cookie_for(DeploymentMode::Internet).await;
         assert!(
-            set_cookie.contains("HttpOnly"),
+            has_cookie_attr(&set_cookie, "HttpOnly"),
             "HttpOnly invariant: cookie must be HttpOnly in every mode; got: {set_cookie}"
         );
         assert!(
-            set_cookie.contains("Secure"),
+            has_cookie_attr(&set_cookie, "Secure"),
             "Internet mode assumes HTTPS at the socket; Secure must be set; got: {set_cookie}"
         );
         assert!(
-            set_cookie.contains("SameSite=Strict"),
+            has_cookie_attr(&set_cookie, "SameSite=Strict"),
             "Internet mode uses SameSite=Strict; got: {set_cookie}"
         );
     }
@@ -126,16 +145,29 @@ mod tests {
     async fn reverse_proxy_mode_emits_secure_strict_httponly_cookie() {
         let set_cookie = set_cookie_for(DeploymentMode::ReverseProxy).await;
         assert!(
-            set_cookie.contains("HttpOnly"),
+            has_cookie_attr(&set_cookie, "HttpOnly"),
             "HttpOnly invariant: cookie must be HttpOnly in every mode; got: {set_cookie}"
         );
         assert!(
-            set_cookie.contains("Secure"),
+            has_cookie_attr(&set_cookie, "Secure"),
             "ReverseProxy assumes HTTPS at the proxy; Secure must be set; got: {set_cookie}"
         );
         assert!(
-            set_cookie.contains("SameSite=Strict"),
+            has_cookie_attr(&set_cookie, "SameSite=Strict"),
             "ReverseProxy uses SameSite=Strict; got: {set_cookie}"
         );
+    }
+
+    #[test]
+    fn has_cookie_attr_matches_whole_token_only() {
+        // The opaque `id=<value>` pair is skipped so a value like
+        // `id=Securely-random` cannot satisfy a `Secure` check.
+        let h = "id=Securely-random; HttpOnly; SameSite=Lax";
+        assert!(has_cookie_attr(h, "HttpOnly"));
+        assert!(has_cookie_attr(h, "SameSite=Lax"));
+        assert!(!has_cookie_attr(h, "Secure"));
+        // Attribute names are case-insensitive per RFC 6265.
+        assert!(has_cookie_attr(h, "httponly"));
+        assert!(has_cookie_attr(h, "SAMESITE=Lax"));
     }
 }


### PR DESCRIPTION
## Summary

Three deferred data-plane review items from Session 4 (PR #632). All isolated to `crates/kikan/src/data_plane/`; one commit per issue.

- **#633 — `HostPatternError::Malformed` for unclosed IPv6 bracket.** `HostPattern::parse("[::1")` used to return `ContainsPathSeparator`, sending operators looking for a `/` or `\` that was never in the input. Adds a `Malformed { reason: &'static str }` variant and routes the unclosed-bracket branch through it with the static reason `"unclosed bracket"`; `Display` surfaces the reason so error text names the actual defect.
- **#634 — zero-alloc CSRF cookie-prefix check.** `extract_csrf_cookie` allocated a fresh `"csrf_token="` `String` via `format!` for every cookie pair on every request. Rewritten as `strip_prefix(CSRF_COOKIE_NAME).and_then(|r| r.strip_prefix('='))` — same semantics, no allocation.
- **#636 — per-mode cookie-attribute unit tests for `session_layer_for_mode`.** Replaces the prior "builds without panicking" smoke test with one `#[tokio::test]` per `DeploymentMode` that drives a real request through the layer against an in-memory SQLite session store, touches the session to force a flush, and substring-asserts the `Set-Cookie` attributes. Pinned invariants: `HttpOnly` present in every mode; Lan emits `SameSite=Lax` with no `Secure`; Internet / ReverseProxy emit `Secure` and `SameSite=Strict`. Helper asserts the `Set-Cookie` header is present so a future breakage that silences the cookie cannot make every assertion trivially pass.

## Test plan

- [x] `cargo test -p kikan --lib` — 309 passed
- [x] `cargo test -p kikan --test data_plane_modes` — 12 passed
- [x] `cargo clippy -p kikan --tests -- -D warnings` — no issues
- [x] `cargo fmt --all --check` — clean
- [ ] CI green on the PR
- [ ] Manual sanity: no external match on `HostPatternError` variants outside `config.rs` / re-exports, so the new variant is additive-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined CSRF cookie detection to correctly identify valid tokens and prevent false positives
  * Improved error messages for malformed host patterns with descriptive failure reasons

* **Tests**
  * Added end-to-end session layer tests validating secure cookie attributes across deployment modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->