### PR TITLE
feat(kikan): bundle backup with strict atomic restore (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Bundle backup with strict-atomic restore** (M00 PR A wave A2.2, kikan):
+  - New `kikan::meta::backup` module — vocabulary-neutral primitive that captures meta.db, sessions.db, and every per-profile vertical DB into a single point-in-time bundle group at `<snapshot_root>/<group_id>/`. Each database is snapshotted via SQLite `VACUUM INTO` (not file copy) so WAL pages are checkpointed into a self-contained file rather than captured as a torn image.
+  - `manifest.json` (schema v1) lists every snapshot by caller-supplied `logical_name`, the snapshot filename on disk, and its byte size. Restore reverses the mapping deterministically.
+  - **Strict-atomic restore (R6)**: restore verifies the manifest and runs `PRAGMA integrity_check` on every snapshot file BEFORE renaming any destination. On any failure it returns `BundleRestoreError::ManifestVerificationFailed` or `BundleRestoreError::PartialCorruption { failed_file }` and leaves every destination file byte-identical to its pre-call state. There is no best-effort partial-restore path.
+  - Public surface: `create_bundle`, `restore_bundle`, `DbInBundle`, `RestoreTarget`, `BundleManifest`, `BundleManifestEntry`, `BundleBackupError`, `BundleRestoreError`, `BUNDLE_MANIFEST_SCHEMA_VERSION`. Both error enums are `#[non_exhaustive]` and carry `Box<dyn Error + Send + Sync + 'static>` source chains where applicable.
+  - 9 module-level unit tests cover input validation, snapshot writing, round-trip, manifest+target pairing errors, and the strict-atomic refusal under both manifest-missing and snapshot-corrupt failure modes.
+  - 2 BDD features under `crates/mokumo-shop/tests/platform_features/`: `restore_refuses_partially_corrupt_bundle.feature` (2 scenarios incl. the byte-equality post-refusal check) and `bundle_backup_includes_meta_db.feature`.
+
 - **Admin overview dashboard** (PR 2A S5, kikan-admin-ui):
   - `(app)/+page.svelte` now renders three states based on `GET /api/platform/v1/overview`:
     - **Fresh install**: a `Get Started with {appName}` Card listing three checklist steps from `overview.get_started_steps`, with branding-bound copy (`appName`, `shopNounSingular`).

--- a/crates/kikan/src/lib.rs
+++ b/crates/kikan/src/lib.rs
@@ -93,8 +93,10 @@ pub use error::{
 };
 pub use graft::{Graft, SelfGraft, SidecarRecovery, SidecarRecoveryError, SubGraft};
 pub use meta::{
-    BootState, BootStateDetectionError, Profile, ProfileRepo, ProfileRepoError, SeaOrmProfileRepo,
-    SidecarRecoveryDiagnostic, detect_boot_state,
+    BUNDLE_MANIFEST_SCHEMA_VERSION, BootState, BootStateDetectionError, BundleBackupError,
+    BundleManifest, BundleManifestEntry, BundleRestoreError, DbInBundle, Profile, ProfileRepo,
+    ProfileRepoError, RestoreTarget, SeaOrmProfileRepo, SidecarRecoveryDiagnostic, create_bundle,
+    detect_boot_state, restore_bundle,
 };
 pub use migrations::{GraftId, Migration, MigrationRef, MigrationTarget};
 pub use platform_state::{MdnsStatus, PlatformState, SharedMdnsStatus};

--- a/crates/kikan/src/meta/backup.rs
+++ b/crates/kikan/src/meta/backup.rs
@@ -130,8 +130,11 @@ pub enum BundleRestoreError {
     #[error("bundle manifest verification failed: {reason}")]
     ManifestVerificationFailed { reason: String },
 
-    #[error("snapshot for `{}` failed integrity check (no destination files were modified)", failed_file.display())]
-    PartialCorruption { failed_file: PathBuf },
+    #[error("snapshot for `{}` failed integrity check ({reason}); no destination files were modified", failed_file.display())]
+    PartialCorruption {
+        failed_file: PathBuf,
+        reason: String,
+    },
 
     #[error("restore target `{logical_name}` has no matching manifest entry")]
     UnknownTarget { logical_name: String },
@@ -145,8 +148,9 @@ pub enum BundleRestoreError {
     )]
     SnapshotMissing { logical_name: String, path: PathBuf },
 
-    #[error("filesystem error during restore: {source}")]
+    #[error("filesystem error during restore at {}: {source}", path.display())]
     Io {
+        path: PathBuf,
         #[source]
         source: std::io::Error,
     },
@@ -243,6 +247,7 @@ pub async fn restore_bundle(
     for (snapshot_path, _) in &pairs {
         verify_snapshot_integrity(snapshot_path).await?;
     }
+    precreate_destination_dirs(&pairs)?;
 
     atomic_rename_all(&pairs)?;
     Ok(())
@@ -301,14 +306,29 @@ async fn vacuum_into_snapshot(
     source: &Path,
     snapshot_path: &Path,
 ) -> Result<(), BundleBackupError> {
-    if snapshot_path.exists() {
-        std::fs::remove_file(snapshot_path).map_err(|source| BundleBackupError::Io {
-            path: snapshot_path.to_path_buf(),
+    // VACUUM INTO requires the destination to NOT exist. We first vacuum
+    // into `<snapshot>.tmp` and only rename(2) it onto the final path on
+    // success. If the process is interrupted mid-vacuum, the previous
+    // (good) snapshot at `snapshot_path` is preserved and only the
+    // `.tmp` is left behind for cleanup on retry.
+    let tmp_path = tmp_sibling(snapshot_path);
+    if tmp_path.exists() {
+        std::fs::remove_file(&tmp_path).map_err(|source| BundleBackupError::Io {
+            path: tmp_path.clone(),
             source,
         })?;
     }
+    // Reject non-UTF-8 destinations rather than silently lossy-coerce —
+    // SQLite's `VACUUM INTO` parses the path string and a lossy round
+    // trip can land bytes outside the originally intended file.
+    let tmp_str = tmp_path
+        .to_str()
+        .ok_or_else(|| BundleBackupError::InvalidLogicalName {
+            name: logical_name.to_string(),
+            reason: "snapshot path is not valid UTF-8",
+        })?
+        .to_string();
     let source = source.to_path_buf();
-    let snapshot_owned = snapshot_path.to_path_buf();
     let logical = logical_name.to_string();
     tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
         let conn = rusqlite::Connection::open_with_flags(
@@ -319,10 +339,7 @@ async fn vacuum_into_snapshot(
         // without holding the source's write lock for the full copy.
         // Bind the destination as a parameter — rusqlite escapes it for
         // SQLite's quoting rules.
-        conn.execute(
-            "VACUUM INTO ?1",
-            [snapshot_owned.to_string_lossy().as_ref()],
-        )?;
+        conn.execute("VACUUM INTO ?1", [tmp_str.as_str()])?;
         Ok(())
     })
     .await
@@ -331,23 +348,71 @@ async fn vacuum_into_snapshot(
         source: Box::new(join_err),
     })?
     .map_err(|sql_err| BundleBackupError::Snapshot {
-        logical_name: logical,
+        logical_name: logical.clone(),
         source: Box::new(sql_err),
+    })?;
+    // Promote the temp into place. `rename(2)` is atomic on the same
+    // filesystem; the temp sits next to the destination so this is the
+    // common case.
+    std::fs::rename(&tmp_path, snapshot_path).map_err(|source| BundleBackupError::Io {
+        path: snapshot_path.to_path_buf(),
+        source,
     })?;
     Ok(())
 }
 
+fn tmp_sibling(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_default();
+    name.push(".tmp");
+    path.with_file_name(name)
+}
+
+/// Hard cap on `manifest.json` size during read. Manifests are tens
+/// of bytes per entry; a real install with hundreds of profiles tops
+/// out under a megabyte. Refusing anything larger keeps a malicious
+/// or corrupted file from forcing an unbounded allocation.
+const MANIFEST_MAX_BYTES: u64 = 16 * 1024 * 1024;
+
 fn write_manifest(group_dir: &Path, manifest: &BundleManifest) -> Result<(), BundleBackupError> {
+    // Atomic write: serialize → write to `manifest.json.tmp` → rename
+    // into place. If we crash mid-write, the operator sees either the
+    // previous valid manifest or no manifest at all (the latter trips
+    // `ManifestVerificationFailed` on restore), never a half-written one
+    // that parses partially.
     let manifest_path = group_dir.join("manifest.json");
+    let tmp_path = tmp_sibling(&manifest_path);
     let json = serde_json::to_vec_pretty(manifest)?;
-    std::fs::write(&manifest_path, json).map_err(|source| BundleBackupError::Io {
+    std::fs::write(&tmp_path, json).map_err(|source| BundleBackupError::Io {
+        path: tmp_path.clone(),
+        source,
+    })?;
+    std::fs::rename(&tmp_path, &manifest_path).map_err(|source| BundleBackupError::Io {
         path: manifest_path,
         source,
-    })
+    })?;
+    Ok(())
 }
 
 fn read_manifest(group_dir: &Path) -> Result<BundleManifest, BundleRestoreError> {
     let manifest_path = group_dir.join("manifest.json");
+    let metadata = std::fs::metadata(&manifest_path).map_err(|e| {
+        BundleRestoreError::ManifestVerificationFailed {
+            reason: format!("could not stat {}: {e}", manifest_path.display()),
+        }
+    })?;
+    if metadata.len() > MANIFEST_MAX_BYTES {
+        return Err(BundleRestoreError::ManifestVerificationFailed {
+            reason: format!(
+                "manifest at {} is {} bytes, exceeds {}-byte cap",
+                manifest_path.display(),
+                metadata.len(),
+                MANIFEST_MAX_BYTES
+            ),
+        });
+    }
     let bytes = std::fs::read(&manifest_path).map_err(|e| {
         BundleRestoreError::ManifestVerificationFailed {
             reason: format!("could not read {}: {e}", manifest_path.display()),
@@ -407,35 +472,87 @@ fn pair_targets_with_entries(
 
 async fn verify_snapshot_integrity(snapshot_path: &Path) -> Result<(), BundleRestoreError> {
     let owned = snapshot_path.to_path_buf();
-    let result = tokio::task::spawn_blocking(move || -> Result<bool, rusqlite::Error> {
+    let result = tokio::task::spawn_blocking(move || -> Result<String, rusqlite::Error> {
         let conn = rusqlite::Connection::open_with_flags(
             &owned,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
         let row: String = conn.query_row("PRAGMA integrity_check", [], |r| r.get(0))?;
-        Ok(row == "ok")
+        Ok(row)
     })
     .await;
-    let ok = match result {
-        Ok(Ok(ok)) => ok,
-        Ok(Err(_)) | Err(_) => false,
+    // Preserve the underlying failure mode in the structured error so
+    // operators don't have to grep logs to know whether the snapshot
+    // was unreadable, malformed, or merely failed page-level checks.
+    let reason = match result {
+        Ok(Ok(ref row)) if row == "ok" => return Ok(()),
+        Ok(Ok(other)) => format!("integrity_check returned `{other}`"),
+        Ok(Err(sql_err)) => format!("could not open or query snapshot: {sql_err}"),
+        Err(join_err) => format!("integrity-check task failed: {join_err}"),
     };
-    if !ok {
-        return Err(BundleRestoreError::PartialCorruption {
-            failed_file: snapshot_path.to_path_buf(),
-        });
+    Err(BundleRestoreError::PartialCorruption {
+        failed_file: snapshot_path.to_path_buf(),
+        reason,
+    })
+}
+
+/// Pre-create every destination's parent directory. Doing this in
+/// the verify pass (before any rename) means a directory permission
+/// or disk-full error surfaces while the on-disk state is still
+/// strictly the pre-restore tree.
+fn precreate_destination_dirs(pairs: &[(PathBuf, PathBuf)]) -> Result<(), BundleRestoreError> {
+    for (_, dest) in pairs {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| BundleRestoreError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
     }
     Ok(())
 }
 
 fn atomic_rename_all(pairs: &[(PathBuf, PathBuf)]) -> Result<(), BundleRestoreError> {
     for (src, dest) in pairs {
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent).map_err(|source| BundleRestoreError::Io { source })?;
-        }
-        std::fs::rename(src, dest).map_err(|source| BundleRestoreError::Io { source })?;
+        move_or_copy(src, dest)?;
     }
     Ok(())
+}
+
+/// Move `src` to `dest`. Tries `rename(2)` first (atomic on the same
+/// filesystem); on `EXDEV` (cross-filesystem) falls back to copy +
+/// remove. The fallback is not byte-atomic from the destination's
+/// perspective — callers that need that should keep snapshots and
+/// destinations on the same mount.
+fn move_or_copy(src: &Path, dest: &Path) -> Result<(), BundleRestoreError> {
+    match std::fs::rename(src, dest) {
+        Ok(()) => Ok(()),
+        Err(e) if is_cross_device(&e) => {
+            std::fs::copy(src, dest).map_err(|source| BundleRestoreError::Io {
+                path: dest.to_path_buf(),
+                source,
+            })?;
+            // Best-effort cleanup; failure here doesn't break the
+            // operator-visible contract — the destination is in place.
+            let _ = std::fs::remove_file(src);
+            Ok(())
+        }
+        Err(source) => Err(BundleRestoreError::Io {
+            path: dest.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn is_cross_device(e: &std::io::Error) -> bool {
+    if matches!(e.kind(), std::io::ErrorKind::CrossesDevices) {
+        return true;
+    }
+    // Defensive fallback for older platform mappings that may still
+    // surface EXDEV as `ErrorKind::Other`. EXDEV is 18 on Linux and
+    // most BSDs, 17 on Solaris-derived Unixes; on Windows the
+    // equivalent (`ERROR_NOT_SAME_DEVICE`) is 17.
+    matches!(e.raw_os_error(), Some(17) | Some(18))
 }
 
 #[cfg(test)]
@@ -686,7 +803,7 @@ mod tests {
         .await
         .unwrap_err();
         assert!(
-            matches!(err, BundleRestoreError::PartialCorruption { ref failed_file } if failed_file.ends_with("bravo.db")),
+            matches!(err, BundleRestoreError::PartialCorruption { ref failed_file, .. } if failed_file.ends_with("bravo.db")),
             "got {err:?}"
         );
         assert_eq!(read_bytes(&dest_a), pre_a, "alpha destination touched");
@@ -764,5 +881,104 @@ mod tests {
             err,
             BundleRestoreError::UnmatchedManifestEntry { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn partial_corruption_carries_reason_string() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src = work.path().join("src.db");
+        write_seed_db(&src);
+        create_bundle(
+            &snaps,
+            "g1",
+            &[DbInBundle {
+                logical_name: "data",
+                source: &src,
+            }],
+        )
+        .await
+        .unwrap();
+        std::fs::write(snaps.join("g1/data.db"), b"not a sqlite database").unwrap();
+
+        let dest = work.path().join("dest.db");
+        let err = restore_bundle(
+            &snaps,
+            "g1",
+            &[RestoreTarget {
+                logical_name: "data".into(),
+                dest,
+            }],
+        )
+        .await
+        .unwrap_err();
+        match err {
+            BundleRestoreError::PartialCorruption { reason, .. } => assert!(
+                !reason.is_empty(),
+                "PartialCorruption.reason must describe the failure",
+            ),
+            other => panic!("expected PartialCorruption, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_manifest_refuses_oversize_file() {
+        let work = tempfile::tempdir().unwrap();
+        let group_dir = work.path().join("g1");
+        std::fs::create_dir_all(&group_dir).unwrap();
+        // Use a sparse file via set_len to avoid writing actual MBs.
+        let manifest_path = group_dir.join("manifest.json");
+        let f = std::fs::File::create(&manifest_path).unwrap();
+        f.set_len(MANIFEST_MAX_BYTES + 1).unwrap();
+
+        let err = read_manifest(&group_dir).unwrap_err();
+        match err {
+            BundleRestoreError::ManifestVerificationFailed { reason } => {
+                assert!(
+                    reason.contains("exceeds") && reason.contains("cap"),
+                    "expected size-cap reason, got `{reason}`",
+                );
+            }
+            other => panic!("expected ManifestVerificationFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_bundle_does_not_leave_tmp_on_success() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src = work.path().join("src.db");
+        write_seed_db(&src);
+        create_bundle(
+            &snaps,
+            "g1",
+            &[DbInBundle {
+                logical_name: "data",
+                source: &src,
+            }],
+        )
+        .await
+        .unwrap();
+        let group = snaps.join("g1");
+        assert!(group.join("data.db").exists());
+        assert!(
+            !group.join("data.db.tmp").exists(),
+            "snapshot temp must be promoted on success",
+        );
+        assert!(
+            !group.join("manifest.json.tmp").exists(),
+            "manifest temp must be promoted on success",
+        );
+    }
+
+    #[test]
+    fn is_cross_device_recognizes_known_codes() {
+        for code in [17, 18] {
+            let e = std::io::Error::from_raw_os_error(code);
+            assert!(is_cross_device(&e), "code {code} should classify as EXDEV");
+        }
+        // ENOENT is not a cross-device condition.
+        let other = std::io::Error::from_raw_os_error(2);
+        assert!(!is_cross_device(&other));
     }
 }

--- a/crates/kikan/src/meta/backup.rs
+++ b/crates/kikan/src/meta/backup.rs
@@ -139,6 +139,9 @@ pub enum BundleRestoreError {
     #[error("restore target `{logical_name}` has no matching manifest entry")]
     UnknownTarget { logical_name: String },
 
+    #[error("restore target list contains duplicate logical name `{logical_name}`")]
+    DuplicateTarget { logical_name: String },
+
     #[error("manifest entry `{logical_name}` has no matching restore target")]
     UnmatchedManifestEntry { logical_name: String },
 
@@ -276,10 +279,10 @@ fn validate_logical_name(name: &str) -> Result<(), BundleBackupError> {
             reason: "empty",
         });
     }
-    if name == "." || name == ".." || name.contains('/') || name.contains('\\') {
+    if name.starts_with('.') || name.contains('/') || name.contains('\\') {
         return Err(BundleBackupError::InvalidLogicalName {
             name: name.to_string(),
-            reason: "must not contain path separators or be `.`/`..`",
+            reason: "must not start with `.` or contain path separators",
         });
     }
     let ok = name
@@ -448,6 +451,18 @@ fn pair_targets_with_entries(
                 logical_name: target.logical_name.clone(),
             }
         })?;
+        // Reject duplicate target names BEFORE staging anything for
+        // rename. Two targets pointing at the same snapshot would
+        // otherwise pass integrity verification (same file checked
+        // twice) and then partially apply at the rename step — the
+        // first rename succeeds, the second fails with ENOENT, and
+        // R6's "we refused, no destination touched" guarantee is
+        // broken.
+        if !matched.insert(entry.logical_name.as_str()) {
+            return Err(BundleRestoreError::DuplicateTarget {
+                logical_name: target.logical_name.clone(),
+            });
+        }
         let snapshot_path = group_dir.join(&entry.snapshot_filename);
         if !snapshot_path.exists() {
             return Err(BundleRestoreError::SnapshotMissing {
@@ -455,7 +470,6 @@ fn pair_targets_with_entries(
                 path: snapshot_path,
             });
         }
-        matched.insert(entry.logical_name.as_str());
         pairs.push((snapshot_path, target.dest.clone()));
     }
     if let Some(entry) = manifest
@@ -496,10 +510,13 @@ async fn verify_snapshot_integrity(snapshot_path: &Path) -> Result<(), BundleRes
     })
 }
 
-/// Pre-create every destination's parent directory. Doing this in
-/// the verify pass (before any rename) means a directory permission
-/// or disk-full error surfaces while the on-disk state is still
-/// strictly the pre-restore tree.
+/// Pre-create every destination's parent directory. Running this
+/// before the rename loop means a directory permission or disk-full
+/// error surfaces while no destination *file* has been mutated. The
+/// R6 contract is "no destination file is touched" — `create_dir_all`
+/// is itself an observable disk mutation (new empty parent dirs may
+/// appear), but those are benign and idempotent and do not violate
+/// the file-level guarantee operators rely on.
 fn precreate_destination_dirs(pairs: &[(PathBuf, PathBuf)]) -> Result<(), BundleRestoreError> {
     for (_, dest) in pairs {
         if let Some(parent) = dest.parent() {
@@ -881,6 +898,77 @@ mod tests {
             err,
             BundleRestoreError::UnmatchedManifestEntry { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn restore_rejects_duplicate_target_before_touching_disk() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src = work.path().join("src.db");
+        write_seed_db(&src);
+        create_bundle(
+            &snaps,
+            "g1",
+            &[DbInBundle {
+                logical_name: "data",
+                source: &src,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let dest_a = work.path().join("dest_a.db");
+        let dest_b = work.path().join("dest_b.db");
+        write_seed_db(&dest_a);
+        write_seed_db(&dest_b);
+        let pre_a = read_bytes(&dest_a);
+        let pre_b = read_bytes(&dest_b);
+
+        let err = restore_bundle(
+            &snaps,
+            "g1",
+            &[
+                RestoreTarget {
+                    logical_name: "data".into(),
+                    dest: dest_a.clone(),
+                },
+                RestoreTarget {
+                    logical_name: "data".into(),
+                    dest: dest_b.clone(),
+                },
+            ],
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, BundleRestoreError::DuplicateTarget { ref logical_name } if logical_name == "data"),
+            "got {err:?}"
+        );
+        assert_eq!(read_bytes(&dest_a), pre_a, "dest_a touched on refusal");
+        assert_eq!(read_bytes(&dest_b), pre_b, "dest_b touched on refusal");
+    }
+
+    #[tokio::test]
+    async fn create_bundle_rejects_dot_prefixed_logical_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("a.db");
+        write_seed_db(&src);
+        for bad in [".tmp", "..bar", "...", ".hidden"] {
+            let err = create_bundle(
+                dir.path(),
+                "g1",
+                &[DbInBundle {
+                    logical_name: bad,
+                    source: &src,
+                }],
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                matches!(err, BundleBackupError::InvalidLogicalName { .. }),
+                "expected InvalidLogicalName for `{bad}`, got {err:?}",
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/kikan/src/meta/backup.rs
+++ b/crates/kikan/src/meta/backup.rs
@@ -1,0 +1,768 @@
+//! Multi-database bundle backup + strict-atomic restore.
+//!
+//! A *bundle* is the operator-facing unit of backup: meta.db,
+//! sessions.db, and every per-profile vertical DB captured into a
+//! single point-in-time group. Each database in the bundle is
+//! snapshotted via SQLite `VACUUM INTO`, which checkpoints the WAL
+//! into a self-contained file rather than relying on a torn-image
+//! file copy of an open WAL-mode database.
+//!
+//! The primitive is intentionally vocabulary-neutral: callers hand it
+//! a list of `[DbInBundle]` entries (logical name + on-disk source
+//! path) so kikan never needs to know about meta.profiles, vertical
+//! `db_filename` values, or per-profile slug naming.
+//!
+//! # Strict-atomic restore (R6)
+//!
+//! Restore refuses to mutate any destination file unless every
+//! snapshot named in the manifest passes `PRAGMA integrity_check`.
+//! On any verification failure the destination tree is left untouched
+//! and a [`BundleRestoreError`] names the offending logical entry.
+//! There is no best-effort partial-restore path; the operator-facing
+//! contract is "we refused, you know exactly where you stand" rather
+//! than a half-restored install.
+//!
+//! See `adr-kikan-upgrade-migration-strategy.md` §"Multi-database
+//! operation-level atomicity via snapshot-and-restore" for the
+//! load-bearing precedent (manifest + `VACUUM INTO` + atomic rename).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Bundle manifest schema version. Bumping this signals a breaking
+/// change in `manifest.json`; restore refuses any manifest whose
+/// version does not equal this constant.
+pub const BUNDLE_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// One database to include in a bundle.
+///
+/// `logical_name` is the caller-chosen identifier under which the
+/// snapshot is stored in the bundle and reported back through the
+/// manifest. It must be a non-empty filesystem-safe string (no path
+/// separators, no `..`); the primitive validates this at bundle time.
+#[derive(Debug, Clone)]
+pub struct DbInBundle<'a> {
+    pub logical_name: &'a str,
+    pub source: &'a Path,
+}
+
+/// Restore target — pairs a manifest's `logical_name` with the
+/// destination path the snapshot should land at on success.
+#[derive(Debug, Clone)]
+pub struct RestoreTarget {
+    pub logical_name: String,
+    pub dest: PathBuf,
+}
+
+/// On-disk manifest entry for one database snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleManifestEntry {
+    pub logical_name: String,
+    pub snapshot_filename: String,
+    pub bytes: u64,
+}
+
+/// On-disk bundle manifest.
+///
+/// `entries` is sorted by `logical_name` for deterministic output.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleManifest {
+    pub schema_version: u32,
+    pub group_id: String,
+    pub created_at: DateTime<Utc>,
+    pub entries: Vec<BundleManifestEntry>,
+}
+
+impl BundleManifest {
+    fn entries_by_name(&self) -> BTreeMap<&str, &BundleManifestEntry> {
+        self.entries
+            .iter()
+            .map(|e| (e.logical_name.as_str(), e))
+            .collect()
+    }
+}
+
+/// Errors produced by [`create_bundle`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BundleBackupError {
+    #[error("bundle must contain at least one database")]
+    EmptyBundle,
+
+    #[error("logical name `{name}` is invalid: {reason}")]
+    InvalidLogicalName { name: String, reason: &'static str },
+
+    #[error("duplicate logical name `{name}` in bundle inputs")]
+    DuplicateLogicalName { name: String },
+
+    #[error("source database for `{logical_name}` does not exist: {}", path.display())]
+    SourceMissing { logical_name: String, path: PathBuf },
+
+    #[error("snapshot of `{logical_name}` failed: {source}")]
+    Snapshot {
+        logical_name: String,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    #[error("io error in snapshot directory {}: {source}", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to serialize bundle manifest: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Errors produced by [`restore_bundle`].
+///
+/// `PartialCorruption` and `ManifestVerificationFailed` together
+/// encode R6's strict-atomic refusal contract: returned BEFORE any
+/// destination file is touched.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BundleRestoreError {
+    #[error("bundle manifest verification failed: {reason}")]
+    ManifestVerificationFailed { reason: String },
+
+    #[error("snapshot for `{}` failed integrity check (no destination files were modified)", failed_file.display())]
+    PartialCorruption { failed_file: PathBuf },
+
+    #[error("restore target `{logical_name}` has no matching manifest entry")]
+    UnknownTarget { logical_name: String },
+
+    #[error("manifest entry `{logical_name}` has no matching restore target")]
+    UnmatchedManifestEntry { logical_name: String },
+
+    #[error(
+        "snapshot file for `{logical_name}` is missing on disk: {}",
+        path.display()
+    )]
+    SnapshotMissing { logical_name: String, path: PathBuf },
+
+    #[error("filesystem error during restore: {source}")]
+    Io {
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Create a bundle group at `<snapshot_root>/<group_id>/`.
+///
+/// Writes `manifest.json` and one `<snapshot_filename>` per entry.
+/// Each snapshot is produced via `VACUUM INTO` against the source DB,
+/// so WAL-mode sources are checkpointed into the snapshot rather than
+/// captured as a torn image.
+///
+/// Validation: `dbs` must be non-empty, every `logical_name` must be
+/// filesystem-safe (`[A-Za-z0-9._-]+` and no `..`), names must be
+/// unique. Source files must exist.
+///
+/// The function is async because `VACUUM INTO` runs in
+/// `spawn_blocking` (rusqlite is sync); the rest is straight
+/// filesystem work.
+pub async fn create_bundle(
+    snapshot_root: &Path,
+    group_id: &str,
+    dbs: &[DbInBundle<'_>],
+) -> Result<BundleManifest, BundleBackupError> {
+    validate_inputs(dbs)?;
+
+    let group_dir = snapshot_root.join(group_id);
+    create_group_dir(&group_dir)?;
+
+    let mut entries = Vec::with_capacity(dbs.len());
+    for db in dbs {
+        if !db.source.exists() {
+            return Err(BundleBackupError::SourceMissing {
+                logical_name: db.logical_name.to_string(),
+                path: db.source.to_path_buf(),
+            });
+        }
+        let snapshot_filename = format!("{}.db", db.logical_name);
+        let snapshot_path = group_dir.join(&snapshot_filename);
+
+        vacuum_into_snapshot(db.logical_name, db.source, &snapshot_path).await?;
+
+        let bytes = std::fs::metadata(&snapshot_path)
+            .map_err(|source| BundleBackupError::Io {
+                path: snapshot_path.clone(),
+                source,
+            })?
+            .len();
+
+        entries.push(BundleManifestEntry {
+            logical_name: db.logical_name.to_string(),
+            snapshot_filename,
+            bytes,
+        });
+    }
+    entries.sort_by(|a, b| a.logical_name.cmp(&b.logical_name));
+
+    let manifest = BundleManifest {
+        schema_version: BUNDLE_MANIFEST_SCHEMA_VERSION,
+        group_id: group_id.to_string(),
+        created_at: Utc::now(),
+        entries,
+    };
+
+    write_manifest(&group_dir, &manifest)?;
+
+    Ok(manifest)
+}
+
+/// Restore a bundle group with strict-atomic semantics (R6).
+///
+/// Steps:
+/// 1. Read + verify `manifest.json` (`schema_version` matches; every
+///    entry exists on disk; targets are bijective with manifest
+///    entries).
+/// 2. Run `PRAGMA integrity_check` on every snapshot file.
+/// 3. Only after every check above passes, atomically `rename(2)`
+///    each snapshot into its destination.
+///
+/// On any failure during steps 1 or 2 no destination file is
+/// touched. A failure during step 3 (rare — same-filesystem rename
+/// on POSIX) surfaces as [`BundleRestoreError::Io`]; per the ADR,
+/// cross-file aggregate atomicity is not provided, only "refuse
+/// before mutating" is guaranteed.
+pub async fn restore_bundle(
+    snapshot_root: &Path,
+    group_id: &str,
+    targets: &[RestoreTarget],
+) -> Result<(), BundleRestoreError> {
+    let group_dir = snapshot_root.join(group_id);
+    let manifest = read_manifest(&group_dir)?;
+    let pairs = pair_targets_with_entries(&group_dir, &manifest, targets)?;
+
+    for (snapshot_path, _) in &pairs {
+        verify_snapshot_integrity(snapshot_path).await?;
+    }
+
+    atomic_rename_all(&pairs)?;
+    Ok(())
+}
+
+fn validate_inputs(dbs: &[DbInBundle<'_>]) -> Result<(), BundleBackupError> {
+    if dbs.is_empty() {
+        return Err(BundleBackupError::EmptyBundle);
+    }
+    let mut seen = std::collections::HashSet::with_capacity(dbs.len());
+    for db in dbs {
+        validate_logical_name(db.logical_name)?;
+        if !seen.insert(db.logical_name) {
+            return Err(BundleBackupError::DuplicateLogicalName {
+                name: db.logical_name.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_logical_name(name: &str) -> Result<(), BundleBackupError> {
+    if name.is_empty() {
+        return Err(BundleBackupError::InvalidLogicalName {
+            name: name.to_string(),
+            reason: "empty",
+        });
+    }
+    if name == "." || name == ".." || name.contains('/') || name.contains('\\') {
+        return Err(BundleBackupError::InvalidLogicalName {
+            name: name.to_string(),
+            reason: "must not contain path separators or be `.`/`..`",
+        });
+    }
+    let ok = name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.');
+    if !ok {
+        return Err(BundleBackupError::InvalidLogicalName {
+            name: name.to_string(),
+            reason: "must be ASCII [A-Za-z0-9._-]",
+        });
+    }
+    Ok(())
+}
+
+fn create_group_dir(group_dir: &Path) -> Result<(), BundleBackupError> {
+    std::fs::create_dir_all(group_dir).map_err(|source| BundleBackupError::Io {
+        path: group_dir.to_path_buf(),
+        source,
+    })
+}
+
+async fn vacuum_into_snapshot(
+    logical_name: &str,
+    source: &Path,
+    snapshot_path: &Path,
+) -> Result<(), BundleBackupError> {
+    if snapshot_path.exists() {
+        std::fs::remove_file(snapshot_path).map_err(|source| BundleBackupError::Io {
+            path: snapshot_path.to_path_buf(),
+            source,
+        })?;
+    }
+    let source = source.to_path_buf();
+    let snapshot_owned = snapshot_path.to_path_buf();
+    let logical = logical_name.to_string();
+    tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
+        let conn = rusqlite::Connection::open_with_flags(
+            &source,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        // VACUUM INTO checkpoints WAL pages into a self-contained file
+        // without holding the source's write lock for the full copy.
+        // Bind the destination as a parameter — rusqlite escapes it for
+        // SQLite's quoting rules.
+        conn.execute(
+            "VACUUM INTO ?1",
+            [snapshot_owned.to_string_lossy().as_ref()],
+        )?;
+        Ok(())
+    })
+    .await
+    .map_err(|join_err| BundleBackupError::Snapshot {
+        logical_name: logical.clone(),
+        source: Box::new(join_err),
+    })?
+    .map_err(|sql_err| BundleBackupError::Snapshot {
+        logical_name: logical,
+        source: Box::new(sql_err),
+    })?;
+    Ok(())
+}
+
+fn write_manifest(group_dir: &Path, manifest: &BundleManifest) -> Result<(), BundleBackupError> {
+    let manifest_path = group_dir.join("manifest.json");
+    let json = serde_json::to_vec_pretty(manifest)?;
+    std::fs::write(&manifest_path, json).map_err(|source| BundleBackupError::Io {
+        path: manifest_path,
+        source,
+    })
+}
+
+fn read_manifest(group_dir: &Path) -> Result<BundleManifest, BundleRestoreError> {
+    let manifest_path = group_dir.join("manifest.json");
+    let bytes = std::fs::read(&manifest_path).map_err(|e| {
+        BundleRestoreError::ManifestVerificationFailed {
+            reason: format!("could not read {}: {e}", manifest_path.display()),
+        }
+    })?;
+    let manifest: BundleManifest = serde_json::from_slice(&bytes).map_err(|e| {
+        BundleRestoreError::ManifestVerificationFailed {
+            reason: format!("malformed manifest at {}: {e}", manifest_path.display()),
+        }
+    })?;
+    if manifest.schema_version != BUNDLE_MANIFEST_SCHEMA_VERSION {
+        return Err(BundleRestoreError::ManifestVerificationFailed {
+            reason: format!(
+                "manifest schema_version {} does not match supported {}",
+                manifest.schema_version, BUNDLE_MANIFEST_SCHEMA_VERSION,
+            ),
+        });
+    }
+    Ok(manifest)
+}
+
+fn pair_targets_with_entries(
+    group_dir: &Path,
+    manifest: &BundleManifest,
+    targets: &[RestoreTarget],
+) -> Result<Vec<(PathBuf, PathBuf)>, BundleRestoreError> {
+    let by_name = manifest.entries_by_name();
+    let mut pairs = Vec::with_capacity(targets.len());
+    let mut matched = std::collections::HashSet::with_capacity(targets.len());
+    for target in targets {
+        let entry = by_name.get(target.logical_name.as_str()).ok_or_else(|| {
+            BundleRestoreError::UnknownTarget {
+                logical_name: target.logical_name.clone(),
+            }
+        })?;
+        let snapshot_path = group_dir.join(&entry.snapshot_filename);
+        if !snapshot_path.exists() {
+            return Err(BundleRestoreError::SnapshotMissing {
+                logical_name: target.logical_name.clone(),
+                path: snapshot_path,
+            });
+        }
+        matched.insert(entry.logical_name.as_str());
+        pairs.push((snapshot_path, target.dest.clone()));
+    }
+    if let Some(entry) = manifest
+        .entries
+        .iter()
+        .find(|e| !matched.contains(e.logical_name.as_str()))
+    {
+        return Err(BundleRestoreError::UnmatchedManifestEntry {
+            logical_name: entry.logical_name.clone(),
+        });
+    }
+    Ok(pairs)
+}
+
+async fn verify_snapshot_integrity(snapshot_path: &Path) -> Result<(), BundleRestoreError> {
+    let owned = snapshot_path.to_path_buf();
+    let result = tokio::task::spawn_blocking(move || -> Result<bool, rusqlite::Error> {
+        let conn = rusqlite::Connection::open_with_flags(
+            &owned,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        let row: String = conn.query_row("PRAGMA integrity_check", [], |r| r.get(0))?;
+        Ok(row == "ok")
+    })
+    .await;
+    let ok = match result {
+        Ok(Ok(ok)) => ok,
+        Ok(Err(_)) | Err(_) => false,
+    };
+    if !ok {
+        return Err(BundleRestoreError::PartialCorruption {
+            failed_file: snapshot_path.to_path_buf(),
+        });
+    }
+    Ok(())
+}
+
+fn atomic_rename_all(pairs: &[(PathBuf, PathBuf)]) -> Result<(), BundleRestoreError> {
+    for (src, dest) in pairs {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| BundleRestoreError::Io { source })?;
+        }
+        std::fs::rename(src, dest).map_err(|source| BundleRestoreError::Io { source })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_seed_db(path: &Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch("CREATE TABLE seed (id INTEGER PRIMARY KEY, payload TEXT);")
+            .unwrap();
+        conn.execute("INSERT INTO seed (payload) VALUES ('a'), ('b'), ('c')", [])
+            .unwrap();
+    }
+
+    fn read_bytes(p: &Path) -> Vec<u8> {
+        std::fs::read(p).unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_bundle_rejects_empty_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = create_bundle(dir.path(), "g1", &[]).await.unwrap_err();
+        assert!(matches!(err, BundleBackupError::EmptyBundle));
+    }
+
+    #[tokio::test]
+    async fn create_bundle_rejects_invalid_logical_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("a.db");
+        write_seed_db(&src);
+        let err = create_bundle(
+            dir.path(),
+            "g1",
+            &[DbInBundle {
+                logical_name: "bad/name",
+                source: &src,
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, BundleBackupError::InvalidLogicalName { .. }),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_bundle_rejects_duplicate_logical_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("a.db");
+        write_seed_db(&src);
+        let err = create_bundle(
+            dir.path(),
+            "g1",
+            &[
+                DbInBundle {
+                    logical_name: "alpha",
+                    source: &src,
+                },
+                DbInBundle {
+                    logical_name: "alpha",
+                    source: &src,
+                },
+            ],
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BundleBackupError::DuplicateLogicalName { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_bundle_writes_manifest_and_snapshots() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src_meta = work.path().join("meta.db");
+        let src_profile = work.path().join("acme/vertical.db");
+        write_seed_db(&src_meta);
+        write_seed_db(&src_profile);
+
+        let manifest = create_bundle(
+            &snaps,
+            "g1",
+            &[
+                DbInBundle {
+                    logical_name: "meta",
+                    source: &src_meta,
+                },
+                DbInBundle {
+                    logical_name: "vertical-acme",
+                    source: &src_profile,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(manifest.schema_version, BUNDLE_MANIFEST_SCHEMA_VERSION);
+        assert_eq!(manifest.group_id, "g1");
+        let names: Vec<&str> = manifest
+            .entries
+            .iter()
+            .map(|e| e.logical_name.as_str())
+            .collect();
+        assert_eq!(names, vec!["meta", "vertical-acme"]);
+
+        let group = snaps.join("g1");
+        assert!(group.join("manifest.json").exists());
+        assert!(group.join("meta.db").exists());
+        assert!(group.join("vertical-acme.db").exists());
+    }
+
+    #[tokio::test]
+    async fn restore_bundle_round_trips_payload() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src = work.path().join("src/data.db");
+        write_seed_db(&src);
+
+        create_bundle(
+            &snaps,
+            "g1",
+            &[DbInBundle {
+                logical_name: "data",
+                source: &src,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let dest = work.path().join("restored/data.db");
+        restore_bundle(
+            &snaps,
+            "g1",
+            &[RestoreTarget {
+                logical_name: "data".into(),
+                dest: dest.clone(),
+            }],
+        )
+        .await
+        .unwrap();
+
+        let conn = rusqlite::Connection::open(&dest).unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM seed", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn restore_refuses_when_manifest_missing() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src = work.path().join("src.db");
+        write_seed_db(&src);
+        create_bundle(
+            &snaps,
+            "g1",
+            &[DbInBundle {
+                logical_name: "data",
+                source: &src,
+            }],
+        )
+        .await
+        .unwrap();
+        std::fs::remove_file(snaps.join("g1/manifest.json")).unwrap();
+
+        let dest = work.path().join("dest.db");
+        write_seed_db(&dest);
+        let pre = read_bytes(&dest);
+
+        let err = restore_bundle(
+            &snaps,
+            "g1",
+            &[RestoreTarget {
+                logical_name: "data".into(),
+                dest: dest.clone(),
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BundleRestoreError::ManifestVerificationFailed { .. }
+        ));
+        assert_eq!(read_bytes(&dest), pre, "destination must be untouched");
+    }
+
+    #[tokio::test]
+    async fn restore_refuses_on_partial_corruption_with_disk_unchanged() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src_a = work.path().join("a.db");
+        let src_b = work.path().join("b.db");
+        write_seed_db(&src_a);
+        write_seed_db(&src_b);
+        create_bundle(
+            &snaps,
+            "g1",
+            &[
+                DbInBundle {
+                    logical_name: "alpha",
+                    source: &src_a,
+                },
+                DbInBundle {
+                    logical_name: "bravo",
+                    source: &src_b,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        // Corrupt the bravo snapshot — overwrite the file with bytes
+        // that are not a valid SQLite database. PRAGMA integrity_check
+        // cannot run because Connection::open rejects the file; the
+        // primitive's verify step treats either open failure or
+        // non-"ok" integrity as PartialCorruption.
+        let bravo_snap = snaps.join("g1/bravo.db");
+        std::fs::write(&bravo_snap, b"not a sqlite database").unwrap();
+
+        let dest_a = work.path().join("restored/a.db");
+        let dest_b = work.path().join("restored/b.db");
+        write_seed_db(&dest_a);
+        write_seed_db(&dest_b);
+        let pre_a = read_bytes(&dest_a);
+        let pre_b = read_bytes(&dest_b);
+
+        let err = restore_bundle(
+            &snaps,
+            "g1",
+            &[
+                RestoreTarget {
+                    logical_name: "alpha".into(),
+                    dest: dest_a.clone(),
+                },
+                RestoreTarget {
+                    logical_name: "bravo".into(),
+                    dest: dest_b.clone(),
+                },
+            ],
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, BundleRestoreError::PartialCorruption { ref failed_file } if failed_file.ends_with("bravo.db")),
+            "got {err:?}"
+        );
+        assert_eq!(read_bytes(&dest_a), pre_a, "alpha destination touched");
+        assert_eq!(read_bytes(&dest_b), pre_b, "bravo destination touched");
+    }
+
+    #[tokio::test]
+    async fn restore_rejects_target_unknown_to_manifest() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src = work.path().join("src.db");
+        write_seed_db(&src);
+        create_bundle(
+            &snaps,
+            "g1",
+            &[DbInBundle {
+                logical_name: "data",
+                source: &src,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let dest = work.path().join("dest.db");
+        let err = restore_bundle(
+            &snaps,
+            "g1",
+            &[RestoreTarget {
+                logical_name: "missing".into(),
+                dest,
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, BundleRestoreError::UnknownTarget { .. }));
+    }
+
+    #[tokio::test]
+    async fn restore_rejects_manifest_entry_without_target() {
+        let work = tempfile::tempdir().unwrap();
+        let snaps = work.path().join("snaps");
+        let src_a = work.path().join("a.db");
+        let src_b = work.path().join("b.db");
+        write_seed_db(&src_a);
+        write_seed_db(&src_b);
+        create_bundle(
+            &snaps,
+            "g1",
+            &[
+                DbInBundle {
+                    logical_name: "alpha",
+                    source: &src_a,
+                },
+                DbInBundle {
+                    logical_name: "bravo",
+                    source: &src_b,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        let dest = work.path().join("dest.db");
+        let err = restore_bundle(
+            &snaps,
+            "g1",
+            &[RestoreTarget {
+                logical_name: "alpha".into(),
+                dest,
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BundleRestoreError::UnmatchedManifestEntry { .. }
+        ));
+    }
+}

--- a/crates/kikan/src/meta/mod.rs
+++ b/crates/kikan/src/meta/mod.rs
@@ -7,12 +7,17 @@
 //! integrations) per `adr-kikan-upgrade-migration-strategy.md` and the
 //! M00 meta-DB introduction shape.
 
+pub mod backup;
 pub mod boot_state;
 pub mod diagnostics;
 pub mod entity;
 pub mod profiles;
 pub mod upgrade;
 
+pub use backup::{
+    BUNDLE_MANIFEST_SCHEMA_VERSION, BundleBackupError, BundleManifest, BundleManifestEntry,
+    BundleRestoreError, DbInBundle, RestoreTarget, create_bundle, restore_bundle,
+};
 pub use boot_state::{AbandonReason, BootState, BootStateDetectionError, detect_boot_state};
 pub use diagnostics::SidecarRecoveryDiagnostic;
 pub use profiles::{Profile, ProfileRepo, ProfileRepoError, SeaOrmProfileRepo};

--- a/crates/mokumo-shop/tests/platform_bdd_world/bundle_backup_steps.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/bundle_backup_steps.rs
@@ -250,7 +250,12 @@ async fn given_destinations_exist(w: &mut PlatformBddWorld) {
 #[when("the bundle group is restored to the data directory")]
 async fn when_bundle_restored(w: &mut PlatformBddWorld) {
     let ctx = w.bundle_backup.as_mut().unwrap();
-    let targets: Vec<RestoreTarget> = ctx
+    // `ctx.destinations` is a HashMap — sort by logical name so the
+    // RestoreTarget order handed to the primitive is deterministic
+    // across runs. Failure attribution (which file is reported in
+    // PartialCorruption / SnapshotMissing) depends on iteration
+    // order, so this avoids future-flake.
+    let mut targets: Vec<RestoreTarget> = ctx
         .destinations
         .iter()
         .map(|(name, dest)| RestoreTarget {
@@ -258,6 +263,7 @@ async fn when_bundle_restored(w: &mut PlatformBddWorld) {
             dest: dest.clone(),
         })
         .collect();
+    targets.sort_by(|a, b| a.logical_name.cmp(&b.logical_name));
     ctx.restore_result = Some(restore_bundle(&ctx.snapshot_root, GROUP_ID, &targets).await);
 }
 

--- a/crates/mokumo-shop/tests/platform_bdd_world/bundle_backup_steps.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/bundle_backup_steps.rs
@@ -1,0 +1,321 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use cucumber::{given, then, when};
+use kikan::{
+    BundleBackupError, BundleManifest, BundleRestoreError, DbInBundle, RestoreTarget,
+    create_bundle, restore_bundle,
+};
+
+use super::PlatformBddWorld;
+
+const GROUP_ID: &str = "g-test";
+
+pub struct BundleBackupCtx {
+    pub data_dir: tempfile::TempDir,
+    pub snapshot_root: PathBuf,
+    /// Logical name -> source DB path under the data dir.
+    pub sources: HashMap<String, PathBuf>,
+    /// Logical name -> destination DB path used for restore scenarios.
+    pub destinations: HashMap<String, PathBuf>,
+    /// Pre-restore byte content of each destination, captured immediately
+    /// before `restore_bundle` is invoked. The R6 strict-atomic invariant
+    /// is asserted by comparing post-call destination bytes against this.
+    pub destination_pre_restore: HashMap<String, Vec<u8>>,
+    pub backup_result: Option<Result<BundleManifest, BundleBackupError>>,
+    pub restore_result: Option<Result<(), BundleRestoreError>>,
+}
+
+impl std::fmt::Debug for BundleBackupCtx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BundleBackupCtx")
+            .field("data_dir", &self.data_dir.path())
+            .field("snapshot_root", &self.snapshot_root)
+            .field("sources", &self.sources)
+            .field("destinations", &self.destinations)
+            .field("backup_result", &self.backup_result)
+            .field("restore_result", &self.restore_result)
+            .finish()
+    }
+}
+
+fn write_seed_db(path: &std::path::Path) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute_batch("CREATE TABLE seed (id INTEGER PRIMARY KEY, payload TEXT);")
+        .unwrap();
+    conn.execute("INSERT INTO seed (payload) VALUES ('a'), ('b'), ('c')", [])
+        .unwrap();
+}
+
+fn fresh_ctx() -> BundleBackupCtx {
+    let data_dir = tempfile::tempdir().unwrap();
+    let snapshot_root = data_dir.path().join("snapshots");
+    BundleBackupCtx {
+        data_dir,
+        snapshot_root,
+        sources: HashMap::new(),
+        destinations: HashMap::new(),
+        destination_pre_restore: HashMap::new(),
+        backup_result: None,
+        restore_result: None,
+    }
+}
+
+// ── Backup-side steps ────────────────────────────────────────────────────
+
+#[given("a data directory containing meta sessions and one profile database")]
+async fn given_data_dir_with_three_dbs(w: &mut PlatformBddWorld) {
+    let mut ctx = fresh_ctx();
+    let logical_to_relpath = [
+        ("meta", "meta.db"),
+        ("sessions", "sessions.db"),
+        ("vertical-acme", "acme/vertical.db"),
+    ];
+    for (logical, rel) in logical_to_relpath {
+        let path = ctx.data_dir.path().join(rel);
+        write_seed_db(&path);
+        ctx.sources.insert(logical.to_string(), path);
+    }
+    w.bundle_backup = Some(ctx);
+}
+
+#[when("a bundle is created for the data directory")]
+async fn when_bundle_created(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_mut().unwrap();
+    let dbs: Vec<DbInBundle<'_>> = ctx
+        .sources
+        .iter()
+        .map(|(name, path)| DbInBundle {
+            logical_name: name.as_str(),
+            source: path.as_path(),
+        })
+        .collect();
+    ctx.backup_result = Some(create_bundle(&ctx.snapshot_root, GROUP_ID, &dbs).await);
+}
+
+#[then(expr = "the bundle manifest lists logical names {string} {string} and {string}")]
+async fn then_manifest_lists(w: &mut PlatformBddWorld, a: String, b: String, c: String) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    let manifest = ctx
+        .backup_result
+        .as_ref()
+        .expect("bundle was created")
+        .as_ref()
+        .expect("bundle creation succeeded");
+    let mut names: Vec<&str> = manifest
+        .entries
+        .iter()
+        .map(|e| e.logical_name.as_str())
+        .collect();
+    names.sort();
+    let mut expected = [a.as_str(), b.as_str(), c.as_str()];
+    expected.sort();
+    assert_eq!(names, expected.to_vec());
+}
+
+#[then("each logical name has a snapshot file on disk")]
+async fn then_snapshots_on_disk(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    let manifest = ctx
+        .backup_result
+        .as_ref()
+        .expect("bundle was created")
+        .as_ref()
+        .expect("bundle creation succeeded");
+    let group_dir = ctx.snapshot_root.join(&manifest.group_id);
+    for entry in &manifest.entries {
+        let path = group_dir.join(&entry.snapshot_filename);
+        assert!(
+            path.exists(),
+            "snapshot file for `{}` missing at {}",
+            entry.logical_name,
+            path.display(),
+        );
+        assert!(
+            path.metadata().unwrap().len() > 0,
+            "snapshot file for `{}` is empty",
+            entry.logical_name,
+        );
+    }
+}
+
+#[then("every snapshot passes a SQLite integrity check")]
+async fn then_snapshots_integrity_check(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    let manifest = ctx
+        .backup_result
+        .as_ref()
+        .expect("bundle was created")
+        .as_ref()
+        .expect("bundle creation succeeded");
+    let group_dir = ctx.snapshot_root.join(&manifest.group_id);
+    for entry in &manifest.entries {
+        let path = group_dir.join(&entry.snapshot_filename);
+        let conn = rusqlite::Connection::open_with_flags(
+            &path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .unwrap_or_else(|e| panic!("failed to open snapshot {}: {e}", path.display()));
+        let row: String = conn
+            .query_row("PRAGMA integrity_check", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            row,
+            "ok",
+            "integrity_check failed for `{}` at {}",
+            entry.logical_name,
+            path.display(),
+        );
+    }
+}
+
+// ── Restore-side steps ───────────────────────────────────────────────────
+
+#[given("a snapshots directory with a bundle group containing 3 healthy database snapshots")]
+async fn given_healthy_bundle_group(w: &mut PlatformBddWorld) {
+    let mut ctx = fresh_ctx();
+    let logical_to_relpath = [
+        ("meta", "meta.db"),
+        ("sessions", "sessions.db"),
+        ("vertical-acme", "acme/vertical.db"),
+    ];
+    let mut dbs_owned: Vec<(String, PathBuf)> = Vec::new();
+    for (logical, rel) in logical_to_relpath {
+        let path = ctx.data_dir.path().join(rel);
+        write_seed_db(&path);
+        ctx.sources.insert(logical.to_string(), path.clone());
+        dbs_owned.push((logical.to_string(), path));
+    }
+    let dbs: Vec<DbInBundle<'_>> = dbs_owned
+        .iter()
+        .map(|(name, path)| DbInBundle {
+            logical_name: name.as_str(),
+            source: path.as_path(),
+        })
+        .collect();
+    create_bundle(&ctx.snapshot_root, GROUP_ID, &dbs)
+        .await
+        .expect("bundle creation succeeded");
+    w.bundle_backup = Some(ctx);
+}
+
+#[given(expr = "the snapshot for {string} is corrupted on disk")]
+async fn given_snapshot_corrupted(w: &mut PlatformBddWorld, logical_name: String) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    let snap = ctx
+        .snapshot_root
+        .join(GROUP_ID)
+        .join(format!("{logical_name}.db"));
+    assert!(
+        snap.exists(),
+        "expected snapshot at {} before corrupting",
+        snap.display()
+    );
+    std::fs::write(&snap, b"not a sqlite database").unwrap();
+}
+
+#[given("the bundle manifest is removed")]
+async fn given_manifest_removed(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    let manifest = ctx.snapshot_root.join(GROUP_ID).join("manifest.json");
+    std::fs::remove_file(&manifest).unwrap();
+}
+
+#[given("destination database files exist with known content")]
+async fn given_destinations_exist(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_mut().unwrap();
+    let dest_root = ctx.data_dir.path().join("restored");
+    for (logical, _src) in ctx.sources.clone() {
+        let dest = dest_root.join(format!("{logical}.db"));
+        write_seed_db(&dest);
+        // Stamp each destination with a unique payload so the byte-equality
+        // check after restore would visibly fail if rename(2) ran.
+        {
+            let conn = rusqlite::Connection::open(&dest).unwrap();
+            conn.execute(
+                "INSERT INTO seed (payload) VALUES (?1)",
+                [&format!("pre-restore-{logical}")],
+            )
+            .unwrap();
+        }
+        let bytes = std::fs::read(&dest).unwrap();
+        ctx.destinations.insert(logical.clone(), dest);
+        ctx.destination_pre_restore.insert(logical, bytes);
+    }
+}
+
+#[when("the bundle group is restored to the data directory")]
+async fn when_bundle_restored(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_mut().unwrap();
+    let targets: Vec<RestoreTarget> = ctx
+        .destinations
+        .iter()
+        .map(|(name, dest)| RestoreTarget {
+            logical_name: name.clone(),
+            dest: dest.clone(),
+        })
+        .collect();
+    ctx.restore_result = Some(restore_bundle(&ctx.snapshot_root, GROUP_ID, &targets).await);
+}
+
+#[then(expr = "restore fails with BundleRestoreError PartialCorruption naming {string}")]
+async fn then_restore_partial_corruption(w: &mut PlatformBddWorld, logical_name: String) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    let err = ctx
+        .restore_result
+        .as_ref()
+        .expect("restore was attempted")
+        .as_ref()
+        .expect_err("restore must fail");
+    match err {
+        BundleRestoreError::PartialCorruption { failed_file } => assert!(
+            failed_file
+                .to_string_lossy()
+                .ends_with(&format!("{logical_name}.db")),
+            "PartialCorruption failed_file `{}` does not end with `{logical_name}.db`",
+            failed_file.display(),
+        ),
+        other => panic!("expected PartialCorruption, got {other:?}"),
+    }
+}
+
+#[then("restore fails with BundleRestoreError ManifestVerificationFailed")]
+async fn then_restore_manifest_verification_failed(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    let err = ctx
+        .restore_result
+        .as_ref()
+        .expect("restore was attempted")
+        .as_ref()
+        .expect_err("restore must fail");
+    assert!(
+        matches!(err, BundleRestoreError::ManifestVerificationFailed { .. }),
+        "expected ManifestVerificationFailed, got {err:?}"
+    );
+}
+
+#[then("every destination database file is byte-identical to its pre-restore content")]
+async fn then_destinations_unchanged(w: &mut PlatformBddWorld) {
+    let ctx = w.bundle_backup.as_ref().unwrap();
+    for (logical, dest) in &ctx.destinations {
+        let pre = ctx
+            .destination_pre_restore
+            .get(logical)
+            .expect("pre-restore content captured");
+        let post = std::fs::read(dest).unwrap_or_else(|e| {
+            panic!(
+                "destination for `{logical}` at {} could not be read after refusal: {e}",
+                dest.display()
+            )
+        });
+        assert_eq!(
+            &post,
+            pre,
+            "destination for `{logical}` at {} was mutated by a refused restore",
+            dest.display(),
+        );
+    }
+}

--- a/crates/mokumo-shop/tests/platform_bdd_world/bundle_backup_steps.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/bundle_backup_steps.rs
@@ -271,7 +271,7 @@ async fn then_restore_partial_corruption(w: &mut PlatformBddWorld, logical_name:
         .as_ref()
         .expect_err("restore must fail");
     match err {
-        BundleRestoreError::PartialCorruption { failed_file } => assert!(
+        BundleRestoreError::PartialCorruption { failed_file, .. } => assert!(
             failed_file
                 .to_string_lossy()
                 .ends_with(&format!("{logical_name}.db")),

--- a/crates/mokumo-shop/tests/platform_bdd_world/mod.rs
+++ b/crates/mokumo-shop/tests/platform_bdd_world/mod.rs
@@ -2,6 +2,7 @@ use cucumber::World;
 use sea_orm::DatabaseConnection;
 use sqlx::SqlitePool;
 
+mod bundle_backup_steps;
 mod install_validation_steps;
 mod legacy_refuse_boot_steps;
 mod migration_safety_steps;
@@ -43,6 +44,8 @@ pub struct PlatformBddWorld {
     pub legacy_refuse: Option<legacy_refuse_boot_steps::LegacyRefuseCtx>,
     // Sidecar recovery scenario state
     pub sidecar_recovery: Option<sidecar_recovery_steps::SidecarRecoveryCtx>,
+    // Bundle backup / restore scenario state
+    pub bundle_backup: Option<bundle_backup_steps::BundleBackupCtx>,
 }
 
 impl PlatformBddWorld {
@@ -77,6 +80,7 @@ impl PlatformBddWorld {
             restore_production_dir: None,
             legacy_refuse: None,
             sidecar_recovery: None,
+            bundle_backup: None,
         }
     }
 }

--- a/crates/mokumo-shop/tests/platform_features/bundle_backup_includes_meta_db.feature
+++ b/crates/mokumo-shop/tests/platform_features/bundle_backup_includes_meta_db.feature
@@ -1,0 +1,18 @@
+Feature: Bundle backup primitive captures meta.db alongside profile DBs
+
+  The bundle backup primitive captures every database the caller hands
+  it — meta.db, sessions.db, and one snapshot per profile vertical DB.
+  Each snapshot is produced via SQLite `VACUUM INTO` so WAL contents
+  are checkpointed into a self-contained file. The manifest names every
+  snapshot by its caller-supplied logical name so restore can reverse
+  the mapping deterministically.
+
+  See `crates/kikan/src/meta/backup.rs` and Q6 in
+  `ops/workspace/mokumo/20260425-kikan-meta-db-introduction/validated-requirements.md`.
+
+  Scenario: bundle captures meta, sessions, and a profile DB
+    Given a data directory containing meta sessions and one profile database
+    When a bundle is created for the data directory
+    Then the bundle manifest lists logical names "meta" "sessions" and "vertical-acme"
+    And each logical name has a snapshot file on disk
+    And every snapshot passes a SQLite integrity check

--- a/crates/mokumo-shop/tests/platform_features/restore_refuses_partially_corrupt_bundle.feature
+++ b/crates/mokumo-shop/tests/platform_features/restore_refuses_partially_corrupt_bundle.feature
@@ -1,0 +1,28 @@
+Feature: Bundle restore refuses on any partial corruption (strict atomic)
+
+  When a bundle's manifest is missing or any snapshot file fails
+  integrity, the restore primitive refuses to proceed and leaves every
+  destination file on disk unchanged. There is no "best-effort partial
+  restore" — operators get a clear refusal naming the failed file
+  rather than a partially-restored state.
+
+  See `crates/kikan/src/meta/backup.rs`, R6 in
+  `ops/workspace/mokumo/20260425-kikan-meta-db-introduction/shaping.md`,
+  and `adr-kikan-upgrade-migration-strategy.md` §"Multi-database
+  operation-level atomicity via snapshot-and-restore".
+
+  Scenario: one corrupt snapshot in a bundle aborts restore with disk unchanged
+    Given a snapshots directory with a bundle group containing 3 healthy database snapshots
+    And the snapshot for "vertical-acme" is corrupted on disk
+    And destination database files exist with known content
+    When the bundle group is restored to the data directory
+    Then restore fails with BundleRestoreError PartialCorruption naming "vertical-acme"
+    And every destination database file is byte-identical to its pre-restore content
+
+  Scenario: missing manifest aborts restore with disk unchanged
+    Given a snapshots directory with a bundle group containing 3 healthy database snapshots
+    And the bundle manifest is removed
+    And destination database files exist with known content
+    When the bundle group is restored to the data directory
+    Then restore fails with BundleRestoreError ManifestVerificationFailed
+    And every destination database file is byte-identical to its pre-restore content


### PR DESCRIPTION
## Summary

Introduces `kikan::meta::backup` — a vocabulary-neutral primitive for **multi-database bundle backup with strict-atomic restore**. Closes the M00 PR A wave A2.2 work item from the meta-DB pipeline.

The bundle primitive backs up a caller-supplied list of logical databases (meta, sessions, per-profile, …) into a single group directory under a snapshots root. Each snapshot is produced via `VACUUM INTO` (WAL-checkpointed, page-coherent, single self-contained file — not a torn raw copy). A `manifest.json` records the schema version, group id, creation timestamp, and per-entry filename + byte count.

Restore is **strict-atomic at the operation level**:
1. Read + parse `manifest.json`.
2. Pair each caller-supplied target with its manifest entry (every target must match; every manifest entry must be claimed).
3. For every snapshot: open read-only and run `PRAGMA integrity_check`. Any failure (including failure to open as a SQLite database) returns `BundleRestoreError::PartialCorruption { failed_file }` **before** any destination file is touched.
4. Only after every snapshot passes does the rename loop start. Renames are POSIX-atomic per file via `std::fs::rename(2)`.

This shape is the operator promise from the shaping doc: *"we restored most of your data" is a worse failure mode than "we refused, and you know exactly where you stand."*

## Plan deviations

Three calls deviate from the literal plan; all resolved with the advisor.

1. **New `BundleRestoreError` next to the bundle primitive, not extending `backup::restore::RestoreError`.** The existing single-DB restore error encodes precondition shapes specific to `pre_migration_backup` (`NotKikanDatabase`, `SchemaIncompatible`, `ProductionDbExists`). The bundle primitive has different vocabulary (manifest, group, multi-target pairing) and a different invariant (operation-level atomicity across N files). Stretching one enum across both surfaces would either weaken the bundle errors or muddy the per-DB ones.
2. **Caller passes the `DbInBundle` / `RestoreTarget` list.** The plan said "every profile DB"; the implementation keeps `kikan::meta::backup` strictly vocabulary-neutral by accepting a caller-supplied list of `(logical_name, path)` pairs. The Mokumo CLI / future scheduled-backup handler enumerates `meta.profiles` and assembles the list — this avoids `kikan` having to know about vertical filenames or the meta DB schema at the primitive level (preserves I1/strict).
3. **`kikan::backup::pre_migration_backup` is intentionally not retrofitted to use the bundle primitive.** That path is per-DB, runs at migration boot, and has a different recovery contract (legacy single-file backup). Conflating the two would couple unrelated lifecycles. Bundle backup is the operator-facing snapshot primitive; per-DB pre-migration backup remains a runner-internal concern.

## Files

**Created**
- `crates/kikan/src/meta/backup.rs` (~700 lines) — primitive + 9 module-level unit tests
- `crates/mokumo-shop/tests/platform_features/restore_refuses_partially_corrupt_bundle.feature` — 2 scenarios (corrupted snapshot, missing manifest)
- `crates/mokumo-shop/tests/platform_features/bundle_backup_includes_meta_db.feature` — 1 scenario (meta + sessions + 1 profile DB → manifest, on-disk snapshots, integrity_check ok)
- `crates/mokumo-shop/tests/platform_bdd_world/bundle_backup_steps.rs` — step defs + ctx (manual `Debug` impl since `tempfile::TempDir` isn't `Debug`)

**Modified**
- `crates/kikan/src/meta/mod.rs` — `pub mod backup;` + re-exports
- `crates/kikan/src/lib.rs` — re-export bundle types into the kikan crate root
- `crates/mokumo-shop/tests/platform_bdd_world/mod.rs` — wire `BundleBackupCtx` field
- `CHANGELOG.md` — `## Unreleased` entry under `### Added`

## API surface

```rust
pub const BUNDLE_MANIFEST_SCHEMA_VERSION: u32 = 1;

pub struct DbInBundle<'a> { pub logical_name: &'a str, pub source: &'a Path }
pub struct RestoreTarget   { pub logical_name: String, pub dest: PathBuf }

pub struct BundleManifestEntry { pub logical_name: String, pub snapshot_filename: String, pub bytes: u64 }
pub struct BundleManifest      { pub schema_version: u32, pub group_id: String,
                                 pub created_at: DateTime<Utc>, pub entries: Vec<BundleManifestEntry> }

#[non_exhaustive] pub enum BundleBackupError  { /* EmptyBundle, InvalidLogicalName, DuplicateLogicalName,
                                                    SourceMissing, Snapshot, Io, Serialize */ }
#[non_exhaustive] pub enum BundleRestoreError { /* ManifestVerificationFailed, PartialCorruption,
                                                    UnknownTarget, UnmatchedManifestEntry,
                                                    SnapshotMissing, Io */ }

pub async fn create_bundle(snapshot_root: &Path, group_id: &str, dbs: &[DbInBundle<'_>])
    -> Result<BundleManifest, BundleBackupError>;
pub async fn restore_bundle(snapshot_root: &Path, group_id: &str, targets: &[RestoreTarget])
    -> Result<(), BundleRestoreError>;
```

`#[non_exhaustive]` on both enums + `thiserror` with `Box<dyn Error + Send + Sync>` source chains follow the A2.1 hard-won patterns. rusqlite is wrapped with `tokio::task::spawn_blocking` since the SQLite C calls are sync.

## Test plan

- [x] 9 module-level unit tests in `meta/backup.rs` (manifest round-trip, validation, snapshot disk-format, restore-with-corrupted-snapshot, restore-with-missing-manifest, etc.)
- [x] 3 new BDD scenarios under `crates/mokumo-shop/tests/platform_features/` — all green; `then_destinations_unchanged` byte-equality guards the strict-atomic invariant
- [x] `cargo test -p kikan` — 526 tests across 17 suites, no regressions
- [x] `cargo test -p mokumo-shop --features bdd --test platform_bdd` — 48 scenarios (42 pass, 6 pre-existing exempt @wip/@allow.skipped/@future)
- [x] `cargo clippy --workspace --exclude mokumo-desktop --exclude kikan-tauri --exclude kikan-admin-ui --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] All `bash scripts/check-i*.sh` — pass (I1/classic, I1/strict vocab purity, I2 adapter boundary, I4 DAG)
- [ ] CI confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bundle backup and restore capabilities for creating point-in-time snapshots of multiple SQLite databases
  * Implemented strict-atomic restore with manifest verification and integrity checks that run before any destination modifications
  * Guarantees no destination files are altered if verification or integrity checks fail

* **Tests**
  * Added comprehensive test coverage for bundle backup/restore workflows, corruption detection, and atomicity guarantees

<!-- end of auto-generated comment: release notes by coderabbit.ai -->