### PR TITLE
feat(ci): per-session CRAP delta gate (#569)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -392,6 +392,43 @@ jobs:
           path: tmp/lcov.info
           if-no-files-found: ignore
 
+  crap-delta:
+    # Per-session CRAP delta gate — fails if any function's CRAP score increased
+    # on files changed by the PR. Complements `crap-rust` (threshold gate) by
+    # preventing silent regressions under the strict-preset threshold.
+    # Implements gh#569. Starts non-blocking to collect signal before promotion.
+    needs: [changes]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Stabilize first; promote via gh#569 follow-up after signal
+    env:
+      CARGO_TARGET_DIR: target
+      PR_BASE_REF: ${{ github.base_ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          cache: pnpm
+      - uses: moonrepo/setup-toolchain@v0
+      - uses: moonrepo/setup-rust@v1
+        with:
+          bins: cargo-nextest,cargo-llvm-cov,crap4rs
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "mokumo-rust"
+          save-if: "false"
+      - name: Install JS dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build SvelteKit frontend (required by crap-rust task tree)
+        run: moon run web:build
+      - name: CRAP delta gate
+        run: scripts/check-crap-delta.sh "origin/$PR_BASE_REF"
+
   api-smoke:
     needs: [changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.smoke == 'true')

--- a/scripts/check-crap-delta.sh
+++ b/scripts/check-crap-delta.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Per-session CRAP delta gate — fails if any function's CRAP score increased
+# between the given base ref and HEAD on a file that's changed on HEAD.
+#
+# Usage: scripts/check-crap-delta.sh [base-ref]
+#   base-ref defaults to origin/main.
+#
+# Implements gh#569. For refactor-heavy sessions we want "no CRAP regression on
+# changed code" even when scores stay under the crap4rs global threshold.
+#
+# Strategy: run crap4rs --format json on BOTH refs, limited to changed files on
+# the HEAD side via --diff. Match functions by (file_path, qualified_name).
+# Exit non-zero if any match shows a higher CRAP value on HEAD.
+#
+# Expensive (two coverage runs). Intended for CI / explicit local invocation,
+# not pre-commit. See ops/standards/testing.md#crap-delta-gate.
+
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+TMPDIR="$(mktemp -d)"
+trap "rm -rf $TMPDIR" EXIT
+
+echo "[crap-delta] Base ref: $BASE"
+echo "[crap-delta] Repo:     $REPO_ROOT"
+
+git fetch --no-tags --depth=1000 origin "${BASE#origin/}" 2>/dev/null || true
+git rev-parse --verify "$BASE" >/dev/null
+
+build_and_dump() {
+  local outfile="$1"
+  local diff_ref="${2-}"
+  # shop:crap covers web:build + cargo llvm-cov; we re-run the cargo step so we
+  # can capture --format json (shop:crap uses table output).
+  moon run web:build >/dev/null
+  cargo llvm-cov nextest \
+    --workspace \
+    --exclude mokumo-desktop \
+    --exclude kikan-tauri \
+    --lcov \
+    --output-path "$TMPDIR/lcov.info" >/dev/null
+
+  if [ -n "$diff_ref" ]; then
+    crap4rs \
+      --coverage "$TMPDIR/lcov.info" \
+      --src . \
+      --format json \
+      --diff "$diff_ref" \
+      > "$outfile"
+  else
+    crap4rs \
+      --coverage "$TMPDIR/lcov.info" \
+      --src . \
+      --format json \
+      > "$outfile"
+  fi
+}
+
+echo "[crap-delta] Capturing HEAD CRAP snapshot (changed files only via --diff)..."
+build_and_dump "$TMPDIR/head.json" "$BASE"
+
+BASE_WORKTREE="$TMPDIR/base-worktree"
+echo "[crap-delta] Creating base worktree at $BASE_WORKTREE..."
+git worktree add --detach "$BASE_WORKTREE" "$BASE" >/dev/null
+
+echo "[crap-delta] Capturing BASE CRAP snapshot (full) in worktree..."
+(
+  cd "$BASE_WORKTREE"
+  # pnpm install in case lockfile shifted between base and head
+  pnpm install --frozen-lockfile >/dev/null
+  build_and_dump "$TMPDIR/base.json"
+)
+
+git worktree remove --force "$BASE_WORKTREE" >/dev/null
+
+echo "[crap-delta] Comparing..."
+REGRESSIONS=$(jq -s '
+  .[0].result.functions as $base
+  | .[1].result.functions as $head
+  | [
+      $head[]
+      | . as $hf
+      | ($base[]
+          | select(
+              .scored.identity.file_path == $hf.scored.identity.file_path
+              and .scored.identity.qualified_name == $hf.scored.identity.qualified_name
+            )
+        ) as $bf
+      | select($hf.scored.crap.value > $bf.scored.crap.value + 0.01)
+      | {
+          file: $hf.scored.identity.file_path,
+          function: $hf.scored.identity.qualified_name,
+          base_crap: $bf.scored.crap.value,
+          head_crap: $hf.scored.crap.value,
+          delta: ($hf.scored.crap.value - $bf.scored.crap.value)
+        }
+    ]
+' "$TMPDIR/base.json" "$TMPDIR/head.json")
+
+REGRESSION_COUNT=$(echo "$REGRESSIONS" | jq 'length')
+
+if [ "$REGRESSION_COUNT" -gt 0 ]; then
+  echo "[crap-delta] FAIL: $REGRESSION_COUNT function(s) regressed:"
+  echo "$REGRESSIONS" | jq -r '.[] | "  \(.file)::\(.function)  \(.base_crap) -> \(.head_crap)  (+\(.delta))"'
+  echo ""
+  echo "Full JSON:"
+  echo "$REGRESSIONS" | jq .
+  exit 1
+fi
+
+echo "[crap-delta] PASS: no CRAP regressions on changed functions"


### PR DESCRIPTION
## Summary

Adds a new `crap-delta` CI job that fails whenever any function's CRAP score increased between the PR's base and head on files changed by the PR — even when scores stay under the strict-preset threshold. Closes #569.

**Complements** `crap-rust` (threshold gate) — catches silent regressions during refactor-heavy sessions where cyclomatic complexity creeps up but stays under 15.

## What landed

- `scripts/check-crap-delta.sh` — runs `crap4rs --format json` on both head (via `--diff origin/<base>`) and base (in a throwaway worktree), diffs by `(file_path, qualified_name)`, exits 1 on any score increase.
- `.github/workflows/quality.yml` — new `crap-delta` job wired into the Quality Loop. Starts `continue-on-error: true` to collect signal; flip off once we have a week of clean runs.

## Not in this PR

- **Not promoting `mutation-ts` to blocking.** Investigation of recent failing runs shows Stryker dies in its initial test run because a pre-existing vitest test (`CustomerFormSheet — applyApiErrors routes non-validation error through toastApiError on update`) is broken, failing with `expected vi.fn() to be called with arguments: […(2)] · Number of calls: 0`. Stryker never gets to actually mutate. That's a vitest bug, not a CI config bug — filed as a follow-up issue.
- **Not adding `crap-delta` to `verdict` needs** — since it's `continue-on-error: true`, reporting it through verdict would always read success. Revisit when we promote to blocking.
- **Not adding ops/standards docs yet** — the gate will iterate; docs follow promotion.

## Test plan

- [ ] CI `crap-delta` job runs on this PR and either passes (no regressions) or fails loudly (listing the offending functions).
- [ ] All existing quality-loop gates remain green.
- [ ] `security` + `verdict` remain green post-RUSTSEC bump.
- [ ] No regressions in `test-rust`, `lint-rust`, `crap-rust`, `kikan-invariants`.

## Follow-ups (not blocking)

- Investigate + fix the `CustomerFormSheet` vitest test so `mutation-ts` can actually run mutation testing. (Filing as follow-up issue.)
- Promote `crap-delta` to blocking after signal stabilizes.
- Consider artifact-based baseline (save main-branch JSON, download on PR) to halve the CI cost — currently two full coverage builds per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality validation in the CI pipeline with per-PR regression detection
  * Added automated checks to monitor quality metrics for changed files during the review process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->