### PR TITLE
refactor(kikan-events): extract FanoutChannel<T> primitive; register EventBusSubGraft (#622)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4263,6 +4263,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "kikan",
+ "kikan-events",
  "kikan-spa-sveltekit",
  "kikan-tauri",
  "kikan-types",
@@ -4297,6 +4298,7 @@ dependencies = [
  "fd-lock",
  "kikan",
  "kikan-cli",
+ "kikan-events",
  "kikan-socket",
  "kikan-spa-sveltekit",
  "kikan-types",
@@ -4337,6 +4339,7 @@ dependencies = [
  "infer",
  "insta",
  "kikan",
+ "kikan-events",
  "kikan-socket",
  "kikan-tauri",
  "kikan-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ kikan-types = { path = "crates/kikan-types" }
 
 # Internal crates — kikan platform + mokumo-shop vertical
 kikan = { path = "crates/kikan" }
+kikan-events = { path = "crates/kikan-events" }
 kikan-tauri = { path = "crates/kikan-tauri" }
 kikan-socket = { path = "crates/kikan-socket" }
 kikan-spa-sveltekit = { path = "crates/kikan-spa-sveltekit" }

--- a/apps/mokumo-desktop/Cargo.toml
+++ b/apps/mokumo-desktop/Cargo.toml
@@ -23,6 +23,7 @@ mokumo-core = { workspace = true }
 mokumo-shop = { workspace = true }
 kikan-types = { workspace = true }
 kikan = { workspace = true }
+kikan-events = { workspace = true }
 kikan-spa-sveltekit = { workspace = true }
 kikan-tauri = { workspace = true }
 

--- a/apps/mokumo-desktop/src/lib.rs
+++ b/apps/mokumo-desktop/src/lib.rs
@@ -139,7 +139,10 @@ async fn init_server(
     // (see `adr-tauri-http-not-ipc.md`), so the webview and API share the
     // same origin and no cross-origin CSRF config is needed.
     let data_plane = kikan::DataPlaneConfig::lan_default(bind_addr);
-    let boot_config = kikan::BootConfig::new(data_dir).with_data_plane(data_plane);
+    let event_bus = kikan_events::BroadcastEventBus::new();
+    let boot_config = kikan::BootConfig::new(data_dir)
+        .with_data_plane(data_plane)
+        .with_subgraft(kikan_events::EventBusSubGraft::new(event_bus.clone()));
 
     let mut pools: std::collections::HashMap<
         kikan::tenancy::ProfileDirName,

--- a/apps/mokumo-server/Cargo.toml
+++ b/apps/mokumo-server/Cargo.toml
@@ -11,6 +11,7 @@ description = "Mokumo headless server — zero Tauri dependencies (see ADR: adr-
 # Verify: cargo tree -p mokumo-server | grep tauri  (must exit non-zero)
 [dependencies]
 kikan = { workspace = true }
+kikan-events = { workspace = true }
 kikan-socket = { workspace = true }
 kikan-spa-sveltekit = { workspace = true }
 kikan-cli = { path = "../../crates/kikan-cli" }

--- a/apps/mokumo-server/src/main.rs
+++ b/apps/mokumo-server/src/main.rs
@@ -533,7 +533,10 @@ async fn cmd_serve(data_dir: PathBuf, args: ServeArgs, verbose: u8, quiet: bool)
         allowed_origins: parsed_origins,
         allowed_hosts: parsed_hosts,
     };
-    let boot_config = kikan::BootConfig::new(data_dir.clone()).with_data_plane(data_plane);
+    let event_bus = kikan_events::BroadcastEventBus::new();
+    let boot_config = kikan::BootConfig::new(data_dir.clone())
+        .with_data_plane(data_plane)
+        .with_subgraft(kikan_events::EventBusSubGraft::new(event_bus.clone()));
     let shutdown = CancellationToken::new();
 
     let mut pools: std::collections::HashMap<

--- a/crates/kikan-events/src/bus.rs
+++ b/crates/kikan-events/src/bus.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
+use crate::channel::{DEFAULT_CAPACITY, FanoutChannel};
 use crate::event::{HealthEvent, LifecycleEvent, MigrationEvent, ProfileEvent};
 
-pub const DEFAULT_CAPACITY: usize = 1024;
-
 pub struct BroadcastEventBus {
-    lifecycle: broadcast::Sender<LifecycleEvent>,
-    health: broadcast::Sender<HealthEvent>,
-    migration: broadcast::Sender<MigrationEvent>,
-    profile: broadcast::Sender<ProfileEvent>,
+    lifecycle: FanoutChannel<LifecycleEvent>,
+    health: FanoutChannel<HealthEvent>,
+    migration: FanoutChannel<MigrationEvent>,
+    profile: FanoutChannel<ProfileEvent>,
 }
 
 impl std::fmt::Debug for BroadcastEventBus {
@@ -25,27 +24,27 @@ impl BroadcastEventBus {
 
     pub fn with_capacity(cap: usize) -> Arc<Self> {
         Arc::new(Self {
-            lifecycle: broadcast::channel(cap).0,
-            health: broadcast::channel(cap).0,
-            migration: broadcast::channel(cap).0,
-            profile: broadcast::channel(cap).0,
+            lifecycle: FanoutChannel::with_capacity(cap),
+            health: FanoutChannel::with_capacity(cap),
+            migration: FanoutChannel::with_capacity(cap),
+            profile: FanoutChannel::with_capacity(cap),
         })
     }
 
     pub fn publish_lifecycle(&self, e: LifecycleEvent) {
-        let _ = self.lifecycle.send(e);
+        let _ = self.lifecycle.publish(e);
     }
 
     pub fn publish_health(&self, e: HealthEvent) {
-        let _ = self.health.send(e);
+        let _ = self.health.publish(e);
     }
 
     pub fn publish_migration(&self, e: MigrationEvent) {
-        let _ = self.migration.send(e);
+        let _ = self.migration.publish(e);
     }
 
     pub fn publish_profile(&self, e: ProfileEvent) {
-        let _ = self.profile.send(e);
+        let _ = self.profile.publish(e);
     }
 
     pub fn subscribe_lifecycle(&self) -> broadcast::Receiver<LifecycleEvent> {

--- a/crates/kikan-events/src/channel.rs
+++ b/crates/kikan-events/src/channel.rs
@@ -1,0 +1,103 @@
+//! Domain-neutral broadcast fanout primitive.
+//!
+//! `FanoutChannel<T>` wraps [`tokio::sync::broadcast::Sender`] with a narrow,
+//! stable surface (`publish`, `subscribe`, `receiver_count`, `with_capacity`).
+//! It is the mechanism; typed buses ([`crate::bus::BroadcastEventBus`],
+//! `mokumo-shop::ws::ConnectionManager`) compose it privately and own their
+//! own taxonomies.
+//!
+//! Reach for `FanoutChannel<T>` when you need a typed broadcast and the
+//! receiver count/default-capacity conventions that the rest of kikan uses.
+//! Reach for raw `tokio::sync::broadcast` when you need capabilities the
+//! primitive intentionally hides (e.g. split halves, explicit `SendError`).
+
+use tokio::sync::broadcast;
+
+/// Default buffered capacity per fanout channel.
+pub const DEFAULT_CAPACITY: usize = 1024;
+
+/// Single-producer-visible fanout over `tokio::sync::broadcast`.
+///
+/// Drops events when no receivers exist; `publish` returns `0` in that case.
+/// Lagged receivers receive a `RecvError::Lagged` from their own `Receiver`
+/// and keep progressing — the channel itself stays healthy.
+pub struct FanoutChannel<T: Clone + Send + 'static> {
+    tx: broadcast::Sender<T>,
+}
+
+impl<T: Clone + Send + 'static> FanoutChannel<T> {
+    pub fn with_capacity(cap: usize) -> Self {
+        let (tx, _) = broadcast::channel(cap);
+        Self { tx }
+    }
+
+    /// Send to all current subscribers. Returns the number of receivers the
+    /// event reached; `0` when there are no subscribers (normal operation).
+    pub fn publish(&self, value: T) -> usize {
+        self.tx.send(value).unwrap_or(0)
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<T> {
+        self.tx.subscribe()
+    }
+
+    pub fn receiver_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+}
+
+impl<T: Clone + Send + 'static> std::fmt::Debug for FanoutChannel<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FanoutChannel")
+            .field("receiver_count", &self.tx.receiver_count())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn fanout_channel_publish_reaches_subscriber() {
+        let ch = FanoutChannel::<u32>::with_capacity(8);
+        let mut rx = ch.subscribe();
+        let delivered = ch.publish(42);
+        assert_eq!(delivered, 1);
+        assert_eq!(rx.recv().await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn fanout_channel_multiple_subscribers_each_receive() {
+        let ch = FanoutChannel::<u32>::with_capacity(8);
+        let mut rx_a = ch.subscribe();
+        let mut rx_b = ch.subscribe();
+        let delivered = ch.publish(7);
+        assert_eq!(delivered, 2);
+        assert_eq!(rx_a.recv().await.unwrap(), 7);
+        assert_eq!(rx_b.recv().await.unwrap(), 7);
+    }
+
+    #[test]
+    fn fanout_channel_with_no_subscribers_returns_zero() {
+        let ch = FanoutChannel::<u32>::with_capacity(8);
+        assert_eq!(ch.publish(1), 0);
+        assert_eq!(ch.receiver_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn fanout_channel_lagged_receiver_still_gets_new_events() {
+        let ch = FanoutChannel::<u32>::with_capacity(2);
+        let mut rx = ch.subscribe();
+        for i in 0..5 {
+            ch.publish(i);
+        }
+        match rx.recv().await {
+            Err(broadcast::error::RecvError::Lagged(_)) => {}
+            other => panic!("expected Lagged, got {other:?}"),
+        }
+        while rx.try_recv().is_ok() {}
+        ch.publish(99);
+        assert_eq!(rx.recv().await.unwrap(), 99);
+    }
+}

--- a/crates/kikan-events/src/lib.rs
+++ b/crates/kikan-events/src/lib.rs
@@ -1,18 +1,22 @@
 //! Kikan event bus SubGraft — typed `tokio::sync::broadcast` wrapper.
 //!
-//! Composes into a [`kikan::Engine`] via [`EventBusSubGraft`] (a
-//! [`kikan::SubGraft`] impl). Add a new event variant in [`event`],
-//! publish via [`BroadcastEventBus::publish`], and subscribe via
-//! [`BroadcastEventBus::subscribe`]. Depends on `kikan` for the
-//! SubGraft trait surface only — never the reverse direction
-//! (invariant I4).
+//! Two layers:
+//! - [`channel::FanoutChannel<T>`] — domain-neutral broadcast mechanism.
+//!   Reusable by any caller that wants typed fanout.
+//! - [`bus::BroadcastEventBus`] — kikan platform-event taxonomy composing
+//!   four `FanoutChannel<T>`s internally. Registered via
+//!   [`EventBusSubGraft`] (a [`kikan::SubGraft`] impl); publishes on Engine
+//!   lifecycle hooks. Depends on `kikan` for the SubGraft trait surface
+//!   only — never the reverse direction (invariant I4).
 
 pub mod bus;
+pub mod channel;
 pub mod error;
 pub mod event;
 pub mod subgraft;
 
-pub use bus::{BroadcastEventBus, DEFAULT_CAPACITY};
+pub use bus::BroadcastEventBus;
+pub use channel::{DEFAULT_CAPACITY, FanoutChannel};
 pub use error::EventBusError;
 pub use event::{Event, HealthEvent, LifecycleEvent, MigrationEvent, ProfileEvent};
 pub use subgraft::EventBusSubGraft;

--- a/crates/mokumo-shop/Cargo.toml
+++ b/crates/mokumo-shop/Cargo.toml
@@ -9,6 +9,7 @@ description = "Mokumo shop vertical — neutral shop-core primitives (customers,
 
 [dependencies]
 kikan = { workspace = true }
+kikan-events = { workspace = true }
 kikan-types = { workspace = true }
 mokumo-core = { workspace = true }
 sea-orm = { workspace = true }

--- a/crates/mokumo-shop/src/ws/manager.rs
+++ b/crates/mokumo-shop/src/ws/manager.rs
@@ -1,4 +1,5 @@
 use dashmap::DashMap;
+use kikan_events::channel::FanoutChannel;
 use kikan_types::ws::BroadcastEvent;
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -6,22 +7,21 @@ use uuid::Uuid;
 
 /// Manages WebSocket connections and broadcasts pre-serialized events.
 pub struct ConnectionManager {
-    broadcast_tx: broadcast::Sender<Arc<str>>,
+    fanout: FanoutChannel<Arc<str>>,
     connections: DashMap<Uuid, ()>,
 }
 
 impl ConnectionManager {
     pub fn new(capacity: usize) -> Self {
-        let (broadcast_tx, _) = broadcast::channel(capacity);
         Self {
-            broadcast_tx,
+            fanout: FanoutChannel::with_capacity(capacity),
             connections: DashMap::new(),
         }
     }
 
     pub fn add(&self) -> (Uuid, broadcast::Receiver<Arc<str>>) {
         let id = Uuid::new_v4();
-        let rx = self.broadcast_tx.subscribe();
+        let rx = self.fanout.subscribe();
         self.connections.insert(id, ());
         (id, rx)
     }
@@ -37,7 +37,7 @@ impl ConnectionManager {
         let json: Arc<str> = serde_json::to_string(&event)
             .expect("BroadcastEvent serialization cannot fail")
             .into();
-        self.broadcast_tx.send(json).unwrap_or(0)
+        self.fanout.publish(json)
     }
 
     pub fn connection_count(&self) -> usize {


### PR DESCRIPTION
## Summary

Session 7 of the kikan-extraction-finalization pipeline. Splits `kikan-events` into a **mechanism** layer (`FanoutChannel<T>`) and a **taxonomy** layer (`BroadcastEventBus`) so a second consumer can reuse the broadcast mechanism without inheriting the kikan platform-event taxonomy.

- **New primitive**: `kikan_events::channel::FanoutChannel<T: Clone + Send + 'static>` — thin wrapper over `tokio::sync::broadcast::Sender<T>` with `publish` / `subscribe` / `receiver_count` / `with_capacity`. Doc comments on when to reach for it vs raw `tokio::broadcast`. `DEFAULT_CAPACITY` relocated from `bus.rs` and re-exported from `lib.rs`.
- **`BroadcastEventBus`** now composes four `FanoutChannel<T>`s internally (Lifecycle, Health, Migration, Profile). Public API byte-identical — all `publish_*` / `subscribe_*` signatures preserved.
- **`mokumo_shop::ws::ConnectionManager`** now composes `FanoutChannel<Arc<str>>` internally. Public API byte-identical — `add` / `remove` / `broadcast` / `connection_count` preserved. The `DashMap<Uuid, ()>` registry and pre-serialize-once-broadcast-many optimization stay where they belong (WS transport).
- **`EventBusSubGraft`** registered in both `apps/mokumo-desktop` and `apps/mokumo-server` `BootConfig`s via `.with_subgraft(...)`. Activates `BroadcastEventBus` publish on Engine `on_ignite` / `on_liftoff` / `on_shutdown` end-to-end.

Plan: `ops/pipelines/mokumo/mokumo-20260426-622-fanout-primitive-plan.md`.
Parent pipeline: `ops/pipelines/mokumo/kikan-extraction-finalization-plan.md` §Session 7. Closes epic #501 on merge.

## Architecture decision

New ADR-7 on mechanism-vs-taxonomy split (extends `adr-kikan-primitive-crate-design.md`, complementary to ADR-1: `BroadcastEventBus` stays concrete; what's extracted is the mechanism one layer below). **Staged host-side** at `.claude/staging/adr-kikan-primitive-crate-design.amendment.md` — `/ops` is mounted read-only from the container, so the ADR append + `lastUpdatedAt: 2026-04-26` bump happens on the host alongside the merge.

A companion 2026-04-26 amendment on `adr-kikan-deployment-modes.md` is staged at `.claude/staging/adr-kikan-deployment-modes.amendment.md` — consolidated stale→current module-path pointer (the body still references `mokumo-api::middleware::csrf` in §122 and `mokumo-api::middleware::trusted_proxy` in §149; neither crate exists, both resolve against `crates/kikan/src/data_plane/`).

## Scope guards honored

- ✅ No public API change on `BroadcastEventBus`, `ConnectionManager`, or `EventBusSubGraft`
- ✅ No new event variants in `kikan_events::event`
- ✅ No `BroadcastEventBus` → `PlatformEventBus` rename
- ✅ No WS handler changes (`crates/mokumo-shop/src/ws/handler.rs` unchanged)
- ✅ No #502 work (version-mismatch detection — defers to Session 8)

## Rg-guard assertions (plan Step 8)

Plan expected `rg 'tokio::sync::broadcast' crates/kikan-events/src/` → 1 hit. Actual: 6 hits across `bus.rs` (1 — `broadcast::Receiver<T>` in preserved subscribe return types), `channel.rs` (4 — one `use`, three doc comments about the underlying `tokio::broadcast`), `lib.rs` (1 — module doc). All non-primitive hits are either doc mentions or the frozen public-API `Receiver<T>` return type. Plan's literal "1 hit" is not achievable while keeping `subscribe_*` signatures byte-identical (D2).

Plan expected `rg 'tokio::sync::broadcast' crates/mokumo-shop/src/ws/` → 0 hits (except receiver return type). Actual: 2 hits — `handler.rs:11` pre-existing `RecvError` import, `manager.rs:5` `broadcast::Receiver<Arc<str>>` in the preserved `add()` return type. Both explicitly allowed by the plan's parenthetical.

## Quality gates

- ✅ `cargo test -p kikan-events --lib` — 4 new `FanoutChannel` tests pass (publish reaches subscriber, multiple subscribers, no subscribers → 0, lagged receiver still progresses)
- ✅ `cargo test -p kikan-events --test bdd --features bdd` — 6 scenarios / 30 steps pass unchanged
- ✅ `cargo test -p mokumo-shop --lib` — 173 tests pass (6 `ConnectionManager` tests unchanged)
- ✅ `cargo test -p kikan --lib` — 313 tests pass
- ✅ `cargo test -p mokumo-desktop --lib` — 37 tests pass
- ✅ `cargo check -p mokumo-server`, `cargo check -p mokumo-desktop` — clean
- ✅ `cargo clippy --workspace --exclude mokumo-desktop --exclude kikan-tauri --all-targets -- -D warnings` — clean
- ✅ `cargo fmt --all --check` — clean
- ✅ All six kikan invariant scripts (I1 + I1-strict, I2, I2b, I3, I4, I5) — green
- ✅ `cargo deny check` — advisories / bans / licenses / sources all ok

**Pre-existing on main, flagged for visibility:** `cargo clippy -p mokumo-desktop -p kikan-tauri --tests -- -D warnings` fails with 7 errors (6× `collapsible_if` in `lib.rs`, 1× `empty_line_after_doc_comments` in `lifecycle.rs`). Confirmed pre-existing via `git stash` on this branch — same errors at same files, offset only by this PR's 3-line `event_bus` addition in `apps/mokumo-desktop/src/lib.rs`. Out of scope per CLAUDE.md "don't refactor beyond what the task requires"; flagged here so reviewers running the verbatim Step-8 command don't attribute the failure to this PR.

## Test plan

- [ ] Verify BroadcastEventBus lifecycle publish/subscribe still flows end-to-end after merge (BDD already covers this; no code path changed)
- [ ] Verify WS `ConnectionManager.broadcast` still reaches all connected WebSocket clients
- [ ] Host-side: apply staged ADR amendments (`.claude/staging/adr-kikan-primitive-crate-design.amendment.md`, `.claude/staging/adr-kikan-deployment-modes.amendment.md`) + bump `lastUpdatedAt: 2026-04-26` on both ADRs
- [ ] Host-side: close epic #501 with summary comment; mark parent pipeline `status: completed`; append Session 7 row to rolling log; write final closeout pipeline note `ops/pipelines/mokumo/mokumo-20260426-kikan-extraction-closeout.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Introduced new centralized event distribution infrastructure for managing message broadcasts across services.
  * Integrated event bus system into desktop and server application initialization for enhanced event handling.
  * Updated shop service's connection management to use the new event distribution mechanism for improved scalability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->