### PR TITLE
chore(clippy): fix pre-existing errors in mokumo-desktop

### DIFF
--- a/apps/mokumo-desktop/src/lib.rs
+++ b/apps/mokumo-desktop/src/lib.rs
@@ -502,20 +502,20 @@ pub fn run() {
                     tracing::info!("Restart requested — reinitializing server with fresh database");
 
                     // Deregister stale mDNS before restarting
-                    if let Some(mdns) = app_handle_for_server.try_state::<MdnsState>() {
-                        if let Some(handle) = mdns.handle.lock().ok().and_then(|mut h| h.take()) {
-                            discovery::deregister_mdns(handle, &mdns.status);
-                        }
+                    if let Some(mdns) = app_handle_for_server.try_state::<MdnsState>()
+                        && let Some(handle) = mdns.handle.lock().ok().and_then(|mut h| h.take())
+                    {
+                        discovery::deregister_mdns(handle, &mdns.status);
                     }
 
                     let new_shutdown = CancellationToken::new();
                     let new_server_token = new_shutdown.clone();
 
                     // Expose the live token so ExitRequested cancels the right server
-                    if let Some(state) = app_handle_for_server.try_state::<ShutdownState>() {
-                        if let Ok(mut token) = state.0.lock() {
-                            *token = new_shutdown.clone();
-                        }
+                    if let Some(state) = app_handle_for_server.try_state::<ShutdownState>()
+                        && let Ok(mut token) = state.0.lock()
+                    {
+                        *token = new_shutdown.clone();
                     }
 
                     // Listener-passthrough: bind before init_server so port is
@@ -535,14 +535,14 @@ pub fn run() {
                     };
 
                     let new_port = new_addr.port();
-                    if new_port != port {
-                        if let Some(window) = app_handle_for_server.get_webview_window("main") {
-                            let new_url = format!("http://127.0.0.1:{new_port}");
-                            if let Err(e) =
-                                window.navigate(new_url.parse().expect("valid loopback URL"))
-                            {
-                                tracing::warn!("Failed to navigate webview after port change: {e}");
-                            }
+                    if new_port != port
+                        && let Some(window) = app_handle_for_server.get_webview_window("main")
+                    {
+                        let new_url = format!("http://127.0.0.1:{new_port}");
+                        if let Err(e) =
+                            window.navigate(new_url.parse().expect("valid loopback URL"))
+                        {
+                            tracing::warn!("Failed to navigate webview after port change: {e}");
                         }
                     }
 
@@ -551,10 +551,10 @@ pub fn run() {
                             port = init.port;
 
                             // Store the new mDNS handle for cleanup on exit
-                            if let Some(mdns) = app_handle_for_server.try_state::<MdnsState>() {
-                                if let Ok(mut h) = mdns.handle.lock() {
-                                    *h = init.mdns_handle;
-                                }
+                            if let Some(mdns) = app_handle_for_server.try_state::<MdnsState>()
+                                && let Ok(mut h) = mdns.handle.lock()
+                            {
+                                *h = init.mdns_handle;
                             }
 
                             if let Err(e) = axum::serve(
@@ -763,17 +763,17 @@ pub fn run() {
                 tracing::info!("Exit requested, draining server...");
 
                 // Deregister mDNS BEFORE cancelling the token (matches CLI behavior)
-                if let Some(mdns) = app.try_state::<MdnsState>() {
-                    if let Some(handle) = mdns.handle.lock().ok().and_then(|mut h| h.take()) {
-                        discovery::deregister_mdns(handle, &mdns.status);
-                    }
+                if let Some(mdns) = app.try_state::<MdnsState>()
+                    && let Some(handle) = mdns.handle.lock().ok().and_then(|mut h| h.take())
+                {
+                    discovery::deregister_mdns(handle, &mdns.status);
                 }
 
                 // Cancel the LIVE shutdown token (updated by restart loop)
-                if let Some(state) = app.try_state::<ShutdownState>() {
-                    if let Ok(token) = state.0.lock() {
-                        token.cancel();
-                    }
+                if let Some(state) = app.try_state::<ShutdownState>()
+                    && let Ok(token) = state.0.lock()
+                {
+                    token.cancel();
                 }
 
                 // Take the server handle and await drain with 10s timeout

--- a/apps/mokumo-desktop/src/lib.rs
+++ b/apps/mokumo-desktop/src/lib.rs
@@ -503,7 +503,8 @@ pub fn run() {
 
                     // Deregister stale mDNS before restarting
                     if let Some(mdns) = app_handle_for_server.try_state::<MdnsState>()
-                        && let Some(handle) = mdns.handle.lock().ok().and_then(|mut h| h.take())
+                        && let Ok(mut guard) = mdns.handle.lock()
+                        && let Some(handle) = guard.take()
                     {
                         discovery::deregister_mdns(handle, &mdns.status);
                     }
@@ -764,7 +765,8 @@ pub fn run() {
 
                 // Deregister mDNS BEFORE cancelling the token (matches CLI behavior)
                 if let Some(mdns) = app.try_state::<MdnsState>()
-                    && let Some(handle) = mdns.handle.lock().ok().and_then(|mut h| h.take())
+                    && let Ok(mut guard) = mdns.handle.lock()
+                    && let Some(handle) = guard.take()
                 {
                     discovery::deregister_mdns(handle, &mdns.status);
                 }

--- a/apps/mokumo-desktop/src/lifecycle.rs
+++ b/apps/mokumo-desktop/src/lifecycle.rs
@@ -1,8 +1,7 @@
-/// Desktop lifecycle decision logic.
-///
-/// Pure functions that drive Tauri event handler behavior.
-/// Extracted from handlers so they can be unit-tested without a Tauri runtime.
-/// Sessions 3.1 and 3.2 will refactor handlers to delegate to these functions.
+//! Desktop lifecycle decision logic.
+//!
+//! Pure functions that drive Tauri event handler behavior, extracted from
+//! handlers so they can be unit-tested without a Tauri runtime.
 
 /// What to do when the user closes the window (X button).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Clears 7 pre-existing clippy errors flagged (but deliberately left unfixed) during mokumo PR #658, per the scope-discipline rule in [`ops/playbooks/code-review.md`](../ops/playbooks/code-review.md): *"the PR fixes the thing its title says it fixes"*.
- 6× `collapsible_if` in `apps/mokumo-desktop/src/lib.rs` — nested `if let` pairs merged into `let`-chains (no behaviour change).
- 1× `empty_line_after_doc_comments` in `apps/mokumo-desktop/src/lifecycle.rs` — module header converted from outer `///` to inner `//!` doc, and the stage-narrative line *"Sessions 3.1 and 3.2 will refactor handlers to delegate to these functions"* dropped per CLAUDE.md §18 (no temporal/stage language in comments).

> **Brief correction:** the session brief cited `crates/kikan-tauri/src/lifecycle.rs` for the `empty_line_after_doc_comments` error. That file does not exist — `kikan-tauri` only has `lib.rs` + `net.rs`, and `cargo clippy -p kikan-tauri --tests -- -D warnings` comes back clean on `main`. The actual site was `apps/mokumo-desktop/src/lifecycle.rs`. All 7 errors live in `mokumo-desktop`; `kikan-tauri` needed no change.

## Reproducer

On `main` (commit `3731545`), before this PR:

    CARGO_TARGET_DIR=/tmp/cargo-target RUSTC_WRAPPER= \
      cargo clippy -p mokumo-desktop -p kikan-tauri --tests -- -D warnings

produces 7 errors:

| # | lint | location |
|---|---|---|
| 1 | `empty_line_after_doc_comments` | `apps/mokumo-desktop/src/lifecycle.rs:5:1` |
| 2 | `collapsible_if` | `apps/mokumo-desktop/src/lib.rs:505:21` |
| 3 | `collapsible_if` | `apps/mokumo-desktop/src/lib.rs:515:21` |
| 4 | `collapsible_if` | `apps/mokumo-desktop/src/lib.rs:538:21` |
| 5 | `collapsible_if` | `apps/mokumo-desktop/src/lib.rs:554:29` |
| 6 | `collapsible_if` | `apps/mokumo-desktop/src/lib.rs:766:17` |
| 7 | `collapsible_if` | `apps/mokumo-desktop/src/lib.rs:773:17` |

After this PR the same command exits clean (`No issues found`).

## Test plan

- [x] `cargo clippy -p mokumo-desktop -p kikan-tauri --tests -- -D warnings` — clean
- [x] `cargo fmt --check -p mokumo-desktop -p kikan-tauri` — clean
- [x] `cargo build -p mokumo-desktop` — compiles
- [ ] CI: `moon check --all` green
- [ ] No `Cargo.{toml,lock}` touch, so `moon run shop:deny` not required

## Scope

- No behaviour change. `collapsible_if` rewrites produce identical short-circuit semantics to the nested form (both arms of the outer `if let` must be `Some`/`Ok` before the body runs).
- No API change. Nothing is `pub`.
- No CHANGELOG entry — internal cleanup, not user-facing.
- Not labelled `ci:crap-delta` — pure lint fix, no complexity delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for better maintainability.

* **Documentation**
  * Updated module documentation formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->