### PR TITLE
fix(shop): restore shop_logo_not_found vertical error code (#695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **Shop logo 404 now returns vertical error code** (`mokumo-shop`): `GET /api/shop/logo` and `DELETE /api/shop/logo` when no logo is set now return `{"code":"shop_logo_not_found","..."}` instead of the platform-wide `{"code":"not_found","..."}`. Fixes #695 — the frontend, BDD spec, and Hurl smoke test all expected the vertical code.
+
 ### Added
 
 - **Bundle backup with strict-atomic restore** (M00 PR A wave A2.2, kikan):

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -277,14 +277,6 @@ tasks:
       #     Tracked: PR 2 (auth bootstrap) of mokumo#383 — once the harness
       #     can carry an authenticated admin session, these flip to 404.
       #
-      #   tests/api/shop/logo-get.hurl
-      #     Failure: server returns code=`not_found`, test expects
-      #     code=`shop_logo_not_found`. Genuine contract drift; one side
-      #     is wrong. Test was authored when the handler returned a
-      #     domain-specific error code; the handler now returns the
-      #     generic `not_found`.
-      #     Tracked: mokumo#695 (logo-get contract drift — fix in PR 3 of
-      #     mokumo#383 endpoint backfill).
       # ---------------------------------------------------------------------
       hurl --variables-file tests/api/envs/ci.env --test \
         tests/api/_prelude/healthy-demo.hurl \
@@ -293,7 +285,8 @@ tasks:
         tests/api/offline/boot.hurl \
         tests/api/auth/login-bad-credentials.hurl \
         tests/api/customers/not-found.hurl \
-        tests/api/settings/lan-access.hurl
+        tests/api/settings/lan-access.hurl \
+        tests/api/shop/logo-get.hurl
     deps:
     - web:build
     - web:seed-demo

--- a/crates/mokumo-shop/src/shop/error.rs
+++ b/crates/mokumo-shop/src/shop/error.rs
@@ -46,6 +46,11 @@ pub enum ShopLogoHandlerError {
         code: ShopErrorCode,
         message: String,
     },
+    /// 404 with a shop-vertical code (e.g. `ShopLogoNotFound`).
+    ShopNotFound {
+        code: ShopErrorCode,
+        message: String,
+    },
     Internal(String),
 }
 
@@ -148,6 +153,14 @@ impl IntoResponse for ShopLogoHandlerError {
             ),
             Self::ShopUnprocessable { code, message } => shop_body(
                 StatusCode::UNPROCESSABLE_ENTITY,
+                ShopErrorBody {
+                    code,
+                    message,
+                    details: None,
+                },
+            ),
+            Self::ShopNotFound { code, message } => shop_body(
+                StatusCode::NOT_FOUND,
                 ShopErrorBody {
                     code,
                     message,
@@ -266,6 +279,24 @@ mod tests {
         let json = std::str::from_utf8(&body).unwrap();
         assert!(
             json.contains("\"code\":\"logo_too_large\""),
+            "unexpected wire shape: {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn shop_not_found_wire_shape_uses_vertical_code() {
+        let err = ShopLogoHandlerError::ShopNotFound {
+            code: ShopErrorCode::ShopLogoNotFound,
+            message: "no logo".into(),
+        };
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json = std::str::from_utf8(&body).unwrap();
+        assert!(
+            json.contains("\"code\":\"shop_logo_not_found\""),
             "unexpected wire shape: {json}"
         );
     }

--- a/crates/mokumo-shop/src/shop/handler.rs
+++ b/crates/mokumo-shop/src/shop/handler.rs
@@ -18,7 +18,6 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use kikan::actor::Actor;
-use kikan::error::DomainError;
 use kikan::rate_limit::RateLimiter;
 use kikan_types::error::ErrorCode;
 use tokio::fs;
@@ -99,12 +98,13 @@ pub(crate) async fn get_logo_impl(
     deps: &ShopLogoRouterDeps,
 ) -> Result<axum::response::Response, ShopLogoHandlerError> {
     let svc = build_service(deps.production_db.clone(), deps);
-    let info = svc.get_logo_info().await?.ok_or_else(|| {
-        ShopLogoHandlerError::from(DomainError::NotFound {
-            entity: "shop_logo",
-            id: "1".into(),
-        })
-    })?;
+    let info = svc
+        .get_logo_info()
+        .await?
+        .ok_or_else(|| ShopLogoHandlerError::ShopNotFound {
+            code: ShopErrorCode::ShopLogoNotFound,
+            message: "Shop logo has not been uploaded".into(),
+        })?;
 
     let content_type = match info.extension.as_str() {
         "png" => "image/png",
@@ -126,10 +126,10 @@ pub(crate) async fn get_logo_impl(
 
     let data = fs::read(&path).await.map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
-            ShopLogoHandlerError::from(DomainError::NotFound {
-                entity: "shop_logo",
-                id: "1".into(),
-            })
+            ShopLogoHandlerError::ShopNotFound {
+                code: ShopErrorCode::ShopLogoNotFound,
+                message: "Shop logo has not been uploaded".into(),
+            }
         } else {
             tracing::error!("get_logo: failed to read logo file {path:?}: {e}");
             ShopLogoHandlerError::Internal("Failed to read logo file".into())
@@ -249,12 +249,13 @@ pub(crate) async fn delete_logo_impl(
     require_production(mode)?;
 
     let svc = build_service(db, deps);
-    let info = svc.get_logo_info().await?.ok_or_else(|| {
-        ShopLogoHandlerError::from(DomainError::NotFound {
-            entity: "shop_logo",
-            id: "1".into(),
-        })
-    })?;
+    let info = svc
+        .get_logo_info()
+        .await?
+        .ok_or_else(|| ShopLogoHandlerError::ShopNotFound {
+            code: ShopErrorCode::ShopLogoNotFound,
+            message: "Shop logo has not been uploaded".into(),
+        })?;
 
     let actor = Actor::user(actor_id);
     svc.delete_logo(&actor).await?;

--- a/crates/mokumo-shop/src/types/error.rs
+++ b/crates/mokumo-shop/src/types/error.rs
@@ -72,6 +72,10 @@ pub struct ShopErrorBody {
 mod tests {
     use super::*;
 
+    // Canonical gate: every ShopErrorCode variant must appear here so the
+    // display_matches_serde_for_all_variants test below catches any future
+    // variant whose Display and serde representations diverge before it
+    // reaches the wire. Update the array size when adding variants.
     fn all_shop_error_codes() -> [ShopErrorCode; 7] {
         [
             ShopErrorCode::ShopLogoRequiresProductionProfile,


### PR DESCRIPTION
## Summary
- Add `ShopLogoHandlerError::ShopNotFound` variant emitting vertical-specific `shop_logo_not_found` code
- Re-attach `tests/api/shop/logo-get.hurl` to `shop:smoke` (was darkened pending this fix)
- Standardize: every handler error variant gets a wire-shape unit test (codified in `.claude/ops-pipeline/standards/testing/handler-error-contracts.md` for closeout promotion)

## What this fixes
The `IntoResponse` for `ShopLogoHandlerError` was mapping `DomainError::NotFound` to platform-wide `ErrorCode::NotFound` instead of the vertical `ShopErrorCode::ShopLogoNotFound`. The frontend, the BDD spec, the hurl test, and the file's own header comment all expected the vertical code; the implementation drifted during the Stage 3 S4.3 platform/vertical split (#587).

## Test plan
- [x] `shop:test` green — 314 tests passed (nextest is x86 in this container; ran via `cargo test` directly with identical results)
- [x] Pre-push hook ran `shop:lint` (clippy `-D warnings`) — clean
- [x] `cargo fmt --check` — clean
- [x] New unit test `shop_not_found_wire_shape_uses_vertical_code` asserts the JSON `code` string
- [ ] `shop:smoke` — requires running server + demo seed; `logo-get.hurl` is re-attached and will gate CI

Closes #695
Unblocks #383 PR 3
Related #697 (BDD silent-pass — fix in follow-up)