### PR TITLE
chore(deny): allow BUSL-1.1 for kikan-admin-ui crate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -53,6 +53,7 @@ exceptions = [
     { allow = ["BUSL-1.1"], crate = "kikan-cli" },
     { allow = ["BUSL-1.1"], crate = "mokumo-shop" },
     { allow = ["BUSL-1.1"], crate = "kikan-spa-sveltekit" },
+    { allow = ["BUSL-1.1"], crate = "kikan-admin-ui" },
     { allow = ["BUSL-1.1"], crate = "mokumo-server" },
     { allow = ["BUSL-1.1"], crate = "kikan-events" },
     { allow = ["BUSL-1.1"], crate = "kikan-mail" },


### PR DESCRIPTION
## Summary

PR #667 added the new `kikan-admin-ui` sister crate but did not add it to `deny.toml`'s per-crate `exceptions` list. Since the crate inherits `license.workspace = true` (BUSL-1.1, the workspace default) and BUSL-1.1 is intentionally NOT in the global `licenses.allow` list, cargo-deny rejects it on every workspace check.

This is **why the `security` job has been failing on `main` since 2026-04-25 ~01:11Z**.

## Fix

One line added to `deny.toml`:

```toml
{ allow = ["BUSL-1.1"], crate = "kikan-admin-ui" },
```

Same pattern as every other workspace member (`mokumo-core`, `kikan`, `kikan-spa-sveltekit`, etc.).

## Why per-crate exceptions instead of a global allow

`deny.toml`'s comment block (lines 22, 44–45) explains: BUSL-1.1 is intentionally kept out of the global `allow` so a third-party dependency can't silently slip in under it. Per-crate `exceptions` force a conscious decision every time we add a workspace member that ships under BUSL-1.1.

Note: BUSL-1.1 (Business Source License) is distinct from BSL-1.0 (Boost Software License), which IS in the global `allow` list. Easy to confuse.

## Test plan

- [x] `cargo deny check licenses` (locally) passes
- [ ] `security` CI job goes green on this PR (and unblocks `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)