### PR TITLE
feat(kikan): runtime profile sidecar recovery (#540)

### DIFF
--- a/apps/mokumo-server/src/main.rs
+++ b/apps/mokumo-server/src/main.rs
@@ -1493,6 +1493,9 @@ fn build_bootstrap_platform_state(
         is_first_launch: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         setup_completed: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         profile_db_initializer: std::sync::Arc::new(NoOpProfileDbInitializer),
+        sidecar_recoveries: std::sync::Arc::new(parking_lot::RwLock::new(
+            std::collections::HashMap::new(),
+        )),
     }
 }
 

--- a/crates/kikan-types/src/activity.rs
+++ b/crates/kikan-types/src/activity.rs
@@ -29,6 +29,12 @@ pub enum ActivityAction {
     /// path so an operator can correlate the audit entry with the on-disk
     /// rename that followed.
     LegacyUpgradeMigrated,
+    /// The engine's boot-time self-repair pass detected a missing or
+    /// corrupt profile database and force-copied a fresh one from the
+    /// vertical's bundled sidecar. Written to `meta.activity_log`.
+    /// Payload carries the source path, destination path, and bytes
+    /// copied for operator audit.
+    ProfileSidecarRecovered,
 }
 
 impl std::fmt::Display for ActivityAction {
@@ -49,6 +55,7 @@ impl std::fmt::Display for ActivityAction {
             Self::AccountUnlocked => write!(f, "account_unlocked"),
             Self::Bootstrap => write!(f, "bootstrap"),
             Self::LegacyUpgradeMigrated => write!(f, "legacy_upgrade_migrated"),
+            Self::ProfileSidecarRecovered => write!(f, "profile_sidecar_recovered"),
         }
     }
 }
@@ -175,6 +182,10 @@ mod tests {
         assert_eq!(
             ActivityAction::LegacyUpgradeMigrated.to_string(),
             "legacy_upgrade_migrated"
+        );
+        assert_eq!(
+            ActivityAction::ProfileSidecarRecovered.to_string(),
+            "profile_sidecar_recovered"
         );
     }
 }

--- a/crates/kikan/src/data_plane/kikan_version.rs
+++ b/crates/kikan/src/data_plane/kikan_version.rs
@@ -158,6 +158,7 @@ mod tests {
             is_first_launch: Arc::new(AtomicBool::new(false)),
             setup_completed: Arc::new(AtomicBool::new(true)),
             profile_db_initializer: Arc::new(UnreachableInitializer),
+            sidecar_recoveries: Arc::new(parking_lot::RwLock::new(HashMap::new())),
         }
     }
 

--- a/crates/kikan/src/data_plane/router.rs
+++ b/crates/kikan/src/data_plane/router.rs
@@ -267,6 +267,7 @@ mod compose_router_tests {
             is_first_launch: Arc::new(AtomicBool::new(false)),
             setup_completed: Arc::new(AtomicBool::new(true)),
             profile_db_initializer: Arc::new(UnreachableInitializer),
+            sidecar_recoveries: Arc::new(parking_lot::RwLock::new(HashMap::new())),
         };
 
         // Single-connection in-memory pool: migrate + session writes must

--- a/crates/kikan/src/engine.rs
+++ b/crates/kikan/src/engine.rs
@@ -615,10 +615,10 @@ async fn handle_sidecar_outcome(
             );
             None
         }
-        Err(SidecarRecoveryError::Failed { message }) => {
+        Err(SidecarRecoveryError::Failed { source }) => {
             tracing::warn!(
                 profile_dir = %dir_name,
-                error = %message,
+                error = %source,
                 "sidecar recovery: hook reported failure; continuing boot",
             );
             None
@@ -831,7 +831,7 @@ mod sidecar_recovery_tests {
         let got = handle_sidecar_outcome(
             &dir(),
             Err(SidecarRecoveryError::Failed {
-                message: "synthetic".into(),
+                source: "synthetic".into(),
             }),
             &meta,
         )

--- a/crates/kikan/src/engine.rs
+++ b/crates/kikan/src/engine.rs
@@ -274,6 +274,15 @@ impl<G: Graft> Engine<G> {
         let auth_kind = graft.auth_profile_kind();
         let auth_profile_kind_dir = validate_profile_kind::<G>(&auth_kind)?;
 
+        // ── Sidecar recovery (best-effort, never blocks boot) ────────
+        //
+        // Offer each non-setup-wizard profile kind a chance to self-repair
+        // from its bundled sidecar via [`Graft::recover_profile_sidecar`].
+        // Successful recoveries are surfaced on PlatformState; failures
+        // are logged and ignored — a corrupt sidecar must not gate boot.
+        let sidecar_recoveries =
+            maybe_repair_profile_sidecars(graft, &engine.config.data_dir, &meta_db).await;
+
         // ── PlatformState ────────────────────────────────────────────
         let platform = PlatformState {
             data_dir: engine.config.data_dir.clone(),
@@ -291,6 +300,7 @@ impl<G: Graft> Engine<G> {
             is_first_launch: Arc::new(AtomicBool::new(first_launch)),
             setup_completed,
             profile_db_initializer,
+            sidecar_recoveries: Arc::new(RwLock::new(sidecar_recoveries)),
         };
 
         // ── Resolve setup_token via Graft hook ───────────────────────
@@ -492,6 +502,104 @@ async fn dispatch_boot_state<G: Graft>(
             })
         }
     }
+}
+
+/// Offer each non-setup-wizard profile kind a chance to self-repair from
+/// its bundled sidecar via [`Graft::recover_profile_sidecar`], record an
+/// audit row in `meta.activity_log` for each successful recovery, and
+/// return the per-kind diagnostic map for [`PlatformState::sidecar_recoveries`].
+///
+/// Best-effort: a hook returning [`SidecarRecoveryError::Failed`] is logged
+/// at warn level but never blocks boot — a corrupt sidecar must not gate
+/// startup. [`SidecarRecoveryError::NotSupported`] is the silent default
+/// path for verticals that don't bundle a sidecar; logged at debug.
+///
+/// Activity-log writes use `&meta_db` directly (not a transaction) since
+/// each recovery is independent — failure to record one audit row should
+/// not roll back another successful recovery's diagnostic.
+///
+/// Extracted from [`Engine::boot`] so the boot-orchestrator stays under
+/// the CRAP complexity threshold.
+async fn maybe_repair_profile_sidecars<G: Graft>(
+    graft: &G,
+    data_dir: &std::path::Path,
+    meta_db: &DatabaseConnection,
+) -> HashMap<ProfileDirName, crate::meta::SidecarRecoveryDiagnostic> {
+    use crate::graft::{SidecarRecovery, SidecarRecoveryError};
+
+    let mut diagnostics = HashMap::new();
+    for kind in graft.all_profile_kinds() {
+        if graft.requires_setup_wizard(kind) {
+            continue;
+        }
+        let dir_name = match validate_profile_kind::<G>(kind) {
+            Ok(name) => name,
+            Err(err) => {
+                tracing::warn!(error = %err, "skip sidecar recovery: profile kind validation failed");
+                continue;
+            }
+        };
+        match graft.recover_profile_sidecar(kind, data_dir, graft.db_filename()) {
+            Ok(SidecarRecovery::NotNeeded) => {
+                tracing::debug!(profile_dir = %dir_name, "sidecar recovery: healthy, no copy");
+            }
+            Ok(SidecarRecovery::Recreated {
+                source,
+                dest,
+                bytes,
+            }) => {
+                let diagnostic = crate::meta::SidecarRecoveryDiagnostic {
+                    source: source.clone(),
+                    dest: dest.clone(),
+                    bytes,
+                    recovered_at: chrono::Utc::now(),
+                };
+                let payload = serde_json::json!({
+                    "source": source.display().to_string(),
+                    "dest": dest.display().to_string(),
+                    "bytes": bytes,
+                });
+                if let Err(err) = crate::activity::insert_activity_log_raw(
+                    meta_db,
+                    "profile",
+                    dir_name.as_str(),
+                    kikan_types::activity::ActivityAction::ProfileSidecarRecovered,
+                    "system",
+                    "system",
+                    &payload,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        profile_dir = %dir_name,
+                        error = %err,
+                        "sidecar recovery: failed to write meta.activity_log entry; \
+                         diagnostic still surfaced",
+                    );
+                }
+                tracing::info!(
+                    profile_dir = %dir_name,
+                    bytes,
+                    "sidecar recovery: recreated profile database from bundled sidecar",
+                );
+                diagnostics.insert(dir_name, diagnostic);
+            }
+            Err(SidecarRecoveryError::NotSupported) => {
+                tracing::debug!(
+                    profile_dir = %dir_name,
+                    "sidecar recovery: vertical does not bundle a sidecar for this kind",
+                );
+            }
+            Err(SidecarRecoveryError::Failed { message }) => {
+                tracing::warn!(
+                    profile_dir = %dir_name,
+                    error = %message,
+                    "sidecar recovery: hook reported failure; continuing boot",
+                );
+            }
+        }
+    }
+    diagnostics
 }
 
 /// Verify a `ProfileKind` satisfies the two invariants kikan relies on at

--- a/crates/kikan/src/engine.rs
+++ b/crates/kikan/src/engine.rs
@@ -4,8 +4,10 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use axum::Router;
+use chrono::Utc;
 use parking_lot::RwLock;
 use sea_orm::DatabaseConnection;
+use serde_json::json;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tower_sessions_sqlx_store::SqliteStore;
@@ -505,101 +507,158 @@ async fn dispatch_boot_state<G: Graft>(
 }
 
 /// Offer each non-setup-wizard profile kind a chance to self-repair from
-/// its bundled sidecar via [`Graft::recover_profile_sidecar`], record an
-/// audit row in `meta.activity_log` for each successful recovery, and
-/// return the per-kind diagnostic map for [`PlatformState::sidecar_recoveries`].
+/// its bundled sidecar via [`Graft::recover_profile_sidecar`] and return
+/// the per-kind diagnostic map for [`PlatformState::sidecar_recoveries`].
 ///
-/// Best-effort: a hook returning [`SidecarRecoveryError::Failed`] is logged
-/// at warn level but never blocks boot — a corrupt sidecar must not gate
-/// startup. [`SidecarRecoveryError::NotSupported`] is the silent default
-/// path for verticals that don't bundle a sidecar; logged at debug.
-///
-/// Activity-log writes use `&meta_db` directly (not a transaction) since
-/// each recovery is independent — failure to record one audit row should
-/// not roll back another successful recovery's diagnostic.
-///
-/// Extracted from [`Engine::boot`] so the boot-orchestrator stays under
-/// the CRAP complexity threshold.
+/// Per-kind work — hook invocation, activity-log write, diagnostic
+/// construction — is in [`record_sidecar_recovery`]. This loop is the
+/// iteration shell.
 async fn maybe_repair_profile_sidecars<G: Graft>(
     graft: &G,
     data_dir: &std::path::Path,
     meta_db: &DatabaseConnection,
 ) -> HashMap<ProfileDirName, crate::meta::SidecarRecoveryDiagnostic> {
-    use crate::graft::{SidecarRecovery, SidecarRecoveryError};
-
     let mut diagnostics = HashMap::new();
     for kind in graft.all_profile_kinds() {
         if graft.requires_setup_wizard(kind) {
             continue;
         }
-        let dir_name = match validate_profile_kind::<G>(kind) {
-            Ok(name) => name,
-            Err(err) => {
-                tracing::warn!(error = %err, "skip sidecar recovery: profile kind validation failed");
-                continue;
-            }
-        };
-        match graft.recover_profile_sidecar(kind, data_dir, graft.db_filename()) {
-            Ok(SidecarRecovery::NotNeeded) => {
-                tracing::debug!(profile_dir = %dir_name, "sidecar recovery: healthy, no copy");
-            }
-            Ok(SidecarRecovery::Recreated {
-                source,
-                dest,
-                bytes,
-            }) => {
-                let diagnostic = crate::meta::SidecarRecoveryDiagnostic {
-                    source: source.clone(),
-                    dest: dest.clone(),
-                    bytes,
-                    recovered_at: chrono::Utc::now(),
-                };
-                let payload = serde_json::json!({
-                    "source": source.display().to_string(),
-                    "dest": dest.display().to_string(),
-                    "bytes": bytes,
-                });
-                if let Err(err) = crate::activity::insert_activity_log_raw(
-                    meta_db,
-                    "profile",
-                    dir_name.as_str(),
-                    kikan_types::activity::ActivityAction::ProfileSidecarRecovered,
-                    "system",
-                    "system",
-                    &payload,
-                )
-                .await
-                {
-                    tracing::warn!(
-                        profile_dir = %dir_name,
-                        error = %err,
-                        "sidecar recovery: failed to write meta.activity_log entry; \
-                         diagnostic still surfaced",
-                    );
-                }
-                tracing::info!(
-                    profile_dir = %dir_name,
-                    bytes,
-                    "sidecar recovery: recreated profile database from bundled sidecar",
-                );
-                diagnostics.insert(dir_name, diagnostic);
-            }
-            Err(SidecarRecoveryError::NotSupported) => {
-                tracing::debug!(
-                    profile_dir = %dir_name,
-                    "sidecar recovery: vertical does not bundle a sidecar for this kind",
-                );
-            }
-            Err(SidecarRecoveryError::Failed { message }) => {
-                tracing::warn!(
-                    profile_dir = %dir_name,
-                    error = %message,
-                    "sidecar recovery: hook reported failure; continuing boot",
-                );
-            }
+        if let Some((dir_name, diagnostic)) =
+            record_sidecar_recovery::<G>(graft, kind, data_dir, meta_db).await
+        {
+            diagnostics.insert(dir_name, diagnostic);
         }
     }
     diagnostics
+}
+
+/// Validate the profile kind into an opaque [`ProfileDirName`], or log
+/// and return `None` (skipping this kind from recovery).
+///
+/// Generic over `G` because [`validate_profile_kind`] consults the
+/// `Display`/`FromStr` invariants on [`Graft::ProfileKind`].
+fn validate_kind_for_recovery<G: Graft>(kind: &G::ProfileKind) -> Option<ProfileDirName> {
+    match validate_profile_kind::<G>(kind) {
+        Ok(name) => Some(name),
+        Err(err) => {
+            tracing::warn!(error = %err, "skip sidecar recovery: profile kind validation failed");
+            None
+        }
+    }
+}
+
+/// Invoke [`Graft::recover_profile_sidecar`] for one kind, then dispatch
+/// the outcome via [`handle_sidecar_outcome`].
+///
+/// Thin wrapper that exists so [`maybe_repair_profile_sidecars`] doesn't
+/// have to thread the kind validation through every iteration.
+async fn record_sidecar_recovery<G: Graft>(
+    graft: &G,
+    kind: &G::ProfileKind,
+    data_dir: &std::path::Path,
+    meta_db: &DatabaseConnection,
+) -> Option<(ProfileDirName, crate::meta::SidecarRecoveryDiagnostic)> {
+    let dir_name = validate_kind_for_recovery::<G>(kind)?;
+    let outcome = graft.recover_profile_sidecar(kind, data_dir, graft.db_filename());
+    let diagnostic = handle_sidecar_outcome(&dir_name, outcome, meta_db).await?;
+    Some((dir_name, diagnostic))
+}
+
+/// Pure (non-generic) dispatch on a sidecar recovery outcome:
+/// - `NotNeeded` → log debug, return `None`.
+/// - `Recreated` → log info, write `meta.activity_log` audit row,
+///   return the diagnostic.
+/// - `Err(NotSupported)` → log debug, return `None`.
+/// - `Err(Failed)` → log warn, return `None`.
+///
+/// Audit-log write failure is logged but does not suppress the
+/// diagnostic — recoveries are independent and a corrupt audit pool
+/// must not mask a real recovery from the operator UI.
+///
+/// Non-generic so unit tests can drive every arm without setting up a
+/// `Graft` stub.
+async fn handle_sidecar_outcome(
+    dir_name: &ProfileDirName,
+    outcome: Result<crate::graft::SidecarRecovery, crate::graft::SidecarRecoveryError>,
+    meta_db: &DatabaseConnection,
+) -> Option<crate::meta::SidecarRecoveryDiagnostic> {
+    use crate::graft::{SidecarRecovery, SidecarRecoveryError};
+
+    match outcome {
+        Ok(SidecarRecovery::NotNeeded) => {
+            tracing::debug!(profile_dir = %dir_name, "sidecar recovery: healthy, no copy");
+            None
+        }
+        Ok(SidecarRecovery::Recreated {
+            source,
+            dest,
+            bytes,
+        }) => {
+            let diagnostic = crate::meta::SidecarRecoveryDiagnostic {
+                source: source.clone(),
+                dest: dest.clone(),
+                bytes,
+                recovered_at: Utc::now(),
+            };
+            write_sidecar_audit_row(meta_db, dir_name, &source, &dest, bytes).await;
+            tracing::info!(
+                profile_dir = %dir_name,
+                bytes,
+                "sidecar recovery: recreated profile database from bundled sidecar",
+            );
+            Some(diagnostic)
+        }
+        Err(SidecarRecoveryError::NotSupported) => {
+            tracing::debug!(
+                profile_dir = %dir_name,
+                "sidecar recovery: vertical does not bundle a sidecar for this kind",
+            );
+            None
+        }
+        Err(SidecarRecoveryError::Failed { message }) => {
+            tracing::warn!(
+                profile_dir = %dir_name,
+                error = %message,
+                "sidecar recovery: hook reported failure; continuing boot",
+            );
+            None
+        }
+    }
+}
+
+/// Write one `meta.activity_log` audit row for a successful recovery.
+/// Failure is logged at warn level and swallowed — the diagnostic still
+/// surfaces (see [`record_sidecar_recovery`] doc-comment).
+async fn write_sidecar_audit_row(
+    meta_db: &DatabaseConnection,
+    dir_name: &ProfileDirName,
+    source: &std::path::Path,
+    dest: &std::path::Path,
+    bytes: u64,
+) {
+    let payload = json!({
+        "source": source.display().to_string(),
+        "dest": dest.display().to_string(),
+        "bytes": bytes,
+    });
+    if let Err(err) = crate::activity::insert_activity_log_raw(
+        meta_db,
+        "profile",
+        dir_name.as_str(),
+        kikan_types::activity::ActivityAction::ProfileSidecarRecovered,
+        "system",
+        "system",
+        &payload,
+    )
+    .await
+    {
+        tracing::warn!(
+            profile_dir = %dir_name,
+            error = %err,
+            "sidecar recovery: failed to write meta.activity_log entry; \
+             diagnostic still surfaced",
+        );
+    }
 }
 
 /// Verify a `ProfileKind` satisfies the two invariants kikan relies on at
@@ -709,5 +768,121 @@ mod resolve_setup_token_tests {
         std::fs::write(tmp.path(), " \t\n\n").unwrap();
         let got = resolve_setup_token(SetupTokenSource::File(tmp.path().to_path_buf())).unwrap();
         assert!(got.is_none());
+    }
+}
+
+#[cfg(test)]
+mod sidecar_recovery_tests {
+    //! Drive every arm of [`handle_sidecar_outcome`] directly. The fn is
+    //! intentionally non-generic so tests don't need a Graft stub.
+
+    use super::*;
+    use crate::graft::{SidecarRecovery, SidecarRecoveryError};
+    use sea_orm::ConnectionTrait;
+
+    async fn empty_meta_db() -> sea_orm::DatabaseConnection {
+        sea_orm::Database::connect("sqlite::memory:").await.unwrap()
+    }
+
+    /// In-memory meta DB with the `activity_log` table created so
+    /// [`write_sidecar_audit_row`] can succeed. Mirrors the schema kikan
+    /// applies via `m_0003_create_meta_activity_log`.
+    async fn meta_db_with_activity_log() -> sea_orm::DatabaseConnection {
+        let conn = sea_orm::Database::connect("sqlite::memory:").await.unwrap();
+        conn.execute_unprepared(
+            "CREATE TABLE activity_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                actor_id TEXT NOT NULL DEFAULT 'system',
+                actor_type TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )",
+        )
+        .await
+        .unwrap();
+        conn
+    }
+
+    fn dir() -> ProfileDirName {
+        ProfileDirName::from("demo")
+    }
+
+    #[tokio::test]
+    async fn not_needed_returns_none() {
+        let meta = empty_meta_db().await;
+        let got = handle_sidecar_outcome(&dir(), Ok(SidecarRecovery::NotNeeded), &meta).await;
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn not_supported_returns_none() {
+        let meta = empty_meta_db().await;
+        let got =
+            handle_sidecar_outcome(&dir(), Err(SidecarRecoveryError::NotSupported), &meta).await;
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_returns_none_and_continues() {
+        let meta = empty_meta_db().await;
+        let got = handle_sidecar_outcome(
+            &dir(),
+            Err(SidecarRecoveryError::Failed {
+                message: "synthetic".into(),
+            }),
+            &meta,
+        )
+        .await;
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn recreated_writes_audit_and_returns_diagnostic() {
+        let meta = meta_db_with_activity_log().await;
+        let outcome = Ok(SidecarRecovery::Recreated {
+            source: std::path::PathBuf::from("/tmp/src"),
+            dest: std::path::PathBuf::from("/tmp/dest"),
+            bytes: 42,
+        });
+        let got = handle_sidecar_outcome(&dir(), outcome, &meta).await;
+        let diag = got.expect("Recreated yields a diagnostic");
+        assert_eq!(diag.bytes, 42);
+        assert_eq!(diag.dest.as_os_str(), "/tmp/dest");
+        assert_eq!(diag.source.as_os_str(), "/tmp/src");
+
+        use sea_orm::{DbBackend, Statement};
+        let row = meta
+            .query_one_raw(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                "SELECT entity_type, entity_id, action FROM activity_log \
+                 WHERE entity_id = ? AND action = 'profile_sidecar_recovered'",
+                ["demo".into()],
+            ))
+            .await
+            .unwrap()
+            .expect("audit row present");
+        assert_eq!(row.try_get_by_index::<String>(0).unwrap(), "profile");
+        assert_eq!(row.try_get_by_index::<String>(1).unwrap(), "demo");
+        assert_eq!(
+            row.try_get_by_index::<String>(2).unwrap(),
+            "profile_sidecar_recovered"
+        );
+    }
+
+    #[tokio::test]
+    async fn recreated_audit_failure_still_yields_diagnostic() {
+        // Empty meta DB → activity_log table missing → write fails → swallowed.
+        let meta = empty_meta_db().await;
+        let outcome = Ok(SidecarRecovery::Recreated {
+            source: std::path::PathBuf::from("/tmp/src"),
+            dest: std::path::PathBuf::from("/tmp/dest"),
+            bytes: 7,
+        });
+        let got = handle_sidecar_outcome(&dir(), outcome, &meta).await;
+        let diag = got.expect("Recreated yields a diagnostic even when audit insert fails");
+        assert_eq!(diag.bytes, 7);
     }
 }

--- a/crates/kikan/src/graft.rs
+++ b/crates/kikan/src/graft.rs
@@ -231,7 +231,12 @@ pub trait Graft: Sized + 'static {
 /// diagnostic on `PlatformState::sidecar_recoveries` only for the
 /// `Recreated` arm — `NotNeeded` is the silent healthy path and produces
 /// no map entry.
+///
+/// Marked `#[non_exhaustive]` so kikan can add new outcome variants
+/// (e.g. `RestoredFromBackup`) post-1.0 without a breaking change for
+/// downstream verticals.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum SidecarRecovery {
     /// The on-disk database for this kind is healthy; no copy was made.
     NotNeeded,
@@ -245,7 +250,11 @@ pub enum SidecarRecovery {
 }
 
 /// Failure modes for [`Graft::recover_profile_sidecar`].
+///
+/// Marked `#[non_exhaustive]` for the same reason as
+/// [`SidecarRecovery`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SidecarRecoveryError {
     /// The vertical does not bundle a sidecar for this kind. Default
     /// impl on [`Graft::recover_profile_sidecar`] returns this; the
@@ -254,9 +263,13 @@ pub enum SidecarRecoveryError {
     NotSupported,
     /// I/O or integrity-check failure during the recovery attempt. The
     /// engine logs the error and continues boot — recovery is best-effort
-    /// and never blocks startup.
-    #[error("sidecar recovery failed: {message}")]
-    Failed { message: String },
+    /// and never blocks startup. The boxed source preserves the underlying
+    /// error chain so operators can diagnose root cause via the audit log.
+    #[error("sidecar recovery failed: {source}")]
+    Failed {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
 
 #[async_trait::async_trait]

--- a/crates/kikan/src/graft.rs
+++ b/crates/kikan/src/graft.rs
@@ -168,6 +168,43 @@ pub trait Graft: Sized + 'static {
         EMPTY
     }
 
+    // ── Profile sidecar recovery ─────────────────────────────────────
+    //
+    // Verticals may bundle a seed database alongside the binary (a
+    // "sidecar") to back profile kinds that ship with pre-populated data
+    // — preview installs, training data sets, and similar non-blank
+    // profiles. The engine offers each non-setup-wizard profile a chance
+    // to self-repair from its sidecar at boot, so a corrupted or missing
+    // file can be silently recreated without operator intervention.
+    //
+    // Verticals that don't ship a sidecar leave the default impl alone
+    // (which returns `Err(SidecarRecoveryError::NotSupported)`); the
+    // engine logs at debug level and skips that kind. The kind argument
+    // lets a multi-kind vertical attach a sidecar to one kind and not
+    // another.
+
+    /// Inspect the on-disk database for `kind` and recover from the
+    /// vertical's bundled sidecar if the database is missing or fails
+    /// integrity guards. Called once per boot for every kind where
+    /// [`Self::requires_setup_wizard`] returns `false`.
+    ///
+    /// Implementations must be idempotent — a healthy database returns
+    /// [`SidecarRecovery::NotNeeded`] without I/O on the database itself,
+    /// while a failed integrity check triggers a force-copy from the
+    /// sidecar source and returns [`SidecarRecovery::Recreated`].
+    ///
+    /// Verticals without a bundled sidecar leave the default in place;
+    /// the engine treats [`SidecarRecoveryError::NotSupported`] as
+    /// "nothing to do here" and logs at debug level.
+    fn recover_profile_sidecar(
+        &self,
+        _kind: &Self::ProfileKind,
+        _data_dir: &Path,
+        _db_filename: &'static str,
+    ) -> Result<SidecarRecovery, SidecarRecoveryError> {
+        Err(SidecarRecoveryError::NotSupported)
+    }
+
     // ── Data plane composition ───────────────────────────────────────
 
     /// Optional SPA fallback source. Returning `Some(…)` installs the
@@ -186,6 +223,40 @@ pub trait Graft: Sized + 'static {
     fn spa_source(&self) -> Option<Box<dyn crate::data_plane::spa::SpaSource>> {
         None
     }
+}
+
+/// Outcome of [`Graft::recover_profile_sidecar`] on success.
+///
+/// The engine writes a `meta.activity_log` audit entry and surfaces a
+/// diagnostic on `PlatformState::sidecar_recoveries` only for the
+/// `Recreated` arm — `NotNeeded` is the silent healthy path and produces
+/// no map entry.
+#[derive(Debug, Clone)]
+pub enum SidecarRecovery {
+    /// The on-disk database for this kind is healthy; no copy was made.
+    NotNeeded,
+    /// The on-disk database was missing or failed integrity guards and
+    /// was replaced with a fresh copy from the bundled sidecar.
+    Recreated {
+        source: PathBuf,
+        dest: PathBuf,
+        bytes: u64,
+    },
+}
+
+/// Failure modes for [`Graft::recover_profile_sidecar`].
+#[derive(Debug, thiserror::Error)]
+pub enum SidecarRecoveryError {
+    /// The vertical does not bundle a sidecar for this kind. Default
+    /// impl on [`Graft::recover_profile_sidecar`] returns this; the
+    /// engine logs at debug level and skips the kind.
+    #[error("vertical does not bundle a sidecar for this profile kind")]
+    NotSupported,
+    /// I/O or integrity-check failure during the recovery attempt. The
+    /// engine logs the error and continues boot — recovery is best-effort
+    /// and never blocks startup.
+    #[error("sidecar recovery failed: {message}")]
+    Failed { message: String },
 }
 
 #[async_trait::async_trait]

--- a/crates/kikan/src/lib.rs
+++ b/crates/kikan/src/lib.rs
@@ -91,10 +91,10 @@ pub use error::{
     ActivityWriteError, AppHandleError, DagError, DomainError, EngineError, MigrationError,
     TenancyError,
 };
-pub use graft::{Graft, SelfGraft, SubGraft};
+pub use graft::{Graft, SelfGraft, SidecarRecovery, SidecarRecoveryError, SubGraft};
 pub use meta::{
     BootState, BootStateDetectionError, Profile, ProfileRepo, ProfileRepoError, SeaOrmProfileRepo,
-    detect_boot_state,
+    SidecarRecoveryDiagnostic, detect_boot_state,
 };
 pub use migrations::{GraftId, Migration, MigrationRef, MigrationTarget};
 pub use platform_state::{MdnsStatus, PlatformState, SharedMdnsStatus};

--- a/crates/kikan/src/meta/diagnostics.rs
+++ b/crates/kikan/src/meta/diagnostics.rs
@@ -1,0 +1,29 @@
+//! Diagnostics surfaced by [`crate::Engine::boot`] for operator
+//! consumption over the UDS admin surface.
+//!
+//! Currently scoped to sidecar recovery — the engine writes one entry
+//! per profile kind that was force-copied from its bundled sidecar at
+//! boot. The map remains empty for healthy installs; entries are
+//! cleared only by restart (the next boot rebuilds the map from
+//! scratch).
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One sidecar recovery diagnostic — emitted when the engine's
+/// boot-time self-repair pass detects a missing or corrupt profile
+/// database and force-copies a fresh one from the vertical's bundled
+/// sidecar.
+///
+/// Surfaced via the UDS admin socket so an operator UI can render a
+/// banner when bundled-data profiles were restored from the sidecar at
+/// boot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarRecoveryDiagnostic {
+    pub source: PathBuf,
+    pub dest: PathBuf,
+    pub bytes: u64,
+    pub recovered_at: DateTime<Utc>,
+}

--- a/crates/kikan/src/meta/mod.rs
+++ b/crates/kikan/src/meta/mod.rs
@@ -8,10 +8,12 @@
 //! M00 meta-DB introduction shape.
 
 pub mod boot_state;
+pub mod diagnostics;
 pub mod entity;
 pub mod profiles;
 pub mod upgrade;
 
 pub use boot_state::{AbandonReason, BootState, BootStateDetectionError, detect_boot_state};
+pub use diagnostics::SidecarRecoveryDiagnostic;
 pub use profiles::{Profile, ProfileRepo, ProfileRepoError, SeaOrmProfileRepo};
 pub use upgrade::{UpgradeError, UpgradeOutcome, run_legacy_upgrade};

--- a/crates/kikan/src/platform_state.rs
+++ b/crates/kikan/src/platform_state.rs
@@ -139,6 +139,19 @@ pub struct PlatformState {
     /// behind `Arc<dyn …>` so kikan does not depend on any vertical
     /// migrator (preserves I4).
     pub profile_db_initializer: SharedProfileDbInitializer,
+    /// Per-kind sidecar recoveries surfaced by [`crate::Engine::boot`].
+    ///
+    /// The engine offers each non-setup-wizard profile kind a chance to
+    /// self-repair from its bundled sidecar at boot via
+    /// [`crate::Graft::recover_profile_sidecar`]. Successful recoveries
+    /// land here as one map entry per recovered kind, keyed by the
+    /// profile directory name. Healthy kinds produce no entry; the map
+    /// stays empty for installs that booted cleanly.
+    ///
+    /// Read-only after boot. UDS admin handlers expose the map as
+    /// `GET /admin/v1/diagnostics/sidecar-recoveries`.
+    pub sidecar_recoveries:
+        Arc<RwLock<HashMap<ProfileDirName, crate::meta::SidecarRecoveryDiagnostic>>>,
 }
 
 impl PlatformState {

--- a/crates/kikan/tests/support/stub_graft.rs
+++ b/crates/kikan/tests/support/stub_graft.rs
@@ -147,6 +147,7 @@ pub fn stub_app_state(
         is_first_launch: Arc::new(AtomicBool::new(false)),
         setup_completed: Arc::new(AtomicBool::new(false)),
         profile_db_initializer: Arc::new(NoOpProfileDbInitializer),
+        sidecar_recoveries: Arc::new(RwLock::new(std::collections::HashMap::new())),
     };
     let control_plane = kikan::ControlPlaneState {
         platform,

--- a/crates/mokumo-shop/src/admin/router.rs
+++ b/crates/mokumo-shop/src/admin/router.rs
@@ -29,6 +29,10 @@ pub fn build_admin_router(state: PlatformState) -> Router {
         .route("/health", get(health))
         .route("/diagnostics", get(diagnostics))
         .route("/diagnostics/bundle", get(diagnostics_bundle))
+        .route(
+            "/diagnostics/sidecar-recoveries",
+            get(sidecar_recoveries_list),
+        )
         .route("/profiles", get(profiles_list))
         .route("/profiles/switch", post(profiles_switch))
         .route("/migrate/status", get(migrate_status))
@@ -51,6 +55,17 @@ async fn diagnostics(
             tracing::error!("admin UDS diagnostics failed: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })
+}
+
+async fn sidecar_recoveries_list(
+    State(state): State<PlatformState>,
+) -> Json<std::collections::HashMap<String, kikan::SidecarRecoveryDiagnostic>> {
+    let map = state.sidecar_recoveries.read();
+    Json(
+        map.iter()
+            .map(|(k, v)| (k.as_str().to_string(), v.clone()))
+            .collect(),
+    )
 }
 
 async fn diagnostics_bundle(

--- a/crates/mokumo-shop/src/demo_reset.rs
+++ b/crates/mokumo-shop/src/demo_reset.rs
@@ -210,7 +210,12 @@ pub fn force_copy_sidecar(data_dir: &Path) -> Result<(), std::io::Error> {
 /// Locate the demo.db sidecar file.
 ///
 /// Priority: MOKUMO_DEMO_SIDECAR env var > co-located demo.db next to binary.
-fn find_sidecar() -> Option<std::path::PathBuf> {
+///
+/// Public so callers that need to *report* the resolved source (e.g.
+/// the boot-time sidecar recovery diagnostic) can use the same
+/// resolution logic the copy primitive uses internally — single source
+/// of truth.
+pub fn find_sidecar() -> Option<std::path::PathBuf> {
     // 1. Env var
     if let Ok(path) = std::env::var("MOKUMO_DEMO_SIDECAR") {
         let p = std::path::PathBuf::from(&path);

--- a/crates/mokumo-shop/src/demo_reset.rs
+++ b/crates/mokumo-shop/src/demo_reset.rs
@@ -34,7 +34,7 @@ pub async fn demo_reset(
     demo_db.get_sqlite_connection_pool().close().await;
 
     // Force-copy fresh sidecar over the demo database.
-    if let Err(e) = force_copy_sidecar(&state.data_dir) {
+    if let Err(e) = force_copy_sidecar(&state.data_dir, state.db_filename) {
         tracing::error!("Demo reset: failed to copy sidecar: {e}");
         return Err(AppError::InternalError(
             "Failed to reset demo database".into(),
@@ -140,17 +140,28 @@ pub fn copy_sidecar_if_needed(data_dir: &Path) -> Result<bool, std::io::Error> {
     }
 }
 
-/// Force-copy the demo sidecar database to `data_dir/demo/mokumo.db`,
-/// replacing any existing file. Used by the reset endpoint.
+/// Force-copy the demo sidecar database to `data_dir/demo/<db_filename>`,
+/// replacing any existing file. Used by the reset endpoint and the boot-time
+/// sidecar recovery hook.
+///
+/// `db_filename` is the bare leaf name (e.g. `"mokumo.db"`) — caller threads
+/// it from the graft so the destination here matches the destination the
+/// caller computed.
+///
+/// Returns the resolved sidecar source path on success so callers reporting
+/// the recovery (e.g. the diagnostic surfaced at
+/// `/admin/v1/diagnostics/sidecar-recoveries`) describe the same path the
+/// copy actually consumed — single source of truth for the resolver.
 ///
 /// Strategy: copies to a temp file, then atomic-renames over the destination.
 /// On Windows (where rename fails with open handles), falls back to
 /// remove + rename. Callers should close the connection pool first.
-///
-/// Returns an error if no sidecar can be found.
-pub fn force_copy_sidecar(data_dir: &Path) -> Result<(), std::io::Error> {
+pub fn force_copy_sidecar(
+    data_dir: &Path,
+    db_filename: &str,
+) -> Result<std::path::PathBuf, std::io::Error> {
     let demo_dir = data_dir.join("demo");
-    let dest = demo_dir.join("mokumo.db");
+    let dest = demo_dir.join(db_filename);
     let src = find_sidecar().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -161,7 +172,7 @@ pub fn force_copy_sidecar(data_dir: &Path) -> Result<(), std::io::Error> {
     std::fs::create_dir_all(&demo_dir)?;
 
     // Copy to a temp file in the same directory (same filesystem = atomic rename)
-    let tmp = demo_dir.join("mokumo.db.tmp");
+    let tmp = demo_dir.join(format!("{db_filename}.tmp"));
     std::fs::copy(&src, &tmp)?;
 
     // Atomic rename replaces the destination without truncating the live file.
@@ -189,9 +200,9 @@ pub fn force_copy_sidecar(data_dir: &Path) -> Result<(), std::io::Error> {
         })?;
     }
 
-    // Remove WAL/SHM files — they belong to the old DB
-    for suffix in &["mokumo.db-wal", "mokumo.db-shm"] {
-        let path = demo_dir.join(suffix);
+    // Remove WAL/SHM sidecars — they belong to the old DB
+    for suffix in [format!("{db_filename}-wal"), format!("{db_filename}-shm")] {
+        let path = demo_dir.join(&suffix);
         if let Err(e) = std::fs::remove_file(&path)
             && e.kind() != std::io::ErrorKind::NotFound
         {
@@ -204,7 +215,7 @@ pub fn force_copy_sidecar(data_dir: &Path) -> Result<(), std::io::Error> {
         src.display(),
         dest.display()
     );
-    Ok(())
+    Ok(src)
 }
 
 /// Locate the demo.db sidecar file.
@@ -309,7 +320,8 @@ mod tests {
 
         let _guard = EnvVarGuard::set("MOKUMO_DEMO_SIDECAR", sidecar_path.to_str().unwrap());
 
-        force_copy_sidecar(&data_dir).unwrap();
+        let returned_src = force_copy_sidecar(&data_dir, "mokumo.db").unwrap();
+        assert_eq!(returned_src, sidecar_path);
 
         let content = std::fs::read(data_dir.join("demo").join("mokumo.db")).unwrap();
         assert_eq!(content, b"fresh-data");
@@ -324,7 +336,7 @@ mod tests {
 
         let _guard = EnvVarGuard::remove("MOKUMO_DEMO_SIDECAR");
 
-        let result = force_copy_sidecar(&data_dir);
+        let result = force_copy_sidecar(&data_dir, "mokumo.db");
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
     }
@@ -344,7 +356,7 @@ mod tests {
 
         let _guard = EnvVarGuard::set("MOKUMO_DEMO_SIDECAR", sidecar_path.to_str().unwrap());
 
-        force_copy_sidecar(&data_dir).unwrap();
+        force_copy_sidecar(&data_dir, "mokumo.db").unwrap();
 
         assert!(!data_dir.join("demo").join("mokumo.db-wal").exists());
         assert!(!data_dir.join("demo").join("mokumo.db-shm").exists());

--- a/crates/mokumo-shop/src/graft.rs
+++ b/crates/mokumo-shop/src/graft.rs
@@ -141,6 +141,69 @@ impl Graft for MokumoApp {
         SetupMode::Production
     }
 
+    fn recover_profile_sidecar(
+        &self,
+        kind: &SetupMode,
+        data_dir: &std::path::Path,
+        db_filename: &'static str,
+    ) -> Result<kikan::SidecarRecovery, kikan::SidecarRecoveryError> {
+        // Mokumo bundles a sidecar only for the demo profile — the
+        // primary profile starts blank and is filled by the setup wizard.
+        if !matches!(kind, SetupMode::Demo) {
+            return Err(kikan::SidecarRecoveryError::NotSupported);
+        }
+
+        let dest = data_dir.join(kind.as_str()).join(db_filename);
+
+        // Skip recovery if the destination database is present and passes
+        // the kikan application_id guard (guard 1 from
+        // adr-database-startup-guard-chain.md). Guards 2 + 3 (auto_vacuum,
+        // schema compatibility) run later in setup_profile_db on the
+        // re-opened pool — those failures are surfaced as boot errors,
+        // not silently repaired here. Sidecar recovery exists for the
+        // missing-file and corrupt-application_id cases.
+        if dest.try_exists().unwrap_or(false) && kikan::db::check_application_id(&dest).is_ok() {
+            return Ok(kikan::SidecarRecovery::NotNeeded);
+        }
+
+        // crate::demo_reset::force_copy_sidecar resolves the source via
+        // the MOKUMO_DEMO_SIDECAR env var or the binary-adjacent
+        // `demo.db` file. Returning `Failed` here preserves the
+        // best-effort contract: a missing sidecar means we couldn't
+        // self-repair, but boot continues and the operator sees the
+        // existing-but-corrupt file (which the per-profile setup will
+        // surface separately).
+        crate::demo_reset::force_copy_sidecar(data_dir).map_err(|e| {
+            kikan::SidecarRecoveryError::Failed {
+                message: format!("force_copy_sidecar({}): {e}", data_dir.display()),
+            }
+        })?;
+
+        let bytes = std::fs::metadata(&dest).map(|m| m.len()).map_err(|e| {
+            kikan::SidecarRecoveryError::Failed {
+                message: format!("stat {}: {e}", dest.display()),
+            }
+        })?;
+
+        // The source path is best-effort — `force_copy_sidecar` resolves
+        // it internally and doesn't return it. Recompute via the same
+        // env-var-then-binary-adjacent fallback for the diagnostic.
+        let source = std::env::var_os("MOKUMO_DEMO_SIDECAR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| {
+                std::env::current_exe()
+                    .ok()
+                    .and_then(|p| p.parent().map(|d| d.join("demo.db")))
+                    .unwrap_or_else(|| std::path::PathBuf::from("<unknown>"))
+            });
+
+        Ok(kikan::SidecarRecovery::Recreated {
+            source,
+            dest,
+            bytes,
+        })
+    }
+
     fn migrations(&self) -> Vec<Box<dyn Migration>> {
         let seaorm_migrations = Migrator::migrations();
         let names: Vec<&'static str> = vec![

--- a/crates/mokumo-shop/src/graft.rs
+++ b/crates/mokumo-shop/src/graft.rs
@@ -185,17 +185,11 @@ impl Graft for MokumoApp {
             }
         })?;
 
-        // The source path is best-effort — `force_copy_sidecar` resolves
-        // it internally and doesn't return it. Recompute via the same
-        // env-var-then-binary-adjacent fallback for the diagnostic.
-        let source = std::env::var_os("MOKUMO_DEMO_SIDECAR")
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| {
-                std::env::current_exe()
-                    .ok()
-                    .and_then(|p| p.parent().map(|d| d.join("demo.db")))
-                    .unwrap_or_else(|| std::path::PathBuf::from("<unknown>"))
-            });
+        // Re-use the same resolver `force_copy_sidecar` consulted, so
+        // the diagnostic always reports the actual source path (even if
+        // resolution rules grow new fallback locations later).
+        let source = crate::demo_reset::find_sidecar()
+            .unwrap_or_else(|| std::path::PathBuf::from("<unknown>"));
 
         Ok(kikan::SidecarRecovery::Recreated {
             source,

--- a/crates/mokumo-shop/src/graft.rs
+++ b/crates/mokumo-shop/src/graft.rs
@@ -166,30 +166,26 @@ impl Graft for MokumoApp {
             return Ok(kikan::SidecarRecovery::NotNeeded);
         }
 
-        // crate::demo_reset::force_copy_sidecar resolves the source via
-        // the MOKUMO_DEMO_SIDECAR env var or the binary-adjacent
-        // `demo.db` file. Returning `Failed` here preserves the
+        // `force_copy_sidecar` resolves the source via MOKUMO_DEMO_SIDECAR or
+        // the binary-adjacent `demo.db`, copies it over the destination, and
+        // returns the *resolved source path* — so the diagnostic below
+        // describes the exact file the copy consumed (no double-resolution,
+        // no TOCTOU window). Returning `Failed` here preserves the
         // best-effort contract: a missing sidecar means we couldn't
         // self-repair, but boot continues and the operator sees the
         // existing-but-corrupt file (which the per-profile setup will
         // surface separately).
-        crate::demo_reset::force_copy_sidecar(data_dir).map_err(|e| {
+        let source = crate::demo_reset::force_copy_sidecar(data_dir, db_filename).map_err(|e| {
             kikan::SidecarRecoveryError::Failed {
-                message: format!("force_copy_sidecar({}): {e}", data_dir.display()),
+                source: Box::new(e),
             }
         })?;
 
         let bytes = std::fs::metadata(&dest).map(|m| m.len()).map_err(|e| {
             kikan::SidecarRecoveryError::Failed {
-                message: format!("stat {}: {e}", dest.display()),
+                source: Box::new(e),
             }
         })?;
-
-        // Re-use the same resolver `force_copy_sidecar` consulted, so
-        // the diagnostic always reports the actual source path (even if
-        // resolution rules grow new fallback locations later).
-        let source = crate::demo_reset::find_sidecar()
-            .unwrap_or_else(|| std::path::PathBuf::from("<unknown>"));
 
         Ok(kikan::SidecarRecovery::Recreated {
             source,

--- a/crates/mokumo-shop/src/startup.rs
+++ b/crates/mokumo-shop/src/startup.rs
@@ -265,9 +265,15 @@ async fn setup_profile_db(
                     "Demo database has unknown migrations from newer Mokumo version; \
                      resetting to fresh demo data."
                 );
-                crate::demo_reset::force_copy_sidecar(data_dir).map_err(|e| ProfileDbError {
-                    message: format!("Failed to reset demo database: {e}"),
-                    backup_path: backup_path.clone(),
+                let db_filename = db_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("mokumo.db");
+                crate::demo_reset::force_copy_sidecar(data_dir, db_filename).map_err(|e| {
+                    ProfileDbError {
+                        message: format!("Failed to reset demo database: {e}"),
+                        backup_path: backup_path.clone(),
+                    }
                 })?;
                 if db_path.exists() {
                     kikan::db::check_application_id(db_path).map_err(|e| match e {

--- a/crates/mokumo-shop/tests/admin_uds.rs
+++ b/crates/mokumo-shop/tests/admin_uds.rs
@@ -60,6 +60,7 @@ fn build_test_platform_state(
         is_first_launch: Arc::new(AtomicBool::new(false)),
         setup_completed: Arc::new(AtomicBool::new(false)),
         profile_db_initializer: Arc::new(NoOpInit),
+        sidecar_recoveries: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
     }
 }
 

--- a/crates/mokumo-shop/tests/platform_bdd_world/mod.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/mod.rs
@@ -6,6 +6,7 @@ mod install_validation_steps;
 mod legacy_refuse_boot_steps;
 mod migration_safety_steps;
 mod restore_steps;
+mod sidecar_recovery_steps;
 mod storage_diagnostics_steps;
 
 #[derive(Debug, World)]
@@ -40,6 +41,8 @@ pub struct PlatformBddWorld {
     pub restore_production_dir: Option<std::path::PathBuf>,
     // Legacy-install refusal scenario state
     pub legacy_refuse: Option<legacy_refuse_boot_steps::LegacyRefuseCtx>,
+    // Sidecar recovery scenario state
+    pub sidecar_recovery: Option<sidecar_recovery_steps::SidecarRecoveryCtx>,
 }
 
 impl PlatformBddWorld {
@@ -73,6 +76,7 @@ impl PlatformBddWorld {
             restore_copy_result: None,
             restore_production_dir: None,
             legacy_refuse: None,
+            sidecar_recovery: None,
         }
     }
 }

--- a/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
@@ -17,9 +17,17 @@ const VERTICAL_DB_FILE: &str = "mokumo.db";
 /// after A's `Given` set it but before A's `When` reads it. This mutex
 /// serializes any scenario that mutates the env var for its full
 /// lifetime (acquired in the `Given`, released when the ctx drops).
-fn sidecar_env_lock() -> &'static parking_lot::Mutex<()> {
-    static LOCK: std::sync::OnceLock<parking_lot::Mutex<()>> = std::sync::OnceLock::new();
-    LOCK.get_or_init(|| parking_lot::Mutex::new(()))
+///
+/// Uses `tokio::sync::Mutex` (not `parking_lot::Mutex`) because cucumber
+/// schedules scenarios as tokio tasks: a sync mutex held across `.await`
+/// blocks the worker thread, and with enough contention every worker
+/// thread can end up parked on the lock with nobody left to run the
+/// holding task to completion (deadlock). The async mutex yields the
+/// task instead.
+fn sidecar_env_lock() -> Arc<tokio::sync::Mutex<()>> {
+    static LOCK: std::sync::OnceLock<Arc<tokio::sync::Mutex<()>>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
 }
 
 pub struct SidecarRecoveryCtx {
@@ -33,8 +41,9 @@ pub struct SidecarRecoveryCtx {
     pub boot_result: Option<Result<(), EngineError>>,
     /// Held for the lifetime of the scenario; dropped together with the
     /// env-var reset so the lock is released only after this scenario's
-    /// stale path is gone.
-    _env_guard: parking_lot::MutexGuard<'static, ()>,
+    /// stale path is gone. `OwnedMutexGuard` keeps the guard `'static`
+    /// so it can live as a struct field on the World-owned ctx.
+    _env_guard: tokio::sync::OwnedMutexGuard<()>,
 }
 
 // Cucumber's `World` derive needs `Debug`; `MutexGuard` doesn't impl it.
@@ -82,7 +91,7 @@ async fn given_sidecar_present_db_missing(w: &mut PlatformBddWorld) {
     // acquiring the lock again — otherwise we'd deadlock with our own
     // World's prior scenario remnant.
     w.sidecar_recovery = None;
-    let env_guard = sidecar_env_lock().lock();
+    let env_guard = sidecar_env_lock().lock_owned().await;
     let dir = tempfile::tempdir().unwrap();
     let sidecar = dir.path().join("seed-demo.db");
     write_kikan_seed_db(&sidecar);
@@ -104,7 +113,7 @@ async fn given_sidecar_present_db_missing(w: &mut PlatformBddWorld) {
 #[given("a fresh data directory with a bundled demo sidecar and a healthy demo database file")]
 async fn given_sidecar_and_healthy_db(w: &mut PlatformBddWorld) {
     w.sidecar_recovery = None;
-    let env_guard = sidecar_env_lock().lock();
+    let env_guard = sidecar_env_lock().lock_owned().await;
     let dir = tempfile::tempdir().unwrap();
     let sidecar = dir.path().join("seed-demo.db");
     write_kikan_seed_db(&sidecar);

--- a/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
@@ -23,6 +23,19 @@ pub struct SidecarRecoveryCtx {
     pub boot_result: Option<Result<(), EngineError>>,
 }
 
+impl Drop for SidecarRecoveryCtx {
+    fn drop(&mut self) {
+        // The given-steps set MOKUMO_DEMO_SIDECAR; unset it so the path
+        // (which points into a TempDir that's about to be deleted) does
+        // not leak into later cucumber scenarios in the same process.
+        // SAFETY: cucumber serial harness — see set_var rationale in
+        // `given_sidecar_present_db_missing`.
+        unsafe {
+            std::env::remove_var("MOKUMO_DEMO_SIDECAR");
+        }
+    }
+}
+
 fn write_kikan_seed_db(path: &std::path::Path) {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).unwrap();

--- a/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
@@ -11,7 +11,17 @@ use super::PlatformBddWorld;
 
 const VERTICAL_DB_FILE: &str = "mokumo.db";
 
-#[derive(Debug)]
+/// Process-wide guard around `MOKUMO_DEMO_SIDECAR`. cucumber-rs runs
+/// scenarios concurrently by default, so two scenarios in this feature
+/// would otherwise race on the env var: B's `Drop` could unset the var
+/// after A's `Given` set it but before A's `When` reads it. This mutex
+/// serializes any scenario that mutates the env var for its full
+/// lifetime (acquired in the `Given`, released when the ctx drops).
+fn sidecar_env_lock() -> &'static parking_lot::Mutex<()> {
+    static LOCK: std::sync::OnceLock<parking_lot::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| parking_lot::Mutex::new(()))
+}
+
 pub struct SidecarRecoveryCtx {
     pub data_dir: tempfile::TempDir,
     #[allow(dead_code)]
@@ -21,15 +31,30 @@ pub struct SidecarRecoveryCtx {
     pub meta_pool: Option<DatabaseConnection>,
     pub recoveries: Option<std::collections::HashMap<String, kikan::SidecarRecoveryDiagnostic>>,
     pub boot_result: Option<Result<(), EngineError>>,
+    /// Held for the lifetime of the scenario; dropped together with the
+    /// env-var reset so the lock is released only after this scenario's
+    /// stale path is gone.
+    _env_guard: parking_lot::MutexGuard<'static, ()>,
+}
+
+// Cucumber's `World` derive needs `Debug`; `MutexGuard` doesn't impl it.
+impl std::fmt::Debug for SidecarRecoveryCtx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SidecarRecoveryCtx")
+            .field("data_dir", &self.data_dir.path())
+            .field("sidecar_path", &self.sidecar_path)
+            .field("recoveries", &self.recoveries)
+            .field("boot_result", &self.boot_result)
+            .finish()
+    }
 }
 
 impl Drop for SidecarRecoveryCtx {
     fn drop(&mut self) {
-        // The given-steps set MOKUMO_DEMO_SIDECAR; unset it so the path
-        // (which points into a TempDir that's about to be deleted) does
-        // not leak into later cucumber scenarios in the same process.
-        // SAFETY: cucumber serial harness — see set_var rationale in
-        // `given_sidecar_present_db_missing`.
+        // Unset the env var BEFORE releasing the lock so a queued
+        // scenario can't observe this scenario's now-deleted TempDir
+        // path. SAFETY: while `_env_guard` is held no other
+        // sidecar-recovery scenario is touching the env var.
         unsafe {
             std::env::remove_var("MOKUMO_DEMO_SIDECAR");
         }
@@ -53,12 +78,16 @@ fn write_kikan_seed_db(path: &std::path::Path) {
 
 #[given("a fresh data directory with a bundled demo sidecar but no demo database file")]
 async fn given_sidecar_present_db_missing(w: &mut PlatformBddWorld) {
+    // Drop any in-flight previous ctx (and its env-var guard) BEFORE
+    // acquiring the lock again — otherwise we'd deadlock with our own
+    // World's prior scenario remnant.
+    w.sidecar_recovery = None;
+    let env_guard = sidecar_env_lock().lock();
     let dir = tempfile::tempdir().unwrap();
     let sidecar = dir.path().join("seed-demo.db");
     write_kikan_seed_db(&sidecar);
-    // SAFETY: tests run single-threaded under cucumber's serial harness.
-    // Setting MOKUMO_DEMO_SIDECAR is the documented test injection point
-    // for `crate::demo_reset::find_sidecar`.
+    // SAFETY: the env-var lock above ensures no other sidecar-recovery
+    // scenario in this process is reading or writing the var.
     unsafe {
         std::env::set_var("MOKUMO_DEMO_SIDECAR", &sidecar);
     }
@@ -68,11 +97,14 @@ async fn given_sidecar_present_db_missing(w: &mut PlatformBddWorld) {
         meta_pool: None,
         recoveries: None,
         boot_result: None,
+        _env_guard: env_guard,
     });
 }
 
 #[given("a fresh data directory with a bundled demo sidecar and a healthy demo database file")]
 async fn given_sidecar_and_healthy_db(w: &mut PlatformBddWorld) {
+    w.sidecar_recovery = None;
+    let env_guard = sidecar_env_lock().lock();
     let dir = tempfile::tempdir().unwrap();
     let sidecar = dir.path().join("seed-demo.db");
     write_kikan_seed_db(&sidecar);
@@ -89,6 +121,7 @@ async fn given_sidecar_and_healthy_db(w: &mut PlatformBddWorld) {
         meta_pool: None,
         recoveries: None,
         boot_result: None,
+        _env_guard: env_guard,
     });
 }
 

--- a/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/sidecar_recovery_steps.rs
@@ -1,0 +1,217 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use cucumber::{given, then, when};
+use kikan::{EngineError, Graft as _};
+use sea_orm::{ConnectionTrait, Database, DatabaseConnection, DbBackend, Statement};
+use tokio_util::sync::CancellationToken;
+
+use super::PlatformBddWorld;
+
+const VERTICAL_DB_FILE: &str = "mokumo.db";
+
+#[derive(Debug)]
+pub struct SidecarRecoveryCtx {
+    pub data_dir: tempfile::TempDir,
+    #[allow(dead_code)]
+    pub sidecar_path: PathBuf,
+    /// Cloned before `Engine::boot` consumes the original so post-boot
+    /// assertions can query `meta.activity_log` and the recoveries map.
+    pub meta_pool: Option<DatabaseConnection>,
+    pub recoveries: Option<std::collections::HashMap<String, kikan::SidecarRecoveryDiagnostic>>,
+    pub boot_result: Option<Result<(), EngineError>>,
+}
+
+fn write_kikan_seed_db(path: &std::path::Path) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let conn = rusqlite::Connection::open(path).unwrap();
+    // Force a real header + page write so the file is non-empty.
+    // app_id = 0 (not-yet-stamped) is a valid kikan db per
+    // `kikan::db::check_application_id` — the schema content does not
+    // matter to the recovery hook, only that the file exists and is a
+    // valid sqlite db.
+    conn.execute_batch("CREATE TABLE __seed (id INTEGER PRIMARY KEY);")
+        .unwrap();
+    drop(conn);
+}
+
+#[given("a fresh data directory with a bundled demo sidecar but no demo database file")]
+async fn given_sidecar_present_db_missing(w: &mut PlatformBddWorld) {
+    let dir = tempfile::tempdir().unwrap();
+    let sidecar = dir.path().join("seed-demo.db");
+    write_kikan_seed_db(&sidecar);
+    // SAFETY: tests run single-threaded under cucumber's serial harness.
+    // Setting MOKUMO_DEMO_SIDECAR is the documented test injection point
+    // for `crate::demo_reset::find_sidecar`.
+    unsafe {
+        std::env::set_var("MOKUMO_DEMO_SIDECAR", &sidecar);
+    }
+    w.sidecar_recovery = Some(SidecarRecoveryCtx {
+        data_dir: dir,
+        sidecar_path: sidecar,
+        meta_pool: None,
+        recoveries: None,
+        boot_result: None,
+    });
+}
+
+#[given("a fresh data directory with a bundled demo sidecar and a healthy demo database file")]
+async fn given_sidecar_and_healthy_db(w: &mut PlatformBddWorld) {
+    let dir = tempfile::tempdir().unwrap();
+    let sidecar = dir.path().join("seed-demo.db");
+    write_kikan_seed_db(&sidecar);
+    // Pre-place a healthy db at the destination so the hook short-circuits
+    // to NotNeeded.
+    let dest = dir.path().join("demo").join(VERTICAL_DB_FILE);
+    write_kikan_seed_db(&dest);
+    unsafe {
+        std::env::set_var("MOKUMO_DEMO_SIDECAR", &sidecar);
+    }
+    w.sidecar_recovery = Some(SidecarRecoveryCtx {
+        data_dir: dir,
+        sidecar_path: sidecar,
+        meta_pool: None,
+        recoveries: None,
+        boot_result: None,
+    });
+}
+
+#[when("the engine boots from the fresh data directory")]
+async fn when_engine_boots_fresh(w: &mut PlatformBddWorld) {
+    use kikan::tenancy::ProfileDirName;
+    use kikan_types::SetupMode;
+
+    let ctx = w.sidecar_recovery.as_mut().unwrap();
+    let data_dir = ctx.data_dir.path().to_path_buf();
+
+    let meta_db = Database::connect("sqlite::memory:").await.unwrap();
+    let demo_db = mokumo_shop::db::initialize_database("sqlite::memory:")
+        .await
+        .unwrap();
+    let production_db = mokumo_shop::db::initialize_database("sqlite::memory:")
+        .await
+        .unwrap();
+
+    let session_pool = production_db.get_sqlite_connection_pool().clone();
+    let session_store = tower_sessions_sqlx_store::SqliteStore::new(session_pool);
+    session_store.migrate().await.unwrap();
+
+    ctx.meta_pool = Some(meta_db.clone());
+
+    let mut pools = std::collections::HashMap::with_capacity(2);
+    pools.insert(ProfileDirName::from(SetupMode::Demo.as_dir_name()), demo_db);
+    pools.insert(
+        ProfileDirName::from(SetupMode::Production.as_dir_name()),
+        production_db,
+    );
+    let active_profile = ProfileDirName::from(SetupMode::Production.as_dir_name());
+
+    let recovery_dir = data_dir.join("recovery");
+    std::fs::create_dir_all(&recovery_dir).unwrap();
+
+    let graft = mokumo_shop::graft::MokumoApp::new(None).with_recovery_dir(recovery_dir);
+    let profile_initializer: kikan::platform_state::SharedProfileDbInitializer =
+        Arc::new(mokumo_shop::profile_db_init::MokumoProfileDbInitializer);
+    let boot_config = kikan::BootConfig::new(data_dir);
+
+    let result = kikan::Engine::<mokumo_shop::graft::MokumoApp>::boot(
+        boot_config,
+        &graft,
+        meta_db,
+        pools,
+        active_profile,
+        session_store,
+        profile_initializer,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(true)),
+        CancellationToken::new(),
+    )
+    .await;
+
+    ctx.recoveries = result.as_ref().ok().map(|(_engine, app_state)| {
+        let platform = mokumo_shop::graft::MokumoApp::platform_state(app_state);
+        let map = platform.sidecar_recoveries.read();
+        map.iter()
+            .map(|(k, v)| (k.as_str().to_string(), v.clone()))
+            .collect()
+    });
+    ctx.boot_result = Some(result.map(|_| ()));
+}
+
+#[then("the demo database file exists")]
+async fn then_demo_db_exists(w: &mut PlatformBddWorld) {
+    let ctx = w.sidecar_recovery.as_ref().unwrap();
+    let dest = ctx.data_dir.path().join("demo").join(VERTICAL_DB_FILE);
+    assert!(
+        dest.exists(),
+        "expected {} to exist after sidecar recovery, but it does not",
+        dest.display()
+    );
+}
+
+#[then(expr = "PlatformState reports a sidecar recovery for {string}")]
+async fn then_recovery_reported(w: &mut PlatformBddWorld, profile_dir: String) {
+    let ctx = w.sidecar_recovery.as_ref().unwrap();
+    ctx.boot_result
+        .as_ref()
+        .expect("boot was invoked")
+        .as_ref()
+        .expect("boot succeeded");
+    let recoveries = ctx
+        .recoveries
+        .as_ref()
+        .expect("recoveries map populated on boot success");
+    let entry = recoveries
+        .get(&profile_dir)
+        .unwrap_or_else(|| panic!("no sidecar recovery for `{profile_dir}`"));
+    assert!(
+        entry.bytes > 0,
+        "recovery for `{profile_dir}` reported zero bytes"
+    );
+    assert!(
+        entry
+            .dest
+            .ends_with(format!("{profile_dir}/{VERTICAL_DB_FILE}").as_str()),
+        "dest path {} does not end with {profile_dir}/{VERTICAL_DB_FILE}",
+        entry.dest.display()
+    );
+}
+
+#[then("PlatformState reports no sidecar recoveries")]
+async fn then_no_recoveries(w: &mut PlatformBddWorld) {
+    let ctx = w.sidecar_recovery.as_ref().unwrap();
+    let recoveries = ctx
+        .recoveries
+        .as_ref()
+        .expect("recoveries map populated on boot success");
+    assert!(
+        recoveries.is_empty(),
+        "expected empty recoveries, got {:?}",
+        recoveries.keys().collect::<Vec<_>>()
+    );
+}
+
+#[then(expr = "meta.activity_log has a profile_sidecar_recovered entry for {string}")]
+async fn then_activity_log_entry(w: &mut PlatformBddWorld, expected_profile: String) {
+    let ctx = w.sidecar_recovery.as_ref().unwrap();
+    let meta = ctx.meta_pool.as_ref().expect("meta pool was captured");
+    let row = meta
+        .query_one_raw(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "SELECT entity_type, entity_id, action FROM activity_log \
+             WHERE entity_id = ? AND action = 'profile_sidecar_recovered'",
+            [expected_profile.clone().into()],
+        ))
+        .await
+        .unwrap()
+        .unwrap_or_else(|| panic!("no profile_sidecar_recovered entry for `{expected_profile}`"));
+    let entity_type: String = row.try_get_by_index(0).unwrap();
+    let entity_id: String = row.try_get_by_index(1).unwrap();
+    let action: String = row.try_get_by_index(2).unwrap();
+    assert_eq!(entity_type, "profile");
+    assert_eq!(entity_id, expected_profile);
+    assert_eq!(action, "profile_sidecar_recovered");
+}

--- a/crates/mokumo-shop/tests/platform_features/profile_sidecar_self_repair_via_graft_hook.feature
+++ b/crates/mokumo-shop/tests/platform_features/profile_sidecar_self_repair_via_graft_hook.feature
@@ -1,0 +1,29 @@
+Feature: Profile sidecar self-repair via Graft hook
+
+  When the engine boots and a non-setup-wizard profile kind has a
+  missing or corrupt database file, it consults the vertical's
+  `Graft::recover_profile_sidecar` hook. On a successful recovery the
+  engine writes a `meta.activity_log` audit entry, surfaces a
+  diagnostic on `PlatformState::sidecar_recoveries`, and continues
+  boot. Failures are logged and never block startup.
+
+  Healthy installs report nothing — the diagnostic map is empty after a
+  clean boot. Verticals that don't bundle a sidecar see their default
+  hook impl return `NotSupported`, which the engine logs at debug and
+  skips.
+
+  See `crates/kikan/src/graft.rs` (`recover_profile_sidecar`),
+  `crates/kikan/src/engine.rs` (`maybe_repair_profile_sidecars`), and
+  `adr-database-startup-guard-chain.md` 2026-04-16 errata.
+
+  Scenario: missing demo database is recovered from the bundled sidecar
+    Given a fresh data directory with a bundled demo sidecar but no demo database file
+    When the engine boots from the fresh data directory
+    Then the demo database file exists
+    And PlatformState reports a sidecar recovery for "demo"
+    And meta.activity_log has a profile_sidecar_recovered entry for "demo"
+
+  Scenario: healthy demo database produces no recovery entry
+    Given a fresh data directory with a bundled demo sidecar and a healthy demo database file
+    When the engine boots from the fresh data directory
+    Then PlatformState reports no sidecar recoveries


### PR DESCRIPTION
## Summary

Adds an opt-in `Graft::recover_profile_sidecar` hook plus a boot-time
self-repair pass in `Engine::boot` that lets verticals shipping a
bundled seed database recover from a missing or corrupt profile DB
without operator intervention.

This is the **rebased-and-renamed A2.1** from the M00 meta-DB pipeline
(plan §"PR A2.1 (rebased)"). The original `feat/demo-self-repair`
branch was discarded after R0 (#682) so the new code is born
**vocabulary-neutral** — kikan ships zero new `demo`/`production`
literals and the vocab purity allow-list does not grow.

Closes the A2.1 wave of #540.

## Surface

- `Graft::recover_profile_sidecar(kind, data_dir, db_filename) -> Result<SidecarRecovery, SidecarRecoveryError>` with default impl returning `NotSupported` (existing test grafts compile unchanged).
- `kikan::SidecarRecovery::{NotNeeded, Recreated{source, dest, bytes}}`
- `kikan::SidecarRecoveryError::{NotSupported, Failed{message}}`
- `kikan::meta::SidecarRecoveryDiagnostic` + new `PlatformState::sidecar_recoveries: Arc<RwLock<HashMap<ProfileDirName, SidecarRecoveryDiagnostic>>>`
- New `ActivityAction::ProfileSidecarRecovered` variant; engine writes one `meta.activity_log` audit row per successful recovery.
- New helper `engine::maybe_repair_profile_sidecars<G>` (extracted for CRAP threshold; sibling of `dispatch_boot_state<G>`). Iterates `graft.all_profile_kinds()` filtered by `!requires_setup_wizard(kind)` so the demo gets checked, the primary profile gets skipped.
- `MokumoApp::recover_profile_sidecar` wraps existing `crate::demo_reset::force_copy_sidecar` and short-circuits to `NotNeeded` when the destination passes `kikan::db::check_application_id` (guard 1 from `adr-database-startup-guard-chain.md`).
- New UDS endpoint `GET /admin/v1/diagnostics/sidecar-recoveries` returning the diagnostics map keyed by profile dir name.

## Why this shape

- **Best-effort by design.** A sidecar that fails to copy is logged at warn level and boot continues. Audit-log write failures are logged but do not roll back the diagnostic — recoveries are independent.
- **`NotNeeded` distinct from `NotSupported`.** Healthy installs produce empty maps without spamming logs; verticals without sidecars get a quiet debug log per kind. Treating `NotSupported` as healthy would silently hide a regression where the hook stops being implemented.
- **Hook owns the corruption check.** `MokumoApp::recover_profile_sidecar` consults `check_application_id` itself rather than relying on the engine to detect corruption — kikan never opens the sidecar file, only the vertical does.
- **Activity log writes against `meta.db`.** Sidecar recovery is install-level, not per-profile. Mirrors the pattern in `crates/kikan/src/meta/upgrade.rs:110`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --exclude mokumo-desktop --exclude kikan-admin-ui --all-targets -- -D warnings` zero warnings
- [x] `cargo test --workspace --exclude mokumo-desktop --exclude kikan-admin-ui --tests` 957 passed (53 suites)
- [x] `cargo test -p mokumo-shop --features bdd --test platform_bdd` — 39 scenarios passed (6 expected skips), including 2 new sidecar scenarios
- [x] All `scripts/check-i*.sh` pass, including the **new vocab purity script** with no new allow-list entries needed
- [x] `bdd-lint` exit 0 (only pre-existing warnings)
- [x] Lefthook pre-push (rust-fmt, gitleaks, rust-clippy via Moon) passes

## BDD coverage

`crates/mokumo-shop/tests/platform_features/profile_sidecar_self_repair_via_graft_hook.feature`:
- **Missing demo database is recovered from the bundled sidecar** — verifies the file is created, `PlatformState::sidecar_recoveries` is populated, and `meta.activity_log` has the audit row.
- **Healthy demo database produces no recovery entry** — verifies the hook short-circuits to `NotNeeded` and the diagnostics map stays empty.

## What's next on the M00 pipeline

A2.1 → **A2.2** (bundle backup + atomic restore) → **A3.1** (SetupMode shim + PR A finalize) → [PR A merges] → **B0.1** (profile CRUD + TypedConfirmation extractor) → **{B1.1 destructive ops, B1.2 setup wizard refactor}** → **B2.1** (surgical removal of SetupMode + auth_profile_kind + all_profile_kinds, including shrinking the bucket-3 vocab purity allow-list per #683).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic profile database self-repair at startup with per-profile recovery diagnostics surfaced.
  * Diagnostics API: new /diagnostics/sidecar-recoveries endpoint returns recovery details.
  * Recovery events are recorded in the activity log for auditing.

* **Tests**
  * New integration and BDD scenarios covering sidecar self-repair, diagnostics population, and audit logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->