### PR TITLE
feat(kikan-admin-ui): admin overview dashboard (PR 2A S5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Admin overview dashboard** (PR 2A S5, kikan-admin-ui):
+  - `(app)/+page.svelte` now renders three states based on `GET /api/platform/v1/overview`:
+    - **Fresh install**: a `Get Started with {appName}` Card listing three checklist steps from `overview.get_started_steps`, with branding-bound copy (`appName`, `shopNounSingular`).
+    - **Populated**: a four-region grid — At-a-glance stat strip, Recent activity (each entry is a `<a data-activity-entry>` to its source), Backups (last/next timestamps), System health (ok/degraded/down).
+    - **Backend unavailable**: a dashed-border `overview-unavailable` Card explaining the platform isn't reporting yet — replaces the prior misleading "All systems operational" green dot when no overview data is loaded.
+  - `(app)/+page.ts` adds the loader: tries `fetchPlatform<OverviewData>("/overview")`, returns `{ overview: undefined }` on error so the empty-state branch can render.
+  - "You're set up!" completion banner (`youre-set-up-banner` testid): subscribes to `document.body.dataset.youreSetUp` via `MutationObserver` and auto-dismisses after 500 ms; banner is a sibling overlay so the populated dashboard remains visible during and after.
+  - BDD: closes the four `@pr2a` overview scenarios, taking the @pr2a baseline from 36/40 to **40/40**.
+
 - **Meta DB foundation + target-aware migration dispatch** (#540, M00 PR A wave A0.1):
   - Introduce a process-wide `meta.db` at `<data_dir>/meta.db` carrying install-level state (the runtime profile registry and the cross-profile auth surface).
   - `MigrationTarget` now drives dispatch: kikan ships `runner::run_migrations_for_target(pool, migrations, target)` and `Engine::{run_meta_migrations, run_per_profile_migrations}` so each migration lands on the pool whose role matches its target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - **Fresh install**: a `Get Started with {appName}` Card listing three checklist steps from `overview.get_started_steps`, with branding-bound copy (`appName`, `shopNounSingular`).
     - **Populated**: a four-region grid — At-a-glance stat strip, Recent activity (each entry is a `<a data-activity-entry>` to its source), Backups (last/next timestamps), System health (ok/degraded/down).
     - **Backend unavailable**: a dashed-border `overview-unavailable` Card explaining the platform isn't reporting yet — replaces the prior misleading "All systems operational" green dot when no overview data is loaded.
+    - **System health "unknown"**: when `system_health` is omitted from a populated payload, the System health card now renders a muted "Status unknown" indicator instead of defaulting to green "All systems operational" — the same silent-failure class as the unavailable-payload case, fixed for partial payloads.
   - `(app)/+page.ts` adds the loader: tries `fetchPlatform<OverviewData>("/overview")`, returns `{ overview: undefined }` on error so the empty-state branch can render.
-  - "You're set up!" completion banner (`youre-set-up-banner` testid): subscribes to `document.body.dataset.youreSetUp` via `MutationObserver` and auto-dismisses after 500 ms; banner is a sibling overlay so the populated dashboard remains visible during and after.
+  - "You're set up!" completion banner (`youre-set-up-banner` testid): subscribes to `document.body.dataset.youreSetUp` via `MutationObserver` and auto-dismisses after 3 seconds — long enough for `aria-live="polite"` screen reader announcement to debounce and fire; banner is a sibling overlay so the populated dashboard remains visible during and after.
+  - `formatBackupAt` rejects `Invalid Date` via `Number.isNaN(parsed.getTime())` rather than relying on `new Date` to throw (it doesn't), so malformed timestamps render the original string instead of silently displaying "Invalid Date".
   - BDD: closes the four `@pr2a` overview scenarios, taking the @pr2a baseline from 36/40 to **40/40**.
 
 - **Meta DB foundation + target-aware migration dispatch** (#540, M00 PR A wave A0.1):

--- a/crates/kikan-admin-ui/frontend/src/routes/(app)/+page.svelte
+++ b/crates/kikan-admin-ui/frontend/src/routes/(app)/+page.svelte
@@ -1,21 +1,230 @@
 <script lang="ts">
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card/index.js";
+  import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
+  } from "$lib/components/ui/alert/index.js";
+  import CheckCircle2 from "@lucide/svelte/icons/check-circle-2";
+  import Circle from "@lucide/svelte/icons/circle";
   import { FALLBACK_BRANDING } from "$lib/branding";
 
-  // Body-shell stub. The Get Started checklist + 4-region dashboard land in S5.
-  // The inline brand-token style satisfies the chrome contract test, which
-  // asserts that overview-body carries --brand-* somewhere on its style chain.
+  let { data } = $props();
+
+  let branding = $derived(data.branding ?? FALLBACK_BRANDING);
+  let overview = $derived(data.overview);
+  let overviewLoaded = $derived(overview !== undefined);
+  let isFreshInstall = $derived(overview?.fresh_install ?? false);
+  let healthStatus = $derived(overview?.system_health?.status ?? "ok");
+
+  let bannerVisible = $state(false);
+
+  const BANNER_DISPLAY_MS = 500;
+
+  function formatBackupAt(value: string | null | undefined): string {
+    if (!value) return "—";
+    try {
+      return new Date(value).toLocaleString();
+    } catch {
+      return value;
+    }
+  }
+
+  $effect(() => {
+    if (typeof document === "undefined") return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    function showIfFlagged(): void {
+      if (document.body.dataset.youreSetUp === "true") {
+        bannerVisible = true;
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          bannerVisible = false;
+        }, BANNER_DISPLAY_MS);
+      }
+    }
+
+    showIfFlagged();
+    const obs = new MutationObserver(showIfFlagged);
+    obs.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["data-youre-set-up"],
+    });
+
+    return () => {
+      obs.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  });
 </script>
 
 <section
   data-testid="overview-body"
-  class="p-8"
-  style:--brand-bg={FALLBACK_BRANDING.tokens.bg}
-  style:--brand-fg={FALLBACK_BRANDING.tokens.fg}
-  style:--brand-primary={FALLBACK_BRANDING.tokens.primary}
-  style:--brand-accent={FALLBACK_BRANDING.tokens.accent}
+  class="space-y-6 p-8"
+  style:--brand-bg={branding.tokens.bg}
+  style:--brand-fg={branding.tokens.fg}
+  style:--brand-primary={branding.tokens.primary}
+  style:--brand-accent={branding.tokens.accent}
 >
   <h1 class="text-2xl font-semibold">Overview</h1>
-  <p class="mt-2 text-sm text-muted-foreground">
-    Dashboard regions and Get Started checklist arrive in the next session.
-  </p>
+
+  {#if !overviewLoaded}
+    <Card data-testid="overview-unavailable" class="max-w-2xl border-dashed">
+      <CardHeader>
+        <CardTitle>Dashboard data unavailable</CardTitle>
+        <CardDescription>
+          The {branding.appName} platform isn't reporting overview data yet. Check
+          back once the shop server is online.
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  {:else if isFreshInstall}
+    <Card data-testid="get-started-panel" class="max-w-2xl">
+      <CardHeader>
+        <CardTitle>Get Started with {branding.appName}</CardTitle>
+        <CardDescription>
+          Three quick steps to set up your {branding.shopNounSingular}.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul class="space-y-3">
+          {#each overview?.get_started_steps ?? [] as step (step.id)}
+            <li
+              data-checklist-step
+              data-checklist-step-id={step.id}
+              data-checklist-complete={step.complete}
+              class="flex items-center gap-3"
+            >
+              {#if step.complete}
+                <CheckCircle2 class="size-5 text-primary" aria-hidden="true" />
+              {:else}
+                <Circle
+                  class="size-5 text-muted-foreground"
+                  aria-hidden="true"
+                />
+              {/if}
+              <span class="text-sm">{step.label}</span>
+            </li>
+          {/each}
+        </ul>
+      </CardContent>
+    </Card>
+  {:else}
+    <div class="grid gap-6 md:grid-cols-2">
+      <Card data-testid="overview-stat-strip">
+        <CardHeader>
+          <CardTitle>At a glance</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl class="grid grid-cols-2 gap-4">
+            {#each overview?.stat_strip ?? [] as stat (stat.label)}
+              <div>
+                <dt
+                  class="text-xs uppercase tracking-wide text-muted-foreground"
+                >
+                  {stat.label}
+                </dt>
+                <dd class="mt-1 text-2xl font-semibold">{stat.value}</dd>
+              </div>
+            {/each}
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card data-testid="overview-recent-activity">
+        <CardHeader>
+          <CardTitle>Recent activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul class="space-y-1">
+            {#each overview?.recent_activity ?? [] as entry (entry.id)}
+              <li>
+                <a
+                  data-activity-entry
+                  data-activity-id={entry.id}
+                  href={entry.href}
+                  class="block rounded px-2 py-1.5 text-sm hover:bg-muted"
+                >
+                  {entry.label}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card data-testid="overview-backups">
+        <CardHeader>
+          <CardTitle>Backups</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl class="space-y-2 text-sm">
+            <div class="flex justify-between gap-3">
+              <dt class="text-muted-foreground">Last</dt>
+              <dd>{formatBackupAt(overview?.backups?.last_at)}</dd>
+            </div>
+            <div class="flex justify-between gap-3">
+              <dt class="text-muted-foreground">Next</dt>
+              <dd>{formatBackupAt(overview?.backups?.next_at)}</dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card data-testid="overview-system-health">
+        <CardHeader>
+          <CardTitle>System health</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {#if healthStatus === "ok"}
+            <p class="flex items-center gap-2 text-sm">
+              <span
+                class="inline-block size-2 rounded-full bg-emerald-500"
+                aria-hidden="true"
+              ></span>
+              All systems operational
+            </p>
+          {:else if healthStatus === "degraded"}
+            <p class="flex items-center gap-2 text-sm text-amber-700">
+              <span
+                class="inline-block size-2 rounded-full bg-amber-500"
+                aria-hidden="true"
+              ></span>
+              Degraded
+            </p>
+          {:else}
+            <p class="flex items-center gap-2 text-sm text-destructive">
+              <span
+                class="inline-block size-2 rounded-full bg-destructive"
+                aria-hidden="true"
+              ></span>
+              Down
+            </p>
+          {/if}
+        </CardContent>
+      </Card>
+    </div>
+  {/if}
+
+  {#if bannerVisible}
+    <div
+      data-testid="youre-set-up-banner"
+      role="status"
+      aria-live="polite"
+      class="fixed right-6 bottom-6 z-50 max-w-sm"
+    >
+      <Alert class="border-emerald-500/50 bg-emerald-50 shadow-lg">
+        <AlertTitle>You're set up!</AlertTitle>
+        <AlertDescription>
+          Your {branding.shopNounSingular} is ready to go.
+        </AlertDescription>
+      </Alert>
+    </div>
+  {/if}
 </section>

--- a/crates/kikan-admin-ui/frontend/src/routes/(app)/+page.svelte
+++ b/crates/kikan-admin-ui/frontend/src/routes/(app)/+page.svelte
@@ -21,19 +21,23 @@
   let overview = $derived(data.overview);
   let overviewLoaded = $derived(overview !== undefined);
   let isFreshInstall = $derived(overview?.fresh_install ?? false);
-  let healthStatus = $derived(overview?.system_health?.status ?? "ok");
+  // Missing system_health must NOT default to "ok" — that lies to the user
+  // about platform health when the backend never reported it.
+  let healthStatus = $derived<"ok" | "degraded" | "down" | "unknown">(
+    overview?.system_health?.status ?? "unknown",
+  );
 
   let bannerVisible = $state(false);
 
-  const BANNER_DISPLAY_MS = 500;
+  // 3s threads the needle: long enough for `aria-live="polite"` to debounce
+  // and announce, short enough to feel like a transient confirmation.
+  const BANNER_DISPLAY_MS = 3000;
 
   function formatBackupAt(value: string | null | undefined): string {
     if (!value) return "—";
-    try {
-      return new Date(value).toLocaleString();
-    } catch {
-      return value;
-    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return value;
+    return parsed.toLocaleString();
   }
 
   $effect(() => {
@@ -198,13 +202,21 @@
               ></span>
               Degraded
             </p>
-          {:else}
+          {:else if healthStatus === "down"}
             <p class="flex items-center gap-2 text-sm text-destructive">
               <span
                 class="inline-block size-2 rounded-full bg-destructive"
                 aria-hidden="true"
               ></span>
               Down
+            </p>
+          {:else}
+            <p class="flex items-center gap-2 text-sm text-muted-foreground">
+              <span
+                class="inline-block size-2 rounded-full bg-muted-foreground"
+                aria-hidden="true"
+              ></span>
+              Status unknown
             </p>
           {/if}
         </CardContent>

--- a/crates/kikan-admin-ui/frontend/src/routes/(app)/+page.ts
+++ b/crates/kikan-admin-ui/frontend/src/routes/(app)/+page.ts
@@ -1,0 +1,47 @@
+import { fetchPlatform } from "$lib/platform";
+
+export interface OverviewChecklistStep {
+  id: string;
+  label: string;
+  complete: boolean;
+}
+
+export interface OverviewStat {
+  label: string;
+  value: string;
+}
+
+export interface OverviewActivity {
+  id: string;
+  label: string;
+  href: string;
+}
+
+export interface OverviewBackups {
+  last_at: string | null;
+  next_at: string | null;
+}
+
+export interface OverviewSystemHealth {
+  status: "ok" | "degraded" | "down";
+}
+
+export interface OverviewData {
+  fresh_install: boolean;
+  get_started_steps: OverviewChecklistStep[];
+  stat_strip?: OverviewStat[];
+  recent_activity?: OverviewActivity[];
+  backups?: OverviewBackups;
+  system_health?: OverviewSystemHealth;
+}
+
+export const load = async (): Promise<{
+  overview: OverviewData | undefined;
+}> => {
+  try {
+    const overview = await fetchPlatform<OverviewData>("/overview");
+    return { overview };
+  } catch {
+    return { overview: undefined };
+  }
+};

--- a/crates/kikan-admin-ui/frontend/tests/steps/overview.steps.ts
+++ b/crates/kikan-admin-ui/frontend/tests/steps/overview.steps.ts
@@ -3,7 +3,6 @@ import { Given, Then, When } from "../support/app.fixture";
 import {
   mockAppMeta,
   mockAuthMe,
-  mockBranding,
   mockOverview,
   mockProfiles,
 } from "../support/mocks";
@@ -30,7 +29,9 @@ const POPULATED_OVERVIEW = {
     { label: "Active profiles", value: "2" },
     { label: "Users", value: "5" },
   ],
-  recent_activity: [{ id: "act-1", label: "Profile created", href: "/admin/profiles/p-1" }],
+  recent_activity: [
+    { id: "act-1", label: "Profile created", href: "/admin/profiles/p-1" },
+  ],
   backups: { last_at: "2026-04-24T03:00:00Z", next_at: "2026-04-25T03:00:00Z" },
   system_health: { status: "ok" as const },
 };
@@ -76,11 +77,17 @@ Given("the overview is in the populated state", async ({ page }) => {
   await gotoSignedInOverview(page);
 });
 
-Given("the recent-activity region lists at least one entry", async ({ page }) => {
-  await expect(
-    page.getByTestId("overview-recent-activity").locator("[data-activity-entry]").first(),
-  ).toBeVisible();
-});
+Given(
+  "the recent-activity region lists at least one entry",
+  async ({ page }) => {
+    await expect(
+      page
+        .getByTestId("overview-recent-activity")
+        .locator("[data-activity-entry]")
+        .first(),
+    ).toBeVisible();
+  },
+);
 
 Given("the platform reports no running shops", async ({ page }) => {
   await mockAppMeta(page, {
@@ -115,16 +122,19 @@ Then('I see a "Get Started" panel', async ({ page }) => {
 });
 
 Then("I see three checklist steps", async ({ page }) => {
-  await expect(page.getByTestId("get-started-panel").locator("[data-checklist-step]")).toHaveCount(
-    3,
-  );
+  await expect(
+    page.getByTestId("get-started-panel").locator("[data-checklist-step]"),
+  ).toHaveCount(3);
 });
 
-Then("the steps use the configured app name and shop noun in their copy", async ({ page }) => {
-  const text = await page.getByTestId("get-started-panel").innerText();
-  expect(text).toMatch(/Mokumo/);
-  expect(text).toMatch(/shop/i);
-});
+Then(
+  "the steps use the configured app name and shop noun in their copy",
+  async ({ page }) => {
+    const text = await page.getByTestId("get-started-panel").innerText();
+    expect(text).toMatch(/Mokumo/);
+    expect(text).toMatch(/shop/i);
+  },
+);
 
 Then("the populated dashboard remains visible", async ({ page }) => {
   await expect(page.getByTestId("overview-stat-strip")).toBeVisible();
@@ -151,14 +161,21 @@ Then("I am taken to the screen that owns that entry", async ({ page }) => {
   await expect(page).toHaveURL(/\/admin\/profiles\/p-1/);
 });
 
-Then("the sidebar lists every entry declared in the nav config", async ({ page }) => {
-  const navEntries = page.getByTestId("sidebar-nav").locator("[data-nav-entry]");
-  await expect(navEntries.first()).toBeVisible();
-  expect(await navEntries.count()).toBeGreaterThan(0);
-});
+Then(
+  "the sidebar lists every entry declared in the nav config",
+  async ({ page }) => {
+    const navEntries = page
+      .getByTestId("sidebar-nav")
+      .locator("[data-nav-entry]");
+    await expect(navEntries.first()).toBeVisible();
+    expect(await navEntries.count()).toBeGreaterThan(0);
+  },
+);
 
 Then("each entry's label and href match the nav config", async ({ page }) => {
-  const navEntries = page.getByTestId("sidebar-nav").locator("[data-nav-entry]");
+  const navEntries = page
+    .getByTestId("sidebar-nav")
+    .locator("[data-nav-entry]");
   const count = await navEntries.count();
   expect(count).toBeGreaterThan(0);
   for (let i = 0; i < count; i++) {
@@ -177,13 +194,17 @@ Then("the overview entry in the sidebar is marked active", async ({ page }) => {
 });
 
 Then("no other sidebar entry is marked active", async ({ page }) => {
-  const active = page.getByTestId("sidebar-nav").locator('[data-nav-entry][data-active="true"]');
+  const active = page
+    .getByTestId("sidebar-nav")
+    .locator('[data-nav-entry][data-active="true"]');
   await expect(active).toHaveCount(1);
 });
 
 Then('I see a "PROFILE" divider in the sidebar', async ({ page }) => {
   await expect(page.getByTestId("sidebar-profile-divider")).toBeVisible();
-  await expect(page.getByTestId("sidebar-profile-divider")).toContainText(/PROFILE/);
+  await expect(page.getByTestId("sidebar-profile-divider")).toContainText(
+    /PROFILE/,
+  );
 });
 
 Then("the divider sits above the profile switcher block", async ({ page }) => {
@@ -221,7 +242,9 @@ Then("the topbar does not show a countdown timer", async ({ page }) => {
 });
 
 Then('I see a "No shops to open" tooltip', async ({ page }) => {
-  await expect(page.getByRole("tooltip", { name: /no shops to open/i })).toBeVisible();
+  await expect(
+    page.getByRole("tooltip", { name: /no shops to open/i }),
+  ).toBeVisible();
 });
 
 Then("the affordance is disabled", async ({ page }) => {
@@ -262,28 +285,37 @@ Then(
   },
 );
 
-Then("the topbar, sidebar, and overview body all consume those tokens", async ({ page }) => {
-  for (const testId of ["topbar", "sidebar-nav", "overview-body"]) {
-    const surface = page.getByTestId(testId);
-    // getComputedStyle resolves var() into the final color, so we can't read
-    // the var name back. Inspect the inline cssText where the chrome binds
-    // the tokens, which is the actual contract the chrome promises.
-    const usesToken = await surface.evaluate((el) =>
-      (el as HTMLElement).style.cssText.includes("--brand"),
-    );
-    expect(usesToken).toBe(true);
-  }
-});
+Then(
+  "the topbar, sidebar, and overview body all consume those tokens",
+  async ({ page }) => {
+    for (const testId of ["topbar", "sidebar-nav", "overview-body"]) {
+      const surface = page.getByTestId(testId);
+      // getComputedStyle resolves var() into the final color, so we can't read
+      // the var name back. Inspect the inline cssText where the chrome binds
+      // the tokens, which is the actual contract the chrome promises.
+      const usesToken = await surface.evaluate((el) =>
+        (el as HTMLElement).style.cssText.includes("--brand"),
+      );
+      expect(usesToken).toBe(true);
+    }
+  },
+);
 
-Then("the sidebar and topbar copy use the configured shop noun", async ({ page }) => {
-  await expect(page.getByTestId("sidebar-nav")).toContainText(/kiln/);
-  await expect(page.getByTestId("topbar")).toContainText(/kiln/);
-});
+Then(
+  "the sidebar and topbar copy use the configured shop noun",
+  async ({ page }) => {
+    await expect(page.getByTestId("sidebar-nav")).toContainText(/kiln/);
+    await expect(page.getByTestId("topbar")).toContainText(/kiln/);
+  },
+);
 
-Then("no hard-coded mokumo-shop nouns appear in the chrome", async ({ page }) => {
-  const chromeText = await page
-    .locator('[data-testid="topbar"], [data-testid="sidebar-nav"]')
-    .allInnerTexts();
-  const joined = chromeText.join(" ");
-  expect(joined).not.toMatch(/garment|invoice|quote|customer/i);
-});
+Then(
+  "no hard-coded mokumo-shop nouns appear in the chrome",
+  async ({ page }) => {
+    const chromeText = await page
+      .locator('[data-testid="topbar"], [data-testid="sidebar-nav"]')
+      .allInnerTexts();
+    const joined = chromeText.join(" ");
+    expect(joined).not.toMatch(/garment|invoice|quote|customer/i);
+  },
+);

--- a/crates/kikan-admin-ui/frontend/tests/steps/overview.steps.ts
+++ b/crates/kikan-admin-ui/frontend/tests/steps/overview.steps.ts
@@ -102,7 +102,12 @@ When("I open the admin overview", async ({ page }) => {
 });
 
 When("the configured display duration elapses", async ({ page }) => {
-  await page.waitForTimeout(50);
+  // Mirrors BANNER_DISPLAY_MS in (app)/+page.svelte (3000ms) plus a small
+  // buffer for the setTimeout callback + reactive update to flush. If the
+  // page-side constant changes, bump this to match — otherwise the
+  // toBeHidden() that follows would pass on Playwright's auto-retry budget
+  // alone, masking a broken/missing dismiss timer.
+  await page.waitForTimeout(3100);
 });
 
 When("I click a recent-activity entry", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Closes the four RED `@pr2a` `overview.feature` scenarios — fresh-install Get Started checklist, "You're set up!" auto-dismiss banner, populated 4-region dashboard, recent-activity-entry links — taking the @pr2a baseline from **36/40 → 40/40**.
- Backend-uncoupled (same posture as the rest of PR 2A): the loader tries `GET /api/platform/v1/overview` and falls back to a dashed-border `overview-unavailable` Card on error.
- In-PR dogfood pass surfaced one silent-failure bug ("All systems operational" rendered with a green dot when the backend 404'd, lying about platform health) — fixed in the same commit, before push.

## Implementation notes

- **Loader**: `crates/kikan-admin-ui/frontend/src/routes/(app)/+page.ts` — `fetchPlatform<OverviewData>("/overview")`, returns `{ overview: undefined }` on error so the empty-state branch can render.
- **Three-branch render**:
  - `!overviewLoaded` → empty-state Card with branding-bound copy.
  - `isFreshInstall` → `Get Started with {appName}` Card listing each step from `overview.get_started_steps` (`[data-checklist-step]`).
  - else → 2×2 grid of `overview-stat-strip`, `overview-recent-activity` (each entry a plain `<a data-activity-entry>` to its source), `overview-backups`, `overview-system-health`.
- **Banner overlay**: `MutationObserver` on `document.body` watches `data-youre-set-up`; flipping it sets `bannerVisible=true` and schedules a 500ms auto-dismiss. Banner is a sibling overlay so the populated dashboard remains visible during and after.

## Primitives used

Reuses the 10 shadcn-svelte primitives already in `$lib/components/ui/` from PR 2A (button, input, label, card, dialog, tooltip, alert, skeleton, separator, sonner). No new primitives added — `Card` + `Alert` cover both the checklist panel and the banner cleanly. `Progress`/`Badge`/`Tabs` were considered and rejected (scenarios don't require them).

## Backend coupling

None. Same as PR 2A. The `/api/platform/v1/overview` endpoint doesn't exist on the backend yet; tests use `mockOverview()` (already in `tests/support/mocks.ts`). Real wiring lands when the corresponding control-plane handler ships.

## Dogfood

Local pass run via `pnpm exec tsx` driving Playwright's bundled chromium against `pnpm exec vite dev`. Five states captured under `dogfood-output/admin-overview/screenshots/` (gitignored):

1. `01-fresh-install.png` — Get Started panel + 3 unchecked Circle steps + branding-bound copy.
2. `02-populated.png` — 4-region grid with realistic fixtures (3 active profiles, 8 users, 3 recent activity entries).
3. `03-banner-overlay.png` — emerald `Alert` overlay bottom-right while populated dashboard remains visible.
4. `04-backend-404.png` — empty-state Card with dashed border (post-fix; pre-fix this lied "All systems operational").
5. `05-activity-hover.png` — first activity entry shows muted-bg hover state.

Console clean across all states except a pre-existing SvelteKit warning (`Loading … using window.fetch. For best results, use the fetch that is passed to your load function`) that fires on every `fetchPlatform` call from a load function — also present on `loadBranding` in `(app)/+layout.ts`. Tracked as a follow-up: thread `event.fetch` through `fetchPlatform({ fetch })`.

Full dogfood report: `dogfood-output/admin-overview/report.md`.

## Test plan

- [x] `pnpm bdd-pr2a` reports **40 passed / 0 failed**.
- [x] `pnpm exec svelte-check` clean (0 errors / 0 warnings).
- [x] `pnpm exec oxlint src tests` clean.
- [x] Prettier-formatted (svelte + ts).
- [ ] CI green on the same 23 checks PR 2A passed.
- [ ] CodeRabbit + gemini-code-assist reviews addressed.

## Out of scope (tracked elsewhere)

- 28 `@needs-pr2b` scenarios (auth state + permission tiers) — PR 2B.
- `gen-types` fan-out so kikan-admin-ui frontend gets `OverviewData` automatically from the backend's ts-rs export — known follow-up, currently a hand-rolled interface.
- Threading SvelteKit's `event.fetch` through `fetchPlatform({ fetch })` — pre-existing warning, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin overview dashboard: fresh-install checklist, populated four-region dashboard, and an explicit “backend unavailable” state.
  * Dismissible “You’re set up!” banner that observes a page flag and auto-hides after 3 seconds.
* **Bug Fixes**
  * System health now shows “Status unknown” when health status is missing.
  * Backup timestamp display falls back to the original text on malformed dates.
* **Tests**
  * Acceptance tests updated to cover all overview scenarios (now 40/40).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->