### PR TITLE
feat(kikan): M00 platform migrations for roles + integrations

### DIFF
--- a/crates/kikan/src/auth/backend_tests.rs
+++ b/crates/kikan/src/auth/backend_tests.rs
@@ -91,6 +91,9 @@ async fn authenticate_returns_none_for_wrong_password() {
 #[tokio::test]
 async fn authenticate_returns_none_for_inactive_user() {
     let (db, _tmp) = seed_db().await;
+    // Seed a co-Admin so the last-Admin trigger introduced in the M00
+    // migrations doesn't refuse the deactivation this test depends on.
+    seed_user(&db, "keeper@shop.local", "keeps-the-lights-on").await;
     seed_user(&db, "ghost@shop.local", "secret-value-42").await;
     sqlx::query("UPDATE users SET is_active = 0 WHERE email = 'ghost@shop.local'")
         .execute(db.get_sqlite_connection_pool())

--- a/crates/kikan/src/migrations/platform/active_integrations.rs
+++ b/crates/kikan/src/migrations/platform/active_integrations.rs
@@ -1,0 +1,83 @@
+//! M00 platform migration: `active_integrations` — install-level integration state.
+//!
+//! Integrations are install-level external-service adapters (payment
+//! processors, suppliers, backup targets, etc.); unlike extensions which
+//! activate per-profile, a given integration is configured once at the
+//! install level and shared across profiles that are eligible (Pattern 1
+//! coupling per `adr-mokumo-integrations` §ADR-1).
+//!
+//! Credentials are stored as `seal`-ed blobs per
+//! `adr-mokumo-integrations` §ADR-5 (XChaCha20-Poly1305 via RustCrypto
+//! `chacha20poly1305`); the AEAD details are opaque to this table. On
+//! "disconnect and delete credentials" (T2+sudo), the `credentials_*`
+//! columns are zeroed but the row remains — preserves the FK target for
+//! `integration_event_log` entries, which honors the audit-trail intent
+//! over the credential-deletion intent.
+
+use crate::migrations::conn::MigrationConn;
+use crate::migrations::{GraftId, Migration, MigrationRef, MigrationTarget};
+
+use super::PlatformMigrations;
+
+pub(crate) struct ActiveIntegrations;
+
+#[async_trait::async_trait]
+impl Migration for ActiveIntegrations {
+    fn name(&self) -> &'static str {
+        "m20260424_000002_active_integrations"
+    }
+
+    fn graft_id(&self) -> GraftId {
+        PlatformMigrations::graft_id()
+    }
+
+    fn target(&self) -> MigrationTarget {
+        MigrationTarget::PerProfile
+    }
+
+    fn dependencies(&self) -> Vec<MigrationRef> {
+        Vec::new()
+    }
+
+    async fn up(&self, conn: &MigrationConn) -> Result<(), sea_orm::DbErr> {
+        // `integration_id` is the trait `id()` returned by the
+        // `MokumoIntegration` impl (e.g. "stripe-payments", "sanmar"); it
+        // is opaque to kikan. `schema_version` tracks the plaintext-
+        // envelope version so per-integration migrations can evolve
+        // independently without touching the root-key file.
+        //
+        // `enabled_at = NULL` means the integration is configured but
+        // disconnected; `credentials_ciphertext = NULL` means credentials
+        // have been zeroed (the T2+sudo disconnect-and-delete path). Both
+        // states coexist because the trait's lifecycle separates the two
+        // intents.
+        conn.execute_unprepared(
+            "CREATE TABLE active_integrations (
+                integration_id TEXT PRIMARY KEY,
+                enabled_at TEXT,
+                credentials_ciphertext BLOB,
+                credentials_nonce BLOB,
+                last_sync_at TEXT,
+                schema_version INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )",
+        )
+        .await?;
+
+        conn.execute_unprepared(
+            "CREATE TRIGGER active_integrations_updated_at
+                AFTER UPDATE ON active_integrations
+                FOR EACH ROW
+                WHEN NEW.updated_at = OLD.updated_at
+                BEGIN
+                    UPDATE active_integrations
+                       SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+                     WHERE integration_id = OLD.integration_id;
+                END",
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/kikan/src/migrations/platform/active_integrations.rs
+++ b/crates/kikan/src/migrations/platform/active_integrations.rs
@@ -51,6 +51,12 @@ impl Migration for ActiveIntegrations {
         // have been zeroed (the T2+sudo disconnect-and-delete path). Both
         // states coexist because the trait's lifecycle separates the two
         // intents.
+        //
+        // `credentials_ciphertext` and `credentials_nonce` move together —
+        // either both are present (a sealed AEAD envelope) or both are
+        // NULL (zeroed). The CHECK enforces this at the DB layer so a
+        // half-state can't silently corrupt the AEAD invariant and only
+        // surface as a decrypt failure.
         conn.execute_unprepared(
             "CREATE TABLE active_integrations (
                 integration_id TEXT PRIMARY KEY,
@@ -60,7 +66,8 @@ impl Migration for ActiveIntegrations {
                 last_sync_at TEXT,
                 schema_version INTEGER NOT NULL DEFAULT 1,
                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                CHECK ((credentials_ciphertext IS NULL) = (credentials_nonce IS NULL))
             )",
         )
         .await?;

--- a/crates/kikan/src/migrations/platform/active_integrations.rs
+++ b/crates/kikan/src/migrations/platform/active_integrations.rs
@@ -59,8 +59,8 @@ impl Migration for ActiveIntegrations {
                 credentials_nonce BLOB,
                 last_sync_at TEXT,
                 schema_version INTEGER NOT NULL DEFAULT 1,
-                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+                created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
             )",
         )
         .await?;
@@ -72,7 +72,7 @@ impl Migration for ActiveIntegrations {
                 WHEN NEW.updated_at = OLD.updated_at
                 BEGIN
                     UPDATE active_integrations
-                       SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+                       SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
                      WHERE integration_id = OLD.integration_id;
                 END",
         )

--- a/crates/kikan/src/migrations/platform/integration_event_log.rs
+++ b/crates/kikan/src/migrations/platform/integration_event_log.rs
@@ -1,0 +1,65 @@
+//! M00 platform migration: `integration_event_log` — per-integration event record.
+//!
+//! Named `integration_event_log`, not `integration_sync_history`, because
+//! integrations have three dispatch patterns (sync-driven, webhook-driven,
+//! scheduled); the event log records all three uniformly. See
+//! `adr-mokumo-integrations` §ADR-3 — CAO F4 caught the `_sync_history`
+//! framing as a leftover from the pre-webhook shape.
+//!
+//! Payload is stored `_redacted` — credentials and PII are scrubbed before
+//! the event is persisted. The trait's `test_connection` and sync calls
+//! handle the redaction; this table trusts the scrubbed form.
+
+use crate::migrations::conn::MigrationConn;
+use crate::migrations::{GraftId, Migration, MigrationRef, MigrationTarget};
+
+use super::PlatformMigrations;
+
+pub(crate) struct IntegrationEventLog;
+
+#[async_trait::async_trait]
+impl Migration for IntegrationEventLog {
+    fn name(&self) -> &'static str {
+        "m20260424_000003_integration_event_log"
+    }
+
+    fn graft_id(&self) -> GraftId {
+        PlatformMigrations::graft_id()
+    }
+
+    fn target(&self) -> MigrationTarget {
+        MigrationTarget::PerProfile
+    }
+
+    fn dependencies(&self) -> Vec<MigrationRef> {
+        // FK to active_integrations — must run second.
+        vec![MigrationRef {
+            graft: PlatformMigrations::graft_id(),
+            name: "m20260424_000002_active_integrations",
+        }]
+    }
+
+    async fn up(&self, conn: &MigrationConn) -> Result<(), sea_orm::DbErr> {
+        conn.execute_unprepared(
+            "CREATE TABLE integration_event_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                integration_id TEXT NOT NULL REFERENCES active_integrations(integration_id) ON DELETE RESTRICT,
+                at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                event_type TEXT NOT NULL,
+                status TEXT NOT NULL CHECK (status IN ('ok', 'error')),
+                error TEXT,
+                payload_redacted TEXT,
+                CHECK ((status = 'ok' AND error IS NULL) OR (status = 'error' AND error IS NOT NULL))
+            )",
+        )
+        .await?;
+
+        conn.execute_unprepared(
+            "CREATE INDEX idx_integration_event_log_integration_at
+                ON integration_event_log(integration_id, at DESC)",
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/kikan/src/migrations/platform/integration_event_log.rs
+++ b/crates/kikan/src/migrations/platform/integration_event_log.rs
@@ -9,6 +9,11 @@
 //! Payload is stored `_redacted` — credentials and PII are scrubbed before
 //! the event is persisted. The trait's `test_connection` and sync calls
 //! handle the redaction; this table trusts the scrubbed form.
+//!
+//! Append-only: rows are inserted and never updated. There is no
+//! `updated_at` column or AFTER UPDATE trigger by design; event records
+//! are immutable history. A future refactor that introduces row mutation
+//! here would violate the audit-trail contract.
 
 use crate::migrations::conn::MigrationConn;
 use crate::migrations::{GraftId, Migration, MigrationRef, MigrationTarget};
@@ -44,7 +49,7 @@ impl Migration for IntegrationEventLog {
             "CREATE TABLE integration_event_log (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 integration_id TEXT NOT NULL REFERENCES active_integrations(integration_id) ON DELETE RESTRICT,
-                at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
                 event_type TEXT NOT NULL,
                 status TEXT NOT NULL CHECK (status IN ('ok', 'error')),
                 error TEXT,

--- a/crates/kikan/src/migrations/platform/mod.rs
+++ b/crates/kikan/src/migrations/platform/mod.rs
@@ -1,3 +1,7 @@
+mod active_integrations;
+mod integration_event_log;
+mod prevent_last_admin_deactivation;
+mod profile_user_roles;
 mod shop_settings;
 mod users_and_roles;
 
@@ -17,6 +21,12 @@ impl PlatformMigrations {
         vec![
             Box::new(users_and_roles::UsersAndRoles),
             Box::new(shop_settings::ShopSettings),
+            Box::new(profile_user_roles::ProfileUserRoles),
+            Box::new(prevent_last_admin_deactivation::PreventLastAdminDeactivation),
+            // `active_integrations` MUST precede `integration_event_log` —
+            // the latter has a FK to the former.
+            Box::new(active_integrations::ActiveIntegrations),
+            Box::new(integration_event_log::IntegrationEventLog),
         ]
     }
 

--- a/crates/kikan/src/migrations/platform/prevent_last_admin_deactivation.rs
+++ b/crates/kikan/src/migrations/platform/prevent_last_admin_deactivation.rs
@@ -48,6 +48,17 @@ impl Migration for PreventLastAdminDeactivation {
     }
 
     async fn up(&self, conn: &MigrationConn) -> Result<(), sea_orm::DbErr> {
+        // Covering index for the trigger's `COUNT(*) FROM users
+        // WHERE role_id = 1 AND is_active = 1 AND deleted_at IS NULL`
+        // lookup. Without this, every admin deactivation/demotion would
+        // scan the full `users` table.
+        conn.execute_unprepared(
+            "CREATE INDEX idx_users_active_admins
+                ON users(role_id, is_active)
+                WHERE deleted_at IS NULL",
+        )
+        .await?;
+
         // "Admin" here is the install-level role — `users.role_id = 1` per
         // the `roles` table seeded in users_and_roles. The trigger RAISEs
         // ABORT on deactivation when the target row is the only active

--- a/crates/kikan/src/migrations/platform/prevent_last_admin_deactivation.rs
+++ b/crates/kikan/src/migrations/platform/prevent_last_admin_deactivation.rs
@@ -72,11 +72,16 @@ impl Migration for PreventLastAdminDeactivation {
         // would be defense-in-depth but is intentionally omitted here to
         // keep the trigger focused. A follow-up can add it if operator
         // error patterns warrant.
+        // Trigger WHEN clauses include `OLD.deleted_at IS NULL` so the
+        // gating predicate matches the COUNT subquery's filter — a
+        // soft-deleted row (the inconsistent case where deleted_at is
+        // set but is_active is still 1) is excluded from both sides.
         conn.execute_unprepared(
             "CREATE TRIGGER users_last_admin_deactivation_guard
                 BEFORE UPDATE OF is_active ON users
                 FOR EACH ROW
                 WHEN OLD.role_id = 1 AND OLD.is_active = 1 AND NEW.is_active = 0
+                     AND OLD.deleted_at IS NULL
                 BEGIN
                     SELECT CASE
                         WHEN (SELECT COUNT(*) FROM users
@@ -92,6 +97,7 @@ impl Migration for PreventLastAdminDeactivation {
                 BEFORE UPDATE OF role_id ON users
                 FOR EACH ROW
                 WHEN OLD.role_id = 1 AND NEW.role_id != 1 AND OLD.is_active = 1
+                     AND OLD.deleted_at IS NULL
                 BEGIN
                     SELECT CASE
                         WHEN (SELECT COUNT(*) FROM users

--- a/crates/kikan/src/migrations/platform/prevent_last_admin_deactivation.rs
+++ b/crates/kikan/src/migrations/platform/prevent_last_admin_deactivation.rs
@@ -1,0 +1,96 @@
+//! M00 platform migration: refuse to deactivate the last active install Admin.
+//!
+//! Install-level Admin count must stay ≥ 1. Without this trigger, a
+//! mis-click in the Users screen ("Deactivate") on the sole Admin would
+//! lock every operator out of the admin surface; the only recovery would
+//! be a DB edit or a full reinstall.
+//!
+//! Enforced at the DB layer (not just the API) to make the invariant
+//! transport-independent — CLI tools and direct SQL sessions cannot
+//! bypass the guard. The UI still surfaces the same invariant with a
+//! toast to prevent the user from ever seeing the raw trigger error.
+//!
+//! See `ops/decisions/mokumo/adr-kikan-admin-ui.md` §ADR-5 for the role
+//! model this guard enforces.
+
+use crate::migrations::conn::MigrationConn;
+use crate::migrations::{GraftId, Migration, MigrationRef, MigrationTarget};
+
+use super::PlatformMigrations;
+
+pub(crate) struct PreventLastAdminDeactivation;
+
+#[async_trait::async_trait]
+impl Migration for PreventLastAdminDeactivation {
+    fn name(&self) -> &'static str {
+        "m20260424_000001_prevent_last_admin_deactivation"
+    }
+
+    fn graft_id(&self) -> GraftId {
+        PlatformMigrations::graft_id()
+    }
+
+    fn target(&self) -> MigrationTarget {
+        MigrationTarget::PerProfile
+    }
+
+    fn dependencies(&self) -> Vec<MigrationRef> {
+        vec![
+            MigrationRef {
+                graft: PlatformMigrations::graft_id(),
+                name: "m20260327_000000_users_and_roles",
+            },
+            MigrationRef {
+                graft: PlatformMigrations::graft_id(),
+                name: "m20260424_000000_profile_user_roles",
+            },
+        ]
+    }
+
+    async fn up(&self, conn: &MigrationConn) -> Result<(), sea_orm::DbErr> {
+        // "Admin" here is the install-level role — `users.role_id = 1` per
+        // the `roles` table seeded in users_and_roles. The trigger RAISEs
+        // ABORT on deactivation when the target row is the only active
+        // Admin left.
+        //
+        // Runs on UPDATE of `is_active` (the direct deactivate path) and
+        // on UPDATE of `role_id` (the "demote the last Admin" path). Both
+        // SHOULD be prevented. Soft-delete via `deleted_at` is covered by
+        // the `is_active` path because the application sets `is_active=0`
+        // when soft-deleting; a separate UPDATE-of-`deleted_at` branch
+        // would be defense-in-depth but is intentionally omitted here to
+        // keep the trigger focused. A follow-up can add it if operator
+        // error patterns warrant.
+        conn.execute_unprepared(
+            "CREATE TRIGGER users_last_admin_deactivation_guard
+                BEFORE UPDATE OF is_active ON users
+                FOR EACH ROW
+                WHEN OLD.role_id = 1 AND OLD.is_active = 1 AND NEW.is_active = 0
+                BEGIN
+                    SELECT CASE
+                        WHEN (SELECT COUNT(*) FROM users
+                              WHERE role_id = 1 AND is_active = 1 AND deleted_at IS NULL) <= 1
+                        THEN RAISE(ABORT, 'cannot deactivate the last active install Admin')
+                    END;
+                END",
+        )
+        .await?;
+
+        conn.execute_unprepared(
+            "CREATE TRIGGER users_last_admin_demote_guard
+                BEFORE UPDATE OF role_id ON users
+                FOR EACH ROW
+                WHEN OLD.role_id = 1 AND NEW.role_id != 1 AND OLD.is_active = 1
+                BEGIN
+                    SELECT CASE
+                        WHEN (SELECT COUNT(*) FROM users
+                              WHERE role_id = 1 AND is_active = 1 AND deleted_at IS NULL) <= 1
+                        THEN RAISE(ABORT, 'cannot demote the last active install Admin')
+                    END;
+                END",
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/kikan/src/migrations/platform/profile_user_roles.rs
+++ b/crates/kikan/src/migrations/platform/profile_user_roles.rs
@@ -1,0 +1,67 @@
+//! M00 platform migration: install-level `(profile_id, user_id, role)` mapping.
+//!
+//! Introduces the three-tier permission model for Kikan admin UI: a user
+//! may be a Profile Admin or Profile User on each profile they belong to,
+//! independent of their install-level role in the `users` table. Install
+//! Owner / Admin / None is expressed elsewhere; this table captures the
+//! profile-level dimension.
+//!
+//! See `ops/decisions/mokumo/adr-kikan-admin-ui.md` §ADR-5 for the role
+//! model and the three-tier dispatch rules.
+
+use crate::migrations::conn::MigrationConn;
+use crate::migrations::{GraftId, Migration, MigrationRef, MigrationTarget};
+
+use super::PlatformMigrations;
+
+pub(crate) struct ProfileUserRoles;
+
+#[async_trait::async_trait]
+impl Migration for ProfileUserRoles {
+    fn name(&self) -> &'static str {
+        "m20260424_000000_profile_user_roles"
+    }
+
+    fn graft_id(&self) -> GraftId {
+        PlatformMigrations::graft_id()
+    }
+
+    fn target(&self) -> MigrationTarget {
+        MigrationTarget::PerProfile
+    }
+
+    fn dependencies(&self) -> Vec<MigrationRef> {
+        // Depends on users + (implicit) profile identity. Profile identity
+        // lives outside the DB — each profile is its own DB. The FK to
+        // users captures the in-DB half of the (profile_id, user_id) pair.
+        vec![MigrationRef {
+            graft: PlatformMigrations::graft_id(),
+            name: "m20260327_000000_users_and_roles",
+        }]
+    }
+
+    async fn up(&self, conn: &MigrationConn) -> Result<(), sea_orm::DbErr> {
+        // `role` is stored as TEXT with a CHECK constraint rather than a
+        // reference to a roles table — the role enum has only two variants
+        // (Admin, User) and is unlikely to grow. A TEXT+CHECK column keeps
+        // the migration self-contained and matches the existing SQLite
+        // idiom used elsewhere in the platform DB.
+        conn.execute_unprepared(
+            "CREATE TABLE profile_user_roles (
+                profile_id TEXT NOT NULL,
+                user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                role TEXT NOT NULL CHECK (role IN ('Admin', 'User')),
+                granted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                PRIMARY KEY (profile_id, user_id)
+            )",
+        )
+        .await?;
+
+        conn.execute_unprepared(
+            "CREATE INDEX idx_profile_user_roles_user_id ON profile_user_roles(user_id)",
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/kikan/src/migrations/platform/profile_user_roles.rs
+++ b/crates/kikan/src/migrations/platform/profile_user_roles.rs
@@ -51,7 +51,7 @@ impl Migration for ProfileUserRoles {
                 profile_id TEXT NOT NULL,
                 user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
                 role TEXT NOT NULL CHECK (role IN ('Admin', 'User')),
-                granted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+                granted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
                 PRIMARY KEY (profile_id, user_id)
             )",
         )

--- a/crates/kikan/tests/m00_platform_migrations.rs
+++ b/crates/kikan/tests/m00_platform_migrations.rs
@@ -1,0 +1,342 @@
+//! Schema-shape proofs for the four M00 platform migrations.
+//!
+//! Each test applies `run_platform_migrations` against a fresh in-memory
+//! SQLite connection and asserts the expected structural invariants of
+//! the introduced tables, triggers, and indexes via `PRAGMA` +
+//! `sqlite_master` queries. The assertions cover the pieces that
+//! downstream code relies on: column names, FK ordering, the CHECK
+//! constraints, and the two trigger names that the admin UI surfaces
+//! when users hit them.
+//!
+//! Kept as a single file because all four migrations share a setup
+//! (`make_db()`) and we want one failure report rather than four.
+
+use sea_orm::ConnectionTrait;
+use sea_orm::DatabaseConnection;
+use sqlx::Row;
+use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
+
+async fn make_db() -> (DatabaseConnection, SqlitePool) {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory SQLite must connect");
+    let db = sea_orm::SqlxSqliteConnector::from_sqlx_sqlite_pool(pool.clone());
+    kikan::migrations::platform::run_platform_migrations(&db)
+        .await
+        .expect("platform migrations must succeed");
+    (db, pool)
+}
+
+async fn column_names(pool: &SqlitePool, table: &str) -> Vec<String> {
+    sqlx::query(&format!("PRAGMA table_info({table})"))
+        .fetch_all(pool)
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| r.get::<String, _>("name"))
+        .collect()
+}
+
+async fn table_exists(pool: &SqlitePool, table: &str) -> bool {
+    let rows = sqlx::query("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+        .bind(table)
+        .fetch_all(pool)
+        .await
+        .unwrap();
+    !rows.is_empty()
+}
+
+async fn trigger_exists(pool: &SqlitePool, name: &str) -> bool {
+    let rows = sqlx::query("SELECT name FROM sqlite_master WHERE type='trigger' AND name = ?")
+        .bind(name)
+        .fetch_all(pool)
+        .await
+        .unwrap();
+    !rows.is_empty()
+}
+
+async fn index_exists(pool: &SqlitePool, name: &str) -> bool {
+    let rows = sqlx::query("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+        .bind(name)
+        .fetch_all(pool)
+        .await
+        .unwrap();
+    !rows.is_empty()
+}
+
+#[tokio::test]
+async fn profile_user_roles_table_has_expected_shape() {
+    let (_db, pool) = make_db().await;
+
+    assert!(
+        table_exists(&pool, "profile_user_roles").await,
+        "profile_user_roles table must exist after migrations"
+    );
+
+    let cols = column_names(&pool, "profile_user_roles").await;
+    assert_eq!(
+        cols,
+        vec!["profile_id", "user_id", "role", "granted_at"],
+        "profile_user_roles column set changed unexpectedly"
+    );
+
+    assert!(
+        index_exists(&pool, "idx_profile_user_roles_user_id").await,
+        "secondary index on user_id must exist"
+    );
+}
+
+#[tokio::test]
+async fn profile_user_roles_rejects_invalid_role_values() {
+    let (_db, pool) = make_db().await;
+
+    // Seed a user first (FK target).
+    sqlx::query(
+        "INSERT INTO users (id, email, name, password_hash)
+         VALUES (1, 'admin@example.com', 'Admin', 'hash')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Accepted value.
+    sqlx::query(
+        "INSERT INTO profile_user_roles (profile_id, user_id, role) VALUES ('demo', 1, 'Admin')",
+    )
+    .execute(&pool)
+    .await
+    .expect("'Admin' is a valid role value");
+
+    // Rejected value — CHECK constraint fires.
+    let bad = sqlx::query(
+        "INSERT INTO profile_user_roles (profile_id, user_id, role) VALUES ('demo', 1, 'Owner')",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+        bad.is_err(),
+        "CHECK constraint must reject role values outside ('Admin', 'User')"
+    );
+}
+
+#[tokio::test]
+async fn last_admin_deactivation_guard_refuses_last_active_admin() {
+    let (db, pool) = make_db().await;
+
+    // Two Admins, both active. Deactivating either is allowed.
+    db.execute_unprepared(
+        "INSERT INTO users (id, email, name, password_hash, role_id, is_active)
+         VALUES (1, 'alice@example.com', 'Alice', 'hash', 1, 1),
+                (2, 'bob@example.com',   'Bob',   'hash', 1, 1)",
+    )
+    .await
+    .unwrap();
+
+    db.execute_unprepared("UPDATE users SET is_active = 0 WHERE id = 2")
+        .await
+        .expect("deactivating a non-last Admin succeeds");
+
+    // Now only one Admin is active. Deactivating the remaining one must abort.
+    let rejected = db
+        .execute_unprepared("UPDATE users SET is_active = 0 WHERE id = 1")
+        .await;
+    assert!(
+        rejected.is_err(),
+        "deactivating the last active Admin must be refused by the trigger"
+    );
+
+    // The row must still be active.
+    let row = sqlx::query("SELECT is_active FROM users WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let is_active: i64 = row.get("is_active");
+    assert_eq!(is_active, 1, "refused UPDATE must not have partial effect");
+}
+
+#[tokio::test]
+async fn last_admin_demote_guard_refuses_role_change_on_last_admin() {
+    let (db, _pool) = make_db().await;
+
+    db.execute_unprepared(
+        "INSERT INTO users (id, email, name, password_hash, role_id, is_active)
+         VALUES (1, 'alice@example.com', 'Alice', 'hash', 1, 1)",
+    )
+    .await
+    .unwrap();
+
+    let rejected = db
+        .execute_unprepared("UPDATE users SET role_id = 2 WHERE id = 1")
+        .await;
+    assert!(
+        rejected.is_err(),
+        "demoting the last active Admin must be refused by the trigger"
+    );
+}
+
+#[tokio::test]
+async fn active_integrations_table_has_expected_shape() {
+    let (_db, pool) = make_db().await;
+
+    assert!(table_exists(&pool, "active_integrations").await);
+
+    let cols = column_names(&pool, "active_integrations").await;
+    assert_eq!(
+        cols,
+        vec![
+            "integration_id",
+            "enabled_at",
+            "credentials_ciphertext",
+            "credentials_nonce",
+            "last_sync_at",
+            "schema_version",
+            "created_at",
+            "updated_at",
+        ],
+        "active_integrations column set changed unexpectedly"
+    );
+
+    assert!(
+        trigger_exists(&pool, "active_integrations_updated_at").await,
+        "updated_at trigger must exist on active_integrations"
+    );
+}
+
+#[tokio::test]
+async fn active_integrations_updated_at_trigger_touches_updated_at() {
+    let (db, pool) = make_db().await;
+
+    db.execute_unprepared(
+        "INSERT INTO active_integrations (integration_id, enabled_at, schema_version)
+         VALUES ('stripe', '2026-04-24T00:00:00Z', 1)",
+    )
+    .await
+    .unwrap();
+
+    let before =
+        sqlx::query("SELECT updated_at FROM active_integrations WHERE integration_id='stripe'")
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .get::<String, _>("updated_at");
+
+    // Sleep one second so strftime() crosses an integer-second boundary.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    db.execute_unprepared(
+        "UPDATE active_integrations SET last_sync_at = '2026-04-24T00:00:01Z' WHERE integration_id='stripe'",
+    )
+    .await
+    .unwrap();
+
+    let after =
+        sqlx::query("SELECT updated_at FROM active_integrations WHERE integration_id='stripe'")
+            .fetch_one(&pool)
+            .await
+            .unwrap()
+            .get::<String, _>("updated_at");
+
+    assert_ne!(before, after, "trigger must update the updated_at column");
+}
+
+#[tokio::test]
+async fn integration_event_log_table_has_expected_shape() {
+    let (_db, pool) = make_db().await;
+
+    assert!(table_exists(&pool, "integration_event_log").await);
+
+    let cols = column_names(&pool, "integration_event_log").await;
+    assert_eq!(
+        cols,
+        vec![
+            "id",
+            "integration_id",
+            "at",
+            "event_type",
+            "status",
+            "error",
+            "payload_redacted",
+        ],
+    );
+
+    assert!(
+        index_exists(&pool, "idx_integration_event_log_integration_at").await,
+        "event log index must exist for integration_id + at lookup"
+    );
+}
+
+#[tokio::test]
+async fn integration_event_log_enforces_status_error_invariant() {
+    let (db, _pool) = make_db().await;
+
+    db.execute_unprepared(
+        "INSERT INTO active_integrations (integration_id, schema_version)
+         VALUES ('stripe', 1)",
+    )
+    .await
+    .unwrap();
+
+    // ok + error NULL is accepted.
+    db.execute_unprepared(
+        "INSERT INTO integration_event_log (integration_id, event_type, status)
+         VALUES ('stripe', 'checkout.session.completed', 'ok')",
+    )
+    .await
+    .expect("ok + error IS NULL satisfies the invariant");
+
+    // error + error NOT NULL is accepted.
+    db.execute_unprepared(
+        "INSERT INTO integration_event_log (integration_id, event_type, status, error)
+         VALUES ('stripe', 'catalog.refresh', 'error', 'upstream 500')",
+    )
+    .await
+    .expect("error + error NOT NULL satisfies the invariant");
+
+    // ok + error NOT NULL is rejected.
+    let mixed_ok = db
+        .execute_unprepared(
+            "INSERT INTO integration_event_log (integration_id, event_type, status, error)
+             VALUES ('stripe', 'catalog.refresh', 'ok', 'should not be here')",
+        )
+        .await;
+    assert!(
+        mixed_ok.is_err(),
+        "ok status with a non-null error column must be rejected"
+    );
+
+    // error + error NULL is rejected.
+    let missing_error = db
+        .execute_unprepared(
+            "INSERT INTO integration_event_log (integration_id, event_type, status)
+             VALUES ('stripe', 'catalog.refresh', 'error')",
+        )
+        .await;
+    assert!(
+        missing_error.is_err(),
+        "error status without a message must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn integration_event_log_fk_requires_integration_row() {
+    let (_db, pool) = make_db().await;
+
+    // Without an active_integrations row, the FK must refuse the insert.
+    sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let orphan = sqlx::query(
+        "INSERT INTO integration_event_log (integration_id, event_type, status)
+         VALUES ('unknown-integration', 'sync.completed', 'ok')",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+        orphan.is_err(),
+        "FK constraint must refuse events for unknown integrations"
+    );
+}

--- a/crates/kikan/tests/m00_platform_migrations.rs
+++ b/crates/kikan/tests/m00_platform_migrations.rs
@@ -245,6 +245,54 @@ async fn active_integrations_updated_at_trigger_touches_updated_at() {
 }
 
 #[tokio::test]
+async fn active_integrations_credential_columns_must_be_symmetric() {
+    let (db, _pool) = make_db().await;
+
+    // Both NULL — zeroed credentials, accepted.
+    db.execute_unprepared(
+        "INSERT INTO active_integrations (integration_id, schema_version)
+         VALUES ('zeroed', 1)",
+    )
+    .await
+    .expect("both credential columns NULL is a valid state");
+
+    // Both NOT NULL — sealed envelope, accepted.
+    db.execute_unprepared(
+        "INSERT INTO active_integrations
+            (integration_id, credentials_ciphertext, credentials_nonce, schema_version)
+         VALUES ('sealed', x'01', x'02', 1)",
+    )
+    .await
+    .expect("both credential columns NOT NULL is a valid state");
+
+    // ciphertext present, nonce NULL — rejected.
+    let ciphertext_only = db
+        .execute_unprepared(
+            "INSERT INTO active_integrations
+                (integration_id, credentials_ciphertext, schema_version)
+             VALUES ('half-ciphertext', x'01', 1)",
+        )
+        .await;
+    assert!(
+        ciphertext_only.is_err(),
+        "ciphertext without nonce must be rejected by the symmetric-nullability CHECK"
+    );
+
+    // nonce present, ciphertext NULL — rejected.
+    let nonce_only = db
+        .execute_unprepared(
+            "INSERT INTO active_integrations
+                (integration_id, credentials_nonce, schema_version)
+             VALUES ('half-nonce', x'02', 1)",
+        )
+        .await;
+    assert!(
+        nonce_only.is_err(),
+        "nonce without ciphertext must be rejected by the symmetric-nullability CHECK"
+    );
+}
+
+#[tokio::test]
 async fn integration_event_log_table_has_expected_shape() {
     let (_db, pool) = make_db().await;
 

--- a/crates/kikan/tests/m00_platform_migrations.rs
+++ b/crates/kikan/tests/m00_platform_migrations.rs
@@ -109,9 +109,11 @@ async fn profile_user_roles_rejects_invalid_role_values() {
     .await
     .expect("'Admin' is a valid role value");
 
-    // Rejected value — CHECK constraint fires.
+    // Rejected value — CHECK constraint fires. Use a distinct (profile_id,
+    // user_id) pair so a PK-conflict failure can't masquerade as a CHECK
+    // failure (the previous insert was ('demo', 1, 'Admin')).
     let bad = sqlx::query(
-        "INSERT INTO profile_user_roles (profile_id, user_id, role) VALUES ('demo', 1, 'Owner')",
+        "INSERT INTO profile_user_roles (profile_id, user_id, role) VALUES ('demo2', 1, 'Owner')",
     )
     .execute(&pool)
     .await;
@@ -222,8 +224,9 @@ async fn active_integrations_updated_at_trigger_touches_updated_at() {
             .unwrap()
             .get::<String, _>("updated_at");
 
-    // Sleep one second so strftime() crosses an integer-second boundary.
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    // Migration uses millisecond-precision strftime ('%f'), so a few ms
+    // is enough for the timestamp to advance.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
 
     db.execute_unprepared(
         "UPDATE active_integrations SET last_sync_at = '2026-04-24T00:00:01Z' WHERE integration_id='stripe'",


### PR DESCRIPTION
## Summary

Second PR in the **M00 kikan admin UI pipeline** (`mokumo/20260423-kikan-admin-ui-m00`). Adds the four SeaORM platform migrations that the M00 admin UI and the install-level integration registry depend on. Base is `main` — independent of [mokumo#667](https://github.com/breezy-bays-labs/mokumo/pull/667), so the two PRs can land in either order.

## Migrations

1. **`m20260424_000000_profile_user_roles`** — install-level `(profile_id, user_id, role)` mapping for the three-tier permission model. `role` column uses a CHECK constraint over `('Admin', 'User')` rather than a FK to `roles`; the two-variant enum is unlikely to grow. FK to `users.id` with `ON DELETE CASCADE`.

2. **`m20260424_000001_prevent_last_admin_deactivation`** — two DB triggers:
   - `users_last_admin_deactivation_guard` — refuses `UPDATE users SET is_active=0` when the target is the last active install Admin.
   - `users_last_admin_demote_guard` — refuses `UPDATE users SET role_id=…` when the target is the last active install Admin.
   
   Enforces the invariant at the DB layer so CLI tools and direct SQL sessions cannot bypass it; the UI still surfaces the same invariant with a toast.

3. **`m20260424_000002_active_integrations`** — install-level integration state. Credentials stored as seal-ed blobs (`credentials_ciphertext` + `credentials_nonce`); AEAD details are opaque to this table (see `adr-mokumo-integrations` §5 for the XChaCha20-Poly1305 envelope). `schema_version` on the row (plaintext envelope) — future per-integration migrations can evolve independently. `enabled_at = NULL` means configured-but-disconnected; `credentials_* = NULL` means credentials zeroed (the T2+sudo disconnect-and-delete path); both states coexist. `updated_at` trigger touches the column on every UPDATE.

4. **`m20260424_000003_integration_event_log`** — per-integration event record. Named `_event_log`, not `_sync_history`, because the three dispatch patterns (sync, webhook, scheduled) are unified here (CAO F4 caught the `_sync_history` leftover from pre-webhook shape). FK to `active_integrations` with `ON DELETE RESTRICT` so column-zeroing the parent (T2+sudo disconnect-and-delete) preserves the audit trail. CHECK ensures `(status='ok' AND error IS NULL) OR (status='error' AND error IS NOT NULL)`.

## Registration

All four registered in `PlatformMigrations::migrations()` with `active_integrations` before `integration_event_log` (FK-order safety). DAG resolution via the migration-runner handles cross-migration dependencies declared via `MigrationRef`.

## Tests

New integration test file `crates/kikan/tests/m00_platform_migrations.rs` — applies the full platform stack against in-memory SQLite and asserts:

- Exact column ordering on `profile_user_roles` + `active_integrations` + `integration_event_log`.
- `profile_user_roles.role` CHECK rejects invalid values.
- Last-Admin deactivation + last-Admin demotion triggers fire as expected (two Admins → deactivate one succeeds; single Admin → deactivate refused; single Admin → role change refused); refused UPDATE must not have partial effect.
- `active_integrations` `updated_at` trigger touches the column on unrelated-column UPDATEs.
- `integration_event_log` CHECK invariant for all four `(status, error)` combinations.
- `integration_event_log` FK refuses orphan rows when `PRAGMA foreign_keys=ON`.

Existing `authenticate_returns_none_for_inactive_user` in `src/auth/backend_tests.rs` now seeds a co-Admin before deactivating the test user — otherwise the new last-Admin trigger refuses the setup operation. The adjustment is commented in the test for future maintainers.

## Verification

- `cargo test -p kikan --lib --tests` — **428 tests green** (9 new, 0 regressions from the `auth::backend` fix above).
- `cargo test -p mokumo-shop --lib` — **173 tests green** (the vertical that consumes `run_platform_migrations`).
- `cargo clippy -p kikan --tests --no-deps -- -D warnings` clean.

## Related

- Pipeline: `mokumo/20260423-kikan-admin-ui-m00`.
- Companion PRs: [mokumo#667](https://github.com/breezy-bays-labs/mokumo/pull/667) (crate scaffold + CompositeSpaSource), [ops#312](https://github.com/breezy-bays-labs/ops/pull/312) (shape-phase ADRs incl. `adr-kikan-admin-ui` §ADR-5 and `adr-mokumo-integrations` §ADR-3/5/6).

## Test plan

- [x] `cargo test -p kikan --lib --tests` green
- [x] `cargo test -p mokumo-shop --lib` green
- [x] `cargo clippy -p kikan --tests --no-deps -- -D warnings` clean
- [ ] CI: mokumo-shop platform_bdd — should still pass (existing fixtures don't hit last-Admin trigger based on local run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents accidental deactivation or demotion of the last administrator at the database level.

* **New Features**
  * Integration state management and tracking.
  * Integration event logging for monitoring and audit purposes.
  * Profile-level user role assignment.

* **Tests**
  * Added comprehensive platform migration tests validating tables, indexes, triggers, and constraints.
  * Adjusted inactive-user authentication test to account for the new deactivation constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->