### PR TITLE
test(383): re-attach 11 unauth .hurl files + fix structural assertions (PR 1 of #383)

### DIFF
--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -277,17 +277,89 @@ tasks:
       #     Tracked: PR 2 (auth bootstrap) of mokumo#383 — once the harness
       #     can carry an authenticated admin session, these flip to 404.
       #
+      #   tests/api/auth/forgot-password.hurl
+      #   tests/api/auth/login-rate-limit.hurl
+      #   tests/api/auth/reset-password.hurl
+      #     Pre-existing — not yet in shop:smoke. These pass against the
+      #     demo profile today (auto-login carries them, or they exercise
+      #     the validation/rate-limit paths directly), but they touch the
+      #     auth surface that mokumo#685 (auth-handler promotion to the
+      #     kikan platform) is moving to /api/platform/v1/auth/*.
+      #     Deferred from PR 1 → PR 2 to avoid mid-flight conflict; PR 2's
+      #     auth bootstrap will absorb whatever the auth surface looks
+      #     like post-#685.
+      #     Tracked: PR 2 of mokumo#383, coordinates with mokumo#685.
+      #
+      #   tests/api/auth/login-success.hurl
+      #     Failure: requires `admin_email` and `admin_password` variables
+      #     in tests/api/envs/ci.env that the smoke harness does not yet
+      #     thread. Demo auto-login does not satisfy the explicit POST
+      #     /api/auth/login + cookie-capture step.
+      #     Tracked: PR 2 (auth bootstrap) of mokumo#383.
+      #
+      #   tests/api/auth/me.hurl
+      #     Failure: asserts a specific user identity that demo auto-login
+      #     (admin@demo.local) does not match. Needs production-profile
+      #     harness with seeded credentials.
+      #     Tracked: PR 2 (auth bootstrap) of mokumo#383.
+      #
+      #   tests/api/customers/get.hurl
+      #     Failure: references a specific customer id that the demo seed
+      #     does not contain. Needs the harness to either seed a known
+      #     customer or capture an id from a prior step.
+      #     Tracked: PR 2 (auth bootstrap) of mokumo#383.
+      #
+      #   tests/api/session_continuity.hurl
+      #     Failure: requires a pre-Stage-3 session-snapshot fixture and
+      #     a harness that boots the post-Stage-3 binary against it,
+      #     injecting `pre_stage3_session`, `alice_email`,
+      #     `alice_password`, `expected_session_name`. Not a smoke-suite
+      #     test — belongs in a dedicated continuity Moon task.
+      #     Tracked: mokumo#702.
+      #
+      #   tests/api/shop/logo-upload.hurl
+      #   tests/api/shop/logo-upload-errors.hurl
+      #   tests/api/shop/logo-delete.hurl
+      #     Failure: stale `---` request separator (Hurl uses blank-line
+      #     separators; `---` parses as an HTTP method) AND the test does
+      #     its own POST /api/auth/login that needs admin credentials in
+      #     ci.env that PR 2 will introduce. Both blockers resolve under
+      #     PR 2's auth bootstrap pass.
+      #     Tracked: PR 2 (auth bootstrap) of mokumo#383.
+      #
+      # Coverage notes — files in the active list with known structural-only
+      # coverage that requires a Rust-side backstop per the G3 split:
+      #
+      #   tests/api/shop/restore.hurl
+      #   tests/api/shop/restore-validate.hurl
+      #     Under the smoke harness, `RestoreGuard::acquire` always returns
+      #     409 `production_db_exists` before body parsing, so the 400
+      #     `parse_error` and 429 `rate_limited` paths are unreachable here.
+      #     Per-variant Rust unit tests for those wire shapes are tracked in
+      #     mokumo#701.
+      #
       # ---------------------------------------------------------------------
       hurl --variables-file tests/api/envs/ci.env --test \
         tests/api/_prelude/healthy-demo.hurl \
         tests/api/routing/api-prefix-boundary.hurl \
         tests/api/routing/method-rejection.hurl \
         tests/api/health/health.hurl \
+        tests/api/health/security-headers.hurl \
         tests/api/offline/boot.hurl \
+        tests/api/bind/ephemeral-loopback.hurl \
+        tests/api/security/host-allowlist.hurl \
+        tests/api/kikan-version/kikan-version.hurl \
         tests/api/auth/login-bad-credentials.hurl \
         tests/api/customers/not-found.hurl \
+        tests/api/customers/list.hurl \
+        tests/api/customers/create.hurl \
         tests/api/settings/lan-access.hurl \
-        tests/api/shop/logo-get.hurl
+        tests/api/shop/logo-get.hurl \
+        tests/api/shop/restore-validate.hurl \
+        tests/api/shop/restore.hurl \
+        tests/api/backup/status.hurl \
+        tests/api/diagnostics/diagnostics.hurl \
+        tests/api/diagnostics/bundle.hurl
     deps:
     - web:build
     - web:seed-demo

--- a/tests/api/diagnostics/bundle.hurl
+++ b/tests/api/diagnostics/bundle.hurl
@@ -1,4 +1,6 @@
-# Auth-gated — run after auth/login-success.hurl in a cookie-jar chain.
+# Auth-gated. In demo profile, the auto-login middleware authenticates the
+# anonymous caller as the demo admin. In production profile, run after
+# auth/login-success.hurl in a cookie-jar chain (PR 2 of mokumo#383).
 GET http://{{host}}/api/diagnostics/bundle
 
 HTTP 200
@@ -6,4 +8,4 @@ HTTP 200
 header "Content-Type" contains "application/zip"
 header "Content-Disposition" contains "attachment"
 header "Content-Disposition" contains "mokumo-diagnostics"
-bytes isNotEmpty
+bytes count > 0

--- a/tests/api/shop/restore-validate.hurl
+++ b/tests/api/shop/restore-validate.hurl
@@ -1,29 +1,35 @@
 # POST /api/shop/restore/validate — smoke tests
-# NOTE: These run against a running server that has completed setup
-# (non-first-launch). All non-parse requests should return 403 forbidden
-# because the endpoint is only available during first launch.
+#
+# `mokumo-server` eagerly initializes both the demo and production database
+# slots on boot. The validate handler shares the same `RestoreGuard` as
+# `/api/shop/restore`, so 409 `production_db_exists` always wins under the
+# smoke harness.
+#
+# Coverage gap: the body-parse (400 `parse_error`) and rate-limit
+# (429 `rate_limited`) paths are NOT exercised by this file — the guard
+# fires first. Rust unit tests for those wire-shape variants are tracked
+# in mokumo#701 (per the G3 split in `hurl-conventions.md`).
 
-# No body → 400 parse_error
+# Empty/unparseable body still hits the guard first.
 POST http://{{host}}/api/shop/restore/validate
 Content-Type: text/plain
 
-HTTP 400
+HTTP 409
 [Asserts]
 header "Content-Type" contains "application/json"
-jsonpath "$.code" == "parse_error"
+jsonpath "$.code" == "production_db_exists"
 jsonpath "$.message" isString
 jsonpath "$.details" == null
 
----
 
-# Non-first-launch server returns 403 forbidden
+# JSON body with bogus path also hits the guard first.
 POST http://{{host}}/api/shop/restore/validate
 Content-Type: application/json
 {"path": "/tmp/nonexistent.db"}
 
-HTTP 403
+HTTP 409
 [Asserts]
 header "Content-Type" contains "application/json"
-jsonpath "$.code" == "forbidden"
+jsonpath "$.code" == "production_db_exists"
 jsonpath "$.message" isString
 jsonpath "$.details" == null

--- a/tests/api/shop/restore.hurl
+++ b/tests/api/shop/restore.hurl
@@ -1,26 +1,37 @@
 # POST /api/shop/restore — smoke tests
+#
+# `mokumo-server` eagerly initializes both the demo and production database
+# slots on boot. The restore handler holds a `RestoreGuard` that returns
+# 409 `production_db_exists` whenever a production DB is already present —
+# which is always true under the smoke harness. So both an unparseable body
+# and a parseable-but-foreign body collapse to the same structural contract
+# under this state.
+#
+# Coverage gap: the body-parse (400 `parse_error`) and rate-limit
+# (429 `rate_limited`) paths are NOT exercised by this file — the guard
+# fires first. Rust unit tests for those wire-shape variants are tracked
+# in mokumo#701 (per the G3 split in `hurl-conventions.md`).
 
-# No body → 400 parse_error
+# Empty/unparseable body still hits the guard first.
 POST http://{{host}}/api/shop/restore
 Content-Type: text/plain
 
-HTTP 400
+HTTP 409
 [Asserts]
 header "Content-Type" contains "application/json"
-jsonpath "$.code" == "parse_error"
+jsonpath "$.code" == "production_db_exists"
 jsonpath "$.message" isString
 jsonpath "$.details" == null
 
----
 
-# Non-first-launch server returns 403 forbidden
+# JSON body with bogus path also hits the guard first.
 POST http://{{host}}/api/shop/restore
 Content-Type: application/json
 {"path": "/tmp/nonexistent.db"}
 
-HTTP 403
+HTTP 409
 [Asserts]
 header "Content-Type" contains "application/json"
-jsonpath "$.code" == "forbidden"
+jsonpath "$.code" == "production_db_exists"
 jsonpath "$.message" isString
 jsonpath "$.details" == null


### PR DESCRIPTION
## Summary

PR 1 of mokumo#383 (the narrowed scope). Re-attaches **11** unauth `.hurl` files to the canonical `crates/mokumo-shop/moon.yml` `shop:smoke` active list, fixes a few stale assertions to match actual server behavior under the smoke harness, and extends the documented-exclusions ledger to cover everything the audit surfaced.

Result: **20 active files, 37 requests, 100% green** via `moon run shop:smoke` (62ms).

## Re-attached to the active list

```
tests/api/health/security-headers.hurl
tests/api/bind/ephemeral-loopback.hurl
tests/api/security/host-allowlist.hurl
tests/api/kikan-version/kikan-version.hurl
tests/api/customers/list.hurl
tests/api/customers/create.hurl
tests/api/shop/restore-validate.hurl
tests/api/shop/restore.hurl
tests/api/backup/status.hurl
tests/api/diagnostics/diagnostics.hurl
tests/api/diagnostics/bundle.hurl
```

### Scope override note (vs. focus.md)

`customers/create.hurl` and `customers/list.hurl` were classified "Likely PR 2" in the frame because they hit auth-gated routes. They were promoted to PR 1 after empirical verification that demo auto-login (`auth_handlers/mod.rs:468`) carries them — the SOP for demo-shortcut tests in the new `hurl-conventions.md`. They pass green and add real coverage now without any harness work.

## Assertion fixes (matching actual server behavior)

- `tests/api/diagnostics/bundle.hurl` — replaced invalid `bytes isNotEmpty` predicate with `bytes count > 0` (the former is not a Hurl predicate). Added a header comment about the demo auto-login dependency (vs. the production-profile cookie-jar pattern that PR 2 will land).
- `tests/api/shop/restore.hurl` + `tests/api/shop/restore-validate.hurl`:
  - Replaced stale `---` request separators (`---` parses as an HTTP method in Hurl 7.x) with blank-line separators (Hurl's actual block syntax).
  - Replaced 400/403 expectations with the actual `409 production_db_exists` contract. Under the smoke harness, `mokumo-server` eagerly initializes both DB slots on boot, so `RestoreGuard::acquire` always fires before body parsing or rate-limit checks. The 400 `parse_error` and 429 `rate_limited` paths are unreachable from Hurl on this profile; per-variant Rust unit tests for those wire shapes are tracked in **mokumo#701**.

## Ledger extensions

The documented-exclusions block in `moon.yml` now covers 9 deferrals with explicit failure modes and trackers:

- `auth/forgot-password.hurl`, `auth/login-rate-limit.hurl`, `auth/reset-password.hurl` — deferred from PR 1 → PR 2 to avoid mid-flight conflict with **mokumo#685** (auth-handler promotion to `/api/platform/v1/auth/*`).
- `auth/login-success.hurl`, `auth/me.hurl` — need credentials/profile harness landing in PR 2.
- `customers/get.hurl` — needs a known-id demo seed or a captured-id chain (PR 2).
- `session_continuity.hurl` — pre-Stage-3 fixture + post-Stage-3 binary harness; not a smoke-suite test. Tracker updated from the stale "Stage 3 R12" workspace reference to **mokumo#702**.
- `shop/logo-upload.hurl`, `shop/logo-upload-errors.hurl`, `shop/logo-delete.hurl` — same `---`-separator + auth-credentials blockers as restore.hurl had; both resolve under PR 2's auth bootstrap + a separator sweep.

A new **"Coverage notes"** subsection flags structural-only coverage in the active list (currently restore + restore-validate), pointing at **mokumo#701** as the Rust-side backstop tracker per the G3 split.

## Companion ops-repo changes (NOT in this PR)

The other deliverables for PR 1 are staged in this workspace and will land via a separate ops-repo PR:

- **NEW** `ops/standards/testing/hurl-conventions.md` — bakes guardrails G1 (CI YAML is a thin shell), G2 (local DX must be agent-loopable), G3 (Hurl is structural, Rust is logical) with worked examples.
- **FIX** `ops/standards/testing/negative-path.md` — `$.error` → `$.code` at the two doc-example assertions (lines 82, 144) per `adr-api-response-conventions.md`.

Both files are staged at `ops/workspace/mokumo/mokumo-20260426-383-hurl-suite/staged-standards/`. The container has `/ops/standards/` mounted read-only, so the ops PR is filed separately from the host.

## Test plan

- [x] `bash scripts/check-no-hurl-in-workflows.sh` — passes (G1 enforcement: no `tests/api/*.hurl` paths in `.github/workflows/`).
- [x] `moon run shop:smoke` — 20 files, 37 requests, 0 failures, 62ms.
- [ ] CI green on this branch.

## Out of scope (deferred to PR 2)

- The 9 ledgered files above (auth bootstrap + harness work).
- Rust unit tests for `restore_handler` 400/429 wire shapes (**mokumo#701**).
- Continuity harness for `session_continuity.hurl` (**mokumo#702**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)