### PR TITLE
docs(kikan): document concurrent boot locking coverage

### DIFF
--- a/crates/kikan/src/db/pragmas.rs
+++ b/crates/kikan/src/db/pragmas.rs
@@ -13,7 +13,8 @@
 //!   every commit).
 //! - `foreign_keys=ON` — enforced per connection; SQLite requires this
 //!   pragma on every handle, not just once per database.
-//! - `cache_size=-64000` — 64 MiB per connection (negative value = KiB).
+//! - `cache_size=-64000` — 64000 KiB per connection (negative value =
+//!   KiB; ≈62.5 MiB).
 //! - `mmap_size` — set to [`CONFIGURED_MMAP_SIZE`] (non-zero on Linux
 //!   only; see its docs for platform rationale).
 //!
@@ -21,10 +22,16 @@
 //!
 //! Cross-process exclusion against the same data directory is the
 //! caller's responsibility. WAL + `busy_timeout` make a single pool
-//! safe for concurrent in-process work; they do not prevent two
-//! Engines on the same directory from colliding on sidecar swaps,
-//! backup-API calls, or migration runs — those operations reach
-//! outside SQLite's locking protocol. Single-Engine enforcement is an
+//! safe for concurrent in-process work; they do not coordinate
+//! operations between two Engines on the same directory. Sidecar
+//! swaps (demo reset, restore) manipulate the database files via
+//! paths kikan controls, outside SQLite's locking protocol, so two
+//! Engines racing a swap corrupt each other. Backup destination
+//! filenames are app-chosen: concurrent backups race the filesystem,
+//! not SQLite's locks. Migration runs serialize through SQLite's
+//! write lock, but the losing Engine fails to boot (spurious
+//! migration errors or a `SQLITE_BUSY` once `busy_timeout` elapses)
+//! rather than cooperating. Single-Engine enforcement is an
 //! Application-level concern.
 
 use std::future::Future;

--- a/crates/kikan/src/db/pragmas.rs
+++ b/crates/kikan/src/db/pragmas.rs
@@ -1,9 +1,31 @@
 //! PRAGMA configuration applied to every SQLite connection pool in the
 //! kikan platform.
 //!
-//! WAL mode, normal synchronous, 5s busy timeout, foreign keys enforced,
-//! 64MB cache. `mmap_size` is set to [`CONFIGURED_MMAP_SIZE`] — non-zero on
-//! Linux only (see docs below).
+//! # PRAGMAs set
+//!
+//! - `journal_mode=WAL` + `busy_timeout=5000` form the **in-process
+//!   concurrent-safety** pair. WAL lets readers proceed while a writer
+//!   holds the write lock; `busy_timeout` gives competing writers a
+//!   5-second retry window before `SQLITE_BUSY` surfaces. See the
+//!   crate-root docs for where this fits in the full startup-safety
+//!   contract.
+//! - `synchronous=NORMAL` — safe under WAL (fsync on checkpoint, not
+//!   every commit).
+//! - `foreign_keys=ON` — enforced per connection; SQLite requires this
+//!   pragma on every handle, not just once per database.
+//! - `cache_size=-64000` — 64 MiB per connection (negative value = KiB).
+//! - `mmap_size` — set to [`CONFIGURED_MMAP_SIZE`] (non-zero on Linux
+//!   only; see its docs for platform rationale).
+//!
+//! # What this does NOT cover
+//!
+//! Cross-process exclusion against the same data directory is the
+//! caller's responsibility. WAL + `busy_timeout` make a single pool
+//! safe for concurrent in-process work; they do not prevent two
+//! Engines on the same directory from colliding on sidecar swaps,
+//! backup-API calls, or migration runs — those operations reach
+//! outside SQLite's locking protocol. Single-Engine enforcement is an
+//! Application-level concern.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/kikan/src/engine.rs
+++ b/crates/kikan/src/engine.rs
@@ -143,11 +143,13 @@ impl<G: Graft> Engine<G> {
     /// configured in [`crate::db::pragmas`]) make each pool safe for
     /// concurrent in-process reads and writes, and migrations are
     /// serialized by [`crate::migrations::runner`] using
-    /// `SqliteTransactionMode::Immediate`. None of that protects two
-    /// Engines racing on the same data directory — backup-API calls,
-    /// sidecar swaps, and concurrent migration runs reach outside
-    /// SQLite's locking protocol and will corrupt each other. See the
-    /// crate-root docs for the full contract.
+    /// `SqliteTransactionMode::Immediate`. None of that coordinates
+    /// two Engines racing on the same data directory: sidecar swaps
+    /// manipulate files outside SQLite's locking protocol; backup
+    /// destination filenames are app-chosen and race at the
+    /// filesystem layer; concurrent migrations serialize through the
+    /// write lock but the loser fails to boot rather than cooperating.
+    /// See the crate-root docs for the full contract.
     ///
     /// The [`Graft::recovery_dir`] file-drop directory and reset-PIN
     /// store are owned by the vertical on its own state slice; `boot`

--- a/crates/kikan/src/engine.rs
+++ b/crates/kikan/src/engine.rs
@@ -136,10 +136,23 @@ impl<G: Graft> Engine<G> {
     /// `boot` handles migration execution, state composition, and
     /// setup-token resolution via [`Graft::setup_token_source`].
     ///
-    /// The vertical's file-drop recovery directory and reset-PIN store
-    /// are no longer boot parameters. The vertical owns those pieces on
-    /// its own state slice and exposes the recovery-dir path through
-    /// [`Graft::recovery_dir`] for any kikan-side caller that needs it.
+    /// # Concurrent safety
+    ///
+    /// Callers must guarantee a single Engine instance per data
+    /// directory. kikan's pool-level PRAGMAs (WAL + `busy_timeout`,
+    /// configured in [`crate::db::pragmas`]) make each pool safe for
+    /// concurrent in-process reads and writes, and migrations are
+    /// serialized by [`crate::migrations::runner`] using
+    /// `SqliteTransactionMode::Immediate`. None of that protects two
+    /// Engines racing on the same data directory — backup-API calls,
+    /// sidecar swaps, and concurrent migration runs reach outside
+    /// SQLite's locking protocol and will corrupt each other. See the
+    /// crate-root docs for the full contract.
+    ///
+    /// The [`Graft::recovery_dir`] file-drop directory and reset-PIN
+    /// store are owned by the vertical on its own state slice; `boot`
+    /// reaches them through [`Graft::recovery_dir`] for any kikan-side
+    /// caller that needs the path.
     #[allow(clippy::too_many_arguments)]
     pub async fn boot(
         config: BootConfig,

--- a/crates/kikan/src/lib.rs
+++ b/crates/kikan/src/lib.rs
@@ -33,13 +33,18 @@
 //!   application tasks cannot race a boot-time migration.
 //!
 //! **Cross-process** single-Engine-per-data-directory is the caller's
-//! precondition — kikan does not enforce it. Two Engines booted against
-//! the same data directory would still collide on backup-API calls,
-//! sidecar swaps, and migration runs even with WAL on, because those
-//! operations manipulate the database file outside SQLite's locking
-//! protocol. The Application is responsible for single-instance
-//! enforcement; see `ops/decisions/mokumo/adr-process-lock-flock.md`
-//! for the adapter-level mechanism.
+//! precondition — kikan does not enforce it. Two Engines booted
+//! against the same data directory collide in three places that WAL
+//! does not cover: sidecar swaps (demo reset, restore) manipulate the
+//! database files outside SQLite's locking protocol; backup
+//! destination filenames are app-chosen, so concurrent backups race
+//! the filesystem rather than SQLite's locks; migration runs do
+//! serialize through the write lock, but the losing Engine fails to
+//! boot (spurious migration errors or `SQLITE_BUSY` once
+//! `busy_timeout` elapses) rather than cooperating. The Application
+//! is responsible for single-instance enforcement; see
+//! `ops/decisions/mokumo/adr-process-lock-flock.md` for the
+//! adapter-level mechanism.
 //!
 //! Place platform-shaped code here. Shop-vertical identifiers belong
 //! in `mokumo-shop` (invariant I1, enforced by

--- a/crates/kikan/src/lib.rs
+++ b/crates/kikan/src/lib.rs
@@ -16,6 +16,31 @@
 //! trust. The per-mode matrix and layer order are documented at the
 //! [`data_plane`] module level.
 //!
+//! # Startup and concurrent safety
+//!
+//! kikan provides **in-process** concurrent-safety for every SeaORM pool
+//! it manages:
+//!
+//! - `PRAGMA journal_mode=WAL` — readers don't block writers; writers
+//!   serialize through a single write lock. Applied by [`db::pragmas`]
+//!   on every connection.
+//! - `PRAGMA busy_timeout=5000` — a 5-second retry window before
+//!   `SQLITE_BUSY` surfaces to the caller, enough for short write
+//!   contention within a single Engine to self-resolve.
+//! - Migrations run in `SqliteTransactionMode::Immediate` (see
+//!   [`migrations::runner`]) — each migration acquires the write lock
+//!   on `BEGIN` rather than upgrading lazily, so concurrent writes from
+//!   application tasks cannot race a boot-time migration.
+//!
+//! **Cross-process** single-Engine-per-data-directory is the caller's
+//! precondition — kikan does not enforce it. Two Engines booted against
+//! the same data directory would still collide on backup-API calls,
+//! sidecar swaps, and migration runs even with WAL on, because those
+//! operations manipulate the database file outside SQLite's locking
+//! protocol. The Application is responsible for single-instance
+//! enforcement; see `ops/decisions/mokumo/adr-process-lock-flock.md`
+//! for the adapter-level mechanism.
+//!
 //! Place platform-shaped code here. Shop-vertical identifiers belong
 //! in `mokumo-shop` (invariant I1, enforced by
 //! `scripts/check-i1-domain-purity.sh`); shell adapters in

--- a/crates/kikan/src/migrations/runner.rs
+++ b/crates/kikan/src/migrations/runner.rs
@@ -1,3 +1,19 @@
+//! Per-migration transaction runner.
+//!
+//! Each migration runs inside its own `SqliteTransactionMode::Immediate`
+//! transaction — the write lock is acquired on `BEGIN IMMEDIATE` rather
+//! than lazily on first write. That matters for concurrent boot safety:
+//! a migration cannot be mid-flight on a deferred transaction, get
+//! overtaken by a concurrent write from application code, and then eat
+//! `SQLITE_BUSY` when it tries to upgrade to write. Either the
+//! migration holds the write lock for its whole duration or it fails
+//! cleanly on acquire.
+//!
+//! Tracking lives in the `kikan_migrations` table; bootstrap of that
+//! table runs once before any migration body. See
+//! `tests/features/migration_execution.feature` for the behavioral
+//! contract.
+
 use sea_orm::{
     ConnectionTrait, DatabaseBackend, DatabaseConnection, FromQueryResult, Statement, Value,
 };


### PR DESCRIPTION
## Summary

- Adds a `# Startup and concurrent safety` section to the `kikan` crate-root docs naming the single-Engine-per-data-directory invariant as a caller precondition.
- Expands `db::pragmas` module doc to frame WAL + `busy_timeout=5000` as the in-process concurrent-safety pair, and calls out what it does NOT cover (cross-process exclusion).
- Adds a `# Concurrent safety` section to `Engine::boot` stating the same precondition at the API surface.
- Adds a module-level doc to `migrations::runner` explaining why each migration uses `SqliteTransactionMode::Immediate` (`BEGIN IMMEDIATE`) — writer-coordinated acquire prevents mid-migration upgrade races under WAL.

Closes #541.

## Companion ops-repo ADR amendments

Two decision records need corresponding updates in the ops repo (read-only from this container, so they land as a separate commit). Patch staged at `ops/workspace/mokumo/mokumo/20260424-boot-locking-docs/ops-adr-amendments.md`:

- `adr-process-lock-flock.md` — append a four-layer concurrent-safety table (flock + WAL + busy_timeout + BEGIN IMMEDIATE), explicit owner attribution (Application vs Engine), and a test-coverage note flagging the boot-path call-site gap.
- `adr-database-startup-guard-chain.md` — add a pre-chain context section noting that the guard chain assumes the flock is already held.

## Test plan

- [x] `cargo clippy -p kikan --all-targets -- -D warnings` — clean
- [x] `cargo test -p kikan --lib` — 315 passed
- [x] `bash scripts/check-i1-domain-purity.sh` — I1/classic + I1/strict ok
- [x] `cargo doc -p kikan --no-deps` — no new rustdoc warnings in touched files (10 pre-existing warnings elsewhere in the crate)
- [x] CI green

## Deliberately out of scope

- **Optional test for concurrent `Engine::run()`** — the ADR call-site gap note captures the real gap (the flock primitive is covered by `crates/mokumo-shop/tests/cli_reset_db.rs::lock_contention_blocks_second_acquire` but a binary refactor removing the `try_write()` call site would leave that test green). A boot-path integration test that spawns two server processes is the right shape and is deferred to a follow-up — filing it avoids scope creep on a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced crate and module-level documentation describing concurrency models, engine constraints, and database startup behavior.
  * Documented the single-engine-per-data-directory requirement and clarified cross-process limitations when multiple engines target the same directory.
  * Clarified SQLite pragma configurations, transaction handling modes, and migration execution patterns affecting connection-level behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
