### PR TITLE
chore(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6245,9 +6245,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Bump `rustls-webpki` 0.103.12 → 0.103.13 via `cargo update -p rustls-webpki`.
- Clears [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) — reachable panic in CRL parsing.
- Unblocks the `security` + `verdict` CI gates that have been red on every PR (orthogonal blocker documented in PR #631, PR #632, PR #638 notes).

## Scope

`Cargo.lock`-only change. Zero source edits. Zero container-image implications (lockfile lives in the repo; the Rust toolchain in the container image is unchanged).

## Verification

- `cargo deny check advisories` locally → `advisories ok`.
- Expect `security` + `verdict` CI checks to flip green on this PR.

## Test plan

- [ ] CI `security` job passes (cargo-deny)
- [ ] CI `verdict` rollup passes
- [ ] No regressions in `test-rust`, `lint-rust`, `crap-rust`, `kikan-invariants`

🤖 Generated with [Claude Code](https://claude.com/claude-code)