### PR TITLE
chore(ci): gate crap-delta on ci:crap-delta label (opt-in)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -376,9 +376,15 @@ jobs:
     # Per-session CRAP delta gate — fails if any function's CRAP score increased
     # on files changed by the PR. Complements `crap-rust` (threshold gate) by
     # preventing silent regressions under the strict-preset threshold.
-    # Implements gh#569. Starts non-blocking to collect signal before promotion.
+    # Implements gh#569. Opt-in via the `ci:crap-delta` label — matches the
+    # issue's original "refactor-heavy work" framing. Feature PRs with new
+    # functions have no prior baseline, so the delta check is a false-positive
+    # generator there; refactor/extraction PRs set the label to run it.
     needs: [changes]
-    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    if: |
+      github.event_name == 'pull_request'
+      && needs.changes.outputs.rust == 'true'
+      && contains(github.event.pull_request.labels.*.name, 'ci:crap-delta')
     runs-on: ubuntu-latest
     continue-on-error: true  # Stabilize first; promote via gh#569 follow-up after signal
     env:


### PR DESCRIPTION
## Summary

Gate the `crap-delta` CI job on an explicit `ci:crap-delta` label. Matches #569's original framing — "per-session CRAP delta gates for **refactor-heavy work**" — which didn't survive into the initial implementation (PR #640, always-on).

Current config (main) runs `crap-delta` on every PR with Rust changes, including feature PRs that introduce new functions with no prior baseline. Those are false-positive generators: CRAP didn't "regress" on a function that didn't exist. Feature PR #644 (SPA primitive extraction) triggered the check and paid two coverage builds for zero signal.

New config: the job runs only when the PR carries the `ci:crap-delta` label. Session 6 (router hoist, #501) is a true refactor and would opt in; Session 5-style extraction doesn't need to.

Still `continue-on-error: true` — non-blocking. Promotion to blocking stays on the same #569 follow-up track.

## Changes

- `.github/workflows/quality.yml` — `crap-delta` job `if:` now requires `contains(github.event.pull_request.labels.*.name, 'ci:crap-delta')` alongside the existing PR + Rust-changes conditions.
- New label `ci:crap-delta` (color `#D4C5F9`, description: "Run the per-PR CRAP-delta gate (refactor-heavy work). Opt-in; non-blocking today.") created on the repo.

## Test plan

- [ ] CI runs on this PR; `crap-delta` does NOT trigger (this PR is unlabeled + touches only workflow YAML, not Rust).
- [ ] After merge, apply the label to PR #501's follow-up (Session 6 router hoist) and confirm `crap-delta` runs then.
- [ ] No other Quality Loop jobs regress.

## Follow-ups (not this PR)

- Promote `crap-delta` to blocking once signal stabilizes on labeled runs (#569 follow-up track).
- Document the label in `CONTRIBUTING.md` alongside other CI opt-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)