### PR TITLE
test(383): re-attach 10 Phase-2 .hurl files behind HTTP setup wizard (PR 2.5)

### DIFF
--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -453,10 +453,16 @@ tasks:
       hurl --variables-file tests/api/envs/ci.env --cookie-jar "$COOKIE_JAR" --test \
         tests/api/_prelude/admin-login.hurl
       # Phase 2 — explicit-admin tests reading the shared cookie jar.
-      # Order within the shop/logo set: logo-upload first (leaves a logo),
+      # `--jobs 1` is required: hurl --test runs files in parallel by
+      # default (one job per CPU), but the shop/logo-* trio mutates the
+      # same `shop_settings WHERE id = 1` row. Without serialization,
+      # logo-delete.hurl's DELETE can land between logo-upload.hurl's
+      # POST and its follow-up `/api/setup-status` read, blanking
+      # logo_extension/logo_epoch and turning logo_url back to null
+      # under hurl. Order: logo-upload first (leaves a logo),
       # logo-upload-errors next (validation rejects, no state change),
       # logo-delete last (uploads + deletes; ends with no logo on disk).
-      hurl --variables-file tests/api/envs/ci.env --cookie "$COOKIE_JAR" --test \
+      hurl --variables-file tests/api/envs/ci.env --cookie "$COOKIE_JAR" --jobs 1 --test \
         tests/api/auth/me.hurl \
         tests/api/platform/auth/me.hurl \
         tests/api/customers/get.hurl \

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -253,8 +253,10 @@ tasks:
     #   Phase 1.5b — `hurl --cookie-jar "$COOKIE_JAR" --test
     #     tests/api/_prelude/admin-login.hurl` POSTs the canonical
     #     `/api/platform/v1/auth/login` with admin creds. The Set-Cookie
-    #     response carries `mokumo_session` for the auth profile DB, so
-    #     subsequent `Backend::get_user(user_id)` lookups succeed.
+    #     response carries the `id` session cookie (the `tower-sessions`
+    #     default, pinned in `kikan::data_plane::session_layer::SESSION_COOKIE_NAME`)
+    #     for the auth profile DB, so subsequent `Backend::get_user(user_id)`
+    #     lookups succeed.
     #
     #   Phase 2 — `hurl --cookie "$COOKIE_JAR" --test <file…>` runs the
     #     explicit-admin suite (canonical and legacy `/auth/me`, admin
@@ -291,10 +293,12 @@ tasks:
       fi
       # Isolated data dir so each run boots into setup_required state. The
       # trap also removes the cookie jar and the captured stderr.
-      MOKUMO_DATA_DIR=$(mktemp -d -t mokumo-smoke.XXXXXX)
+      # mktemp invocations use a positional template (not `-t`) for portability
+      # across GNU and BSD mktemp — `-t` semantics differ between them.
+      MOKUMO_DATA_DIR=$(mktemp -d "${TMPDIR:-/tmp}/mokumo-smoke.XXXXXX")
       export MOKUMO_DATA_DIR
-      COOKIE_JAR=$(mktemp -t mokumo-smoke-cookies.XXXXXX)
-      SERVER_STDERR=$(mktemp -t mokumo-smoke-stderr.XXXXXX)
+      COOKIE_JAR=$(mktemp "${TMPDIR:-/tmp}/mokumo-smoke-cookies.XXXXXX")
+      SERVER_STDERR=$(mktemp "${TMPDIR:-/tmp}/mokumo-smoke-stderr.XXXXXX")
       cleanup() {
         # Surface server stderr so failures (auth setup, boot guards) are
         # diagnosable from CI logs. Direct redirect above means none of it
@@ -422,21 +426,24 @@ tasks:
         tests/api/backup/status.hurl \
         tests/api/diagnostics/diagnostics.hurl \
         tests/api/diagnostics/bundle.hurl
-      # Setup wizard — capture the `Setup token: <uuid>` line from stderr
-      # and POST /api/setup. Creates admin@demo.local in the auth profile
-      # DB (production), writes shop_settings.shop_name, and atomically
+      # Setup wizard — extract the `Setup token: <uuid>` line from stderr
+      # (anchor on the literal prefix so unrelated UUIDs in trace/request
+      # logs cannot collide), then run tests/api/_prelude/setup-wizard.hurl
+      # which POSTs /api/setup with the captured token plus admin creds
+      # and shop_name from ci.env. The wizard creates the admin user in
+      # the auth profile DB, writes shop_settings.shop_name, and atomically
       # flips `<data_dir>/active_profile` to production. From this point
       # demo auto-login is disabled; cookie-bearing requests are required.
-      SETUP_TOKEN=$(grep -m1 -oE '[a-f0-9-]{36}' "$SERVER_STDERR")
+      SETUP_TOKEN=$(grep -m1 -oE 'Setup token: [0-9a-fA-F-]{36}' "$SERVER_STDERR" \
+        | sed -E 's/^Setup token: //')
       if [ -z "$SETUP_TOKEN" ]; then
         echo "setup token not found in server stderr" >&2
         cat "$SERVER_STDERR" >&2
         exit 1
       fi
-      curl -sf -X POST "http://localhost:6565/api/setup" \
-        -H 'Content-Type: application/json' \
-        -d "{\"setup_token\":\"$SETUP_TOKEN\",\"admin_email\":\"admin@demo.local\",\"admin_name\":\"Smoke Admin\",\"admin_password\":\"demo1234\",\"shop_name\":\"Smoke Test Shop\"}" \
-        > /dev/null
+      hurl --variables-file tests/api/envs/ci.env \
+        --variable "setup_token=$SETUP_TOKEN" \
+        --test tests/api/_prelude/setup-wizard.hurl
       # Phase 1.5a — login-success files. Admin now exists in the auth
       # profile DB; both endpoints (legacy alias + canonical) resolve.
       hurl --variables-file tests/api/envs/ci.env --test \

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -472,6 +472,7 @@ tasks:
     - '@group(allRust)'
     - /tests/api/**/*.hurl
     - /tests/api/envs/ci.env.example
+    - /tests/api/shop/fixtures/**/*
     - /apps/web/scripts/seed-demo.ts
     options:
       cache: false

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -224,24 +224,58 @@ tasks:
     # on the seed; if the sidecar didn't take, we abort with a clear
     # assertion failure instead of cascading 423s downstream.
     #
-    # Single-phase coverage scope (mokumo#383 PR 2):
+    # Multi-phase auth bootstrap (mokumo#723 PR-2.5):
     #
-    #   The active list below covers every endpoint reachable without an
-    #   explicit-admin session — i.e. routes that are either unauthenticated
-    #   or whose auth is carried by the demo profile's auto-login middleware
-    #   (`require_auth_with_demo_auto_login` in `crates/mokumo-shop/src/auth/handlers.rs`).
+    #   Phase 1 — Demo-profile coverage. `hurl --test <file…>` over
+    #     endpoints that either do not need auth, or whose auth is carried
+    #     by the demo profile's auto-login middleware
+    #     (`require_auth_with_demo_auto_login` in
+    #     `crates/mokumo-shop/src/auth/handlers.rs`). Boot is cold: no admin
+    #     exists yet, `active_profile=demo`. `tests/api/_prelude/healthy-demo.hurl`
+    #     fail-fast asserts the demo sidecar took.
     #
-    #   Endpoints that strictly resolve `auth_session.user` via
-    #   `Backend::get_user(user_id)` (e.g. `/api/platform/v1/auth/me`,
-    #   `/api/users/*`, the `shop/logo-*` write trio) are NOT in the active
-    #   list. Demo auto-login mints a session whose `user_id` exists only in
-    #   the demo profile DB, but `Backend::get_user` queries the auth
-    #   profile (`SetupMode::Production` per `crates/mokumo-shop/src/graft.rs`),
-    #   so strict handlers see `auth_session.user == None` and reject 401.
-    #   Re-attach requires a production-profile harness — tracked in PR-2.5
-    #   (`kikan-cli seed-admin` subcommand seeds production_db before boot,
-    #   then standard POST /login with --cookie-jar). See the deferral
-    #   ledger below for the candidate file list.
+    #   Setup wizard — Capture the `Setup token: <uuid>` line `mokumo-server`
+    #     `eprintln!`s on cold boot (operator UX contract from
+    #     `apps/mokumo-server/src/main.rs`). POST /api/setup with the token,
+    #     admin credentials, and a non-empty `shop_name`. The vertical
+    #     handler at `crates/mokumo-shop/src/setup.rs` calls
+    #     `kikan::control_plane::users::setup_admin` (creates admin in the
+    #     auth profile DB atomically with recovery codes + the
+    #     `setup_completed` flag), then writes `shop_settings.shop_name`
+    #     and atomically flips `<data_dir>/active_profile` to `production`.
+    #     From this point demo auto-login is disabled.
+    #
+    #   Phase 1.5a — login-success smoke files. The seeded admin now exists
+    #     in the auth profile DB (`SetupMode::Production`); both the legacy
+    #     `/api/auth/login` alias and the canonical
+    #     `/api/platform/v1/auth/login` resolve cleanly.
+    #
+    #   Phase 1.5b — `hurl --cookie-jar "$COOKIE_JAR" --test
+    #     tests/api/_prelude/admin-login.hurl` POSTs the canonical
+    #     `/api/platform/v1/auth/login` with admin creds. The Set-Cookie
+    #     response carries `mokumo_session` for the auth profile DB, so
+    #     subsequent `Backend::get_user(user_id)` lookups succeed.
+    #
+    #   Phase 2 — `hurl --cookie "$COOKIE_JAR" --test <file…>` runs the
+    #     explicit-admin suite (canonical and legacy `/auth/me`, admin
+    #     `/api/users/*` routes, the `shop/logo-*` write trio, and
+    #     `/api/customers/get` self-seeded chain). All target handlers
+    #     strictly resolve `auth_session.user`, which now resolves cleanly
+    #     because the admin is in the auth profile DB.
+    #
+    # Why a shared cookie jar instead of per-file embedded login: the
+    # in-memory rate limiter in `kikan::rate_limit::RateLimiter`
+    # (10/15min sliding window per email) caps repeated logins; the
+    # shared jar keeps the login cost at one request regardless of
+    # how many explicit-cookie tests are added later.
+    #
+    # Why the HTTP setup wizard (not `mokumo-server bootstrap`): post-M00,
+    # `bootstrap` writes admin rows into the per-profile users table, but
+    # the legacy-completed-install upgrade path on the next boot moves
+    # those rows into `meta.users` (see
+    # `crates/kikan/src/meta/upgrade.rs`). The setup wizard is the
+    # post-M00-correct admin-creation path; it lands the admin where
+    # `Backend::get_user` looks for it on every subsequent request.
     #
     # Local run: moon run shop:smoke
     # Env file: copy tests/api/envs/local.env.example → tests/api/envs/local.env (gitignored)
@@ -255,9 +289,35 @@ tasks:
         echo "demo sidecar missing at $MOKUMO_DEMO_SIDECAR (web:seed-demo must run before shop:smoke)" >&2
         exit 1
       fi
-      "$TARGET_DIR/debug/mokumo-server" serve --deployment-mode lan --host 127.0.0.1 &
+      # Isolated data dir so each run boots into setup_required state. The
+      # trap also removes the cookie jar and the captured stderr.
+      MOKUMO_DATA_DIR=$(mktemp -d -t mokumo-smoke.XXXXXX)
+      export MOKUMO_DATA_DIR
+      COOKIE_JAR=$(mktemp -t mokumo-smoke-cookies.XXXXXX)
+      SERVER_STDERR=$(mktemp -t mokumo-smoke-stderr.XXXXXX)
+      cleanup() {
+        # Surface server stderr so failures (auth setup, boot guards) are
+        # diagnosable from CI logs. Direct redirect above means none of it
+        # has hit the parent's stderr yet.
+        if [ -s "$SERVER_STDERR" ]; then
+          echo "--- mokumo-server stderr ---" >&2
+          cat "$SERVER_STDERR" >&2
+        fi
+        kill $SERVER_PID 2>/dev/null || true
+        rm -f "$COOKIE_JAR" "$SERVER_STDERR" 2>/dev/null || true
+        rm -rf "$MOKUMO_DATA_DIR" 2>/dev/null || true
+      }
+      trap cleanup EXIT
+      # Boot cold. Server prints `Setup token: <uuid>` to stderr on first
+      # boot when no admin exists yet; we capture stderr to a file so the
+      # wizard step below can read the token. Direct redirect (no tee):
+      # `eprintln!` is unbuffered, but `tee` block-buffers its file output,
+      # so a single short line written to a long-lived background process's
+      # stderr never flushes through tee. The cleanup hook dumps the file
+      # to stderr on exit so CI keeps visibility.
+      "$TARGET_DIR/debug/mokumo-server" serve --deployment-mode lan --host 127.0.0.1 \
+        2> "$SERVER_STDERR" &
       SERVER_PID=$!
-      trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
       ready=0
       for i in $(seq 1 30); do
         if curl -sf http://localhost:6565/api/health > /dev/null 2>&1; then ready=1; break; fi
@@ -306,42 +366,14 @@ tasks:
       #
       #   tests/api/auth/login-success.hurl
       #   tests/api/platform/auth/login-success.hurl
-      #     Failure: 401 `invalid_credentials`. Both endpoints route
-      #     through the canonical kikan login handler, which authenticates
-      #     against `Graft::auth_profile_kind()` — `SetupMode::Production`
-      #     for Mokumo (`crates/mokumo-shop/src/graft.rs`). The demo
-      #     sidecar seeds `admin@demo.local` into the demo profile DB
-      #     only; the production profile DB is empty in the smoke harness,
-      #     so login as admin@demo.local cannot resolve to a user record.
-      #     Demo-mode session bootstrap relies on the auto-login
-      #     middleware (which bypasses the production-DB lookup), not on
-      #     an explicit POST /login. Re-attach requires a production-
-      #     profile smoke harness that runs the setup wizard before login.
-      #     Deferred to PR-2.5 (mokumo#723 — kikan-cli seed-admin).
-      #
-      #   tests/api/auth/me.hurl
-      #   tests/api/platform/auth/me.hurl
-      #   tests/api/customers/get.hurl
-      #   tests/api/users/soft-delete-not-found.hurl
-      #   tests/api/users/update-role-not-found.hurl
-      #   tests/api/shop/logo-upload.hurl
-      #   tests/api/shop/logo-upload-errors.hurl
-      #   tests/api/shop/logo-delete.hurl
-      #     [Phase-2 candidates] All eight target handlers strictly resolve
-      #     `auth_session.user` via `Backend::get_user(user_id)`. Demo
-      #     auto-login mints a session whose `user_id` exists only in the
-      #     demo profile DB, but `Backend::get_user` queries the auth
-      #     profile (`SetupMode::Production`), so the user lookup returns
-      #     `None` and strict handlers reject with 401. Re-attach requires
-      #     seeding an admin into production_db before login — deferred to
-      #     PR-2.5 (mokumo#723). PR-2.5 introduces a `kikan-cli seed-admin`
-      #     subcommand that opens production_db directly (matching the
-      #     existing `kikan-cli reset_password` pattern), invokes a
-      #     refactored-out `create_initial_admin` domain fn shared with the
-      #     setup-wizard API path, then marks setup complete. Smoke harness
-      #     calls the CLI before `mokumo-server serve`, then standard
-      #     `POST /api/platform/v1/auth/login` with `--cookie-jar` is
-      #     fed via `--cookie` to the eight files above.
+      #     Resolved (mokumo#723): the production profile DB is seeded
+      #     with `admin@demo.local` by the HTTP setup wizard step below
+      #     (POST /api/setup with the `Setup token: <uuid>` printed to
+      #     stderr on cold boot). Both endpoints route through the
+      #     canonical kikan login handler, which authenticates against
+      #     `Graft::auth_profile_kind()` (`SetupMode::Production`); with
+      #     the seeded admin row present, login resolves cleanly.
+      #     Re-attached in Phase 1.5a, after the wizard runs.
       #
       # Coverage notes — files in the active list with known structural-only
       # coverage that requires a Rust-side backstop per the G3 split:
@@ -355,7 +387,10 @@ tasks:
       #     mokumo#701.
       #
       # ---------------------------------------------------------------------
-      # Active list — unauthenticated paths and demo-auto-login-carried tests.
+      # Phase 1 — unauthenticated paths and demo-auto-login-carried tests.
+      # Excludes login-success.hurl: admin doesn't exist yet (setup wizard
+      # below creates it). Excludes any cookie-bearing tests: those run in
+      # Phase 2 against the post-setup production profile.
       hurl --variables-file tests/api/envs/ci.env --test \
         tests/api/_prelude/healthy-demo.hurl \
         tests/api/routing/api-prefix-boundary.hurl \
@@ -387,6 +422,42 @@ tasks:
         tests/api/backup/status.hurl \
         tests/api/diagnostics/diagnostics.hurl \
         tests/api/diagnostics/bundle.hurl
+      # Setup wizard — capture the `Setup token: <uuid>` line from stderr
+      # and POST /api/setup. Creates admin@demo.local in the auth profile
+      # DB (production), writes shop_settings.shop_name, and atomically
+      # flips `<data_dir>/active_profile` to production. From this point
+      # demo auto-login is disabled; cookie-bearing requests are required.
+      SETUP_TOKEN=$(grep -m1 -oE '[a-f0-9-]{36}' "$SERVER_STDERR")
+      if [ -z "$SETUP_TOKEN" ]; then
+        echo "setup token not found in server stderr" >&2
+        cat "$SERVER_STDERR" >&2
+        exit 1
+      fi
+      curl -sf -X POST "http://localhost:6565/api/setup" \
+        -H 'Content-Type: application/json' \
+        -d "{\"setup_token\":\"$SETUP_TOKEN\",\"admin_email\":\"admin@demo.local\",\"admin_name\":\"Smoke Admin\",\"admin_password\":\"demo1234\",\"shop_name\":\"Smoke Test Shop\"}" \
+        > /dev/null
+      # Phase 1.5a — login-success files. Admin now exists in the auth
+      # profile DB; both endpoints (legacy alias + canonical) resolve.
+      hurl --variables-file tests/api/envs/ci.env --test \
+        tests/api/auth/login-success.hurl \
+        tests/api/platform/auth/login-success.hurl
+      # Phase 1.5b — populate the cookie jar with a single admin session.
+      hurl --variables-file tests/api/envs/ci.env --cookie-jar "$COOKIE_JAR" --test \
+        tests/api/_prelude/admin-login.hurl
+      # Phase 2 — explicit-admin tests reading the shared cookie jar.
+      # Order within the shop/logo set: logo-upload first (leaves a logo),
+      # logo-upload-errors next (validation rejects, no state change),
+      # logo-delete last (uploads + deletes; ends with no logo on disk).
+      hurl --variables-file tests/api/envs/ci.env --cookie "$COOKIE_JAR" --test \
+        tests/api/auth/me.hurl \
+        tests/api/platform/auth/me.hurl \
+        tests/api/customers/get.hurl \
+        tests/api/users/soft-delete-not-found.hurl \
+        tests/api/users/update-role-not-found.hurl \
+        tests/api/shop/logo-upload.hurl \
+        tests/api/shop/logo-upload-errors.hurl \
+        tests/api/shop/logo-delete.hurl
     deps:
     - web:build
     - web:seed-demo

--- a/tests/api/_prelude/admin-login.hurl
+++ b/tests/api/_prelude/admin-login.hurl
@@ -1,0 +1,28 @@
+# Smoke-suite Phase 2 prelude — capture an admin session via the canonical login.
+#
+# The HTTP setup wizard (run earlier in the moon.yml smoke task) seeds an
+# admin user into the auth profile DB. This prelude POSTs the canonical
+# `/api/platform/v1/auth/login` with those credentials so the response
+# Set-Cookie is captured by `--cookie-jar` into a temp file. Phase 2 files
+# then load that cookie via `--cookie` and the session is accepted by every
+# authenticated route — including strict handlers like
+# `/api/platform/v1/auth/me` and `/api/users/*` that resolve
+# `auth_session.user` via `Backend::get_user(user_id)` against the auth
+# profile DB.
+#
+# The session cookie name is `id` — the tower-sessions default, pinned
+# explicitly in `kikan::data_plane::session_layer::SESSION_COOKIE_NAME`.
+#
+# Uses variables: host, admin_email, admin_password.
+
+POST http://{{host}}/api/platform/v1/auth/login
+Content-Type: application/json
+{
+    "email": "{{admin_email}}",
+    "password": "{{admin_password}}"
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+cookie "id" exists

--- a/tests/api/_prelude/setup-wizard.hurl
+++ b/tests/api/_prelude/setup-wizard.hurl
@@ -1,0 +1,38 @@
+# Smoke-suite setup-wizard prelude — completes the first-admin setup.
+#
+# Runs after the cold boot has produced a `Setup token: <uuid>` line on
+# `mokumo-server` stderr. The moon.yml smoke task captures that token
+# from the stderr file and passes it to hurl via `--variable
+# setup_token=<uuid>` so this file can use the canonical
+# `tests/api/envs/ci.env` for `admin_email`, `admin_password`,
+# `admin_name`, and `shop_name` — no parallel hardcoded credentials.
+#
+# Side effects (committed inside the handler at
+# `crates/mokumo-shop/src/setup.rs`):
+#   1. admin user created in the auth profile DB (auth_profile_kind ==
+#      Production for Mokumo) atomically with 10 recovery codes;
+#   2. settings.setup_complete row written ('true');
+#   3. shop_settings.shop_name persisted;
+#   4. <data_dir>/active_profile flipped to "production".
+#
+# After this prelude succeeds, demo auto-login is disabled and every
+# protected route requires a real session cookie.
+#
+# Uses variables: host, admin_email, admin_password, admin_name, shop_name,
+#                 setup_token (passed at invocation).
+
+POST http://{{host}}/api/setup
+Content-Type: application/json
+{
+    "setup_token": "{{setup_token}}",
+    "admin_email": "{{admin_email}}",
+    "admin_name": "{{admin_name}}",
+    "admin_password": "{{admin_password}}",
+    "shop_name": "{{shop_name}}"
+}
+
+HTTP 201
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.recovery_codes" isCollection
+jsonpath "$.recovery_codes" count == 10

--- a/tests/api/auth/login-success.hurl
+++ b/tests/api/auth/login-success.hurl
@@ -11,4 +11,4 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 header "Content-Type" contains "application/json"
-cookie "mokumo_session" exists
+cookie "id" exists

--- a/tests/api/auth/me.hurl
+++ b/tests/api/auth/me.hurl
@@ -1,9 +1,15 @@
-# Must be authenticated. Run after login-success.hurl or use --cookie.
-# In a CI chain: hurl --cookie-jar /tmp/mokumo.jar --cookie /tmp/mokumo.jar ...
+# GET /api/auth/me — legacy alias for /api/platform/v1/auth/me, preserved
+# through M0 for the shop SPA. Wire shape verified against the alias mount
+# so the alias-delegation contract cannot drift silently.
+#
+# Reads the admin session from the cookie jar populated by
+# tests/api/_prelude/admin-login.hurl in the prior smoke phase. The canonical
+# /me wire shape is also covered by tests/api/platform/auth/me.hurl.
 GET http://{{host}}/api/auth/me
 
 HTTP 200
 [Asserts]
+header "Content-Type" contains "application/json"
 jsonpath "$.user" exists
-jsonpath "$.user.email" exists
+jsonpath "$.user.email" == "{{admin_email}}"
 jsonpath "$.setup_complete" exists

--- a/tests/api/customers/get.hurl
+++ b/tests/api/customers/get.hurl
@@ -1,10 +1,28 @@
-# Get a specific customer by ID — authenticated.
-# Replace {{customer_id}} with a real ID from your seed data or a prior create call.
+# GET /api/customers/:id — fetch a specific customer.
+# Self-seeds via POST so the test is profile-agnostic: works against the
+# demo profile (which carries seed data) and against a freshly-created
+# production profile that has no customer rows yet. Avoids relying on the
+# list endpoint having data, which would fail in Phase 2 against the
+# post-setup production profile.
+# Reads admin session via --cookie from the cookie jar populated by
+# tests/api/_prelude/admin-login.hurl.
+
+POST http://{{host}}/api/customers
+Content-Type: application/json
+{
+    "display_name": "Hurl Get-Test Shop"
+}
+
+HTTP 201
+[Captures]
+customer_id: jsonpath "$.id"
+
+
 GET http://{{host}}/api/customers/{{customer_id}}
 
 HTTP 200
 [Asserts]
 header "Content-Type" contains "application/json"
 jsonpath "$.id" == "{{customer_id}}"
-jsonpath "$.display_name" exists
+jsonpath "$.display_name" == "Hurl Get-Test Shop"
 jsonpath "$.created_at" exists

--- a/tests/api/envs/ci.env.example
+++ b/tests/api/envs/ci.env.example
@@ -2,3 +2,5 @@ host=localhost:6565
 customer_email=hurl-test@example.com
 admin_email=admin@demo.local
 admin_password=demo1234
+admin_name=Smoke Admin
+shop_name=Smoke Test Shop

--- a/tests/api/platform/auth/login-success.hurl
+++ b/tests/api/platform/auth/login-success.hurl
@@ -12,4 +12,4 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 header "Content-Type" contains "application/json"
-cookie "mokumo_session" exists
+cookie "id" exists

--- a/tests/api/platform/auth/me.hurl
+++ b/tests/api/platform/auth/me.hurl
@@ -1,10 +1,12 @@
-# Canonical kikan platform /me. Must be authenticated.
-# Run after platform/auth/login-success.hurl or use --cookie.
-# In a CI chain: hurl --cookie-jar /tmp/mokumo.jar --cookie /tmp/mokumo.jar ...
+# GET /api/platform/v1/auth/me — canonical kikan platform endpoint.
+# The canonical mount is NOT behind the demo-auto-login middleware, so this
+# file relies on an explicit admin session loaded via --cookie from the
+# cookie jar populated by tests/api/_prelude/admin-login.hurl.
 GET http://{{host}}/api/platform/v1/auth/me
 
 HTTP 200
 [Asserts]
+header "Content-Type" contains "application/json"
 jsonpath "$.user" exists
-jsonpath "$.user.email" exists
+jsonpath "$.user.email" == "{{admin_email}}"
 jsonpath "$.setup_complete" exists

--- a/tests/api/shop/logo-delete.hurl
+++ b/tests/api/shop/logo-delete.hurl
@@ -1,38 +1,23 @@
-# DELETE /api/shop/logo — deletion smoke tests
-# Requires authentication. Run after setup or with a seeded server.
-# Uses variables: host, admin_email, admin_password
+# DELETE /api/shop/logo — deletion smoke tests.
+# Reads admin session via --cookie from the cookie jar populated by
+# tests/api/_prelude/admin-login.hurl. Uploads then deletes so the test is
+# self-contained regardless of prior smoke files.
 
-# Step 1: Login
-POST http://{{host}}/api/auth/login
-Content-Type: application/json
-{
-    "email": "{{admin_email}}",
-    "password": "{{admin_password}}"
-}
-
-HTTP 200
-[Asserts]
-cookie "mokumo_session" exists
-
----
-
-# Step 2: Upload a logo so we have something to delete
+# Step 1: Upload a logo so we have something to delete
 POST http://{{host}}/api/shop/logo
 [MultipartFormData]
 logo: file,tests/api/shop/fixtures/logo-100x100.png; image/png
 
 HTTP 204
 
----
 
-# Step 3: Delete the logo → 204
+# Step 2: Delete the logo → 204
 DELETE http://{{host}}/api/shop/logo
 
 HTTP 204
 
----
 
-# Step 4: Subsequent GET returns 404
+# Step 3: Subsequent GET returns 404
 GET http://{{host}}/api/shop/logo
 
 HTTP 404
@@ -40,9 +25,8 @@ HTTP 404
 header "Content-Type" contains "application/json"
 jsonpath "$.code" == "shop_logo_not_found"
 
----
 
-# Step 5: Deleting when no logo exists returns 404
+# Step 4: Deleting when no logo exists returns 404
 DELETE http://{{host}}/api/shop/logo
 
 HTTP 404

--- a/tests/api/shop/logo-delete.hurl
+++ b/tests/api/shop/logo-delete.hurl
@@ -6,7 +6,7 @@
 # Step 1: Upload a logo so we have something to delete
 POST http://{{host}}/api/shop/logo
 [MultipartFormData]
-logo: file,tests/api/shop/fixtures/logo-100x100.png; image/png
+logo: file,fixtures/logo-100x100.png; image/png
 
 HTTP 204
 

--- a/tests/api/shop/logo-upload-errors.hurl
+++ b/tests/api/shop/logo-upload-errors.hurl
@@ -5,7 +5,7 @@
 # GIF upload → 422 logo_format_unsupported
 POST http://{{host}}/api/shop/logo
 [MultipartFormData]
-logo: file,tests/api/shop/fixtures/logo.gif; image/gif
+logo: file,fixtures/logo.gif; image/gif
 
 HTTP 422
 [Asserts]
@@ -18,7 +18,7 @@ jsonpath "$.details" == null
 # Oversized upload (2MiB + 1 byte) → 422 logo_too_large
 POST http://{{host}}/api/shop/logo
 [MultipartFormData]
-logo: file,tests/api/shop/fixtures/logo-too-large.bin; application/octet-stream
+logo: file,fixtures/logo-too-large.bin; application/octet-stream
 
 HTTP 422
 [Asserts]
@@ -28,11 +28,14 @@ jsonpath "$.message" isString
 jsonpath "$.details" == null
 
 
-# Empty multipart body (no logo field) → 400 missing_field
+# Empty multipart body (no logo field) → 400 missing_field.
+# Body uses a raw multiline string so hurl does not try to parse the
+# closing `--boundary123--` line as a new request method.
 POST http://{{host}}/api/shop/logo
 Content-Type: multipart/form-data; boundary=boundary123
-
+```
 --boundary123--
+```
 
 HTTP 400
 [Asserts]

--- a/tests/api/shop/logo-upload-errors.hurl
+++ b/tests/api/shop/logo-upload-errors.hurl
@@ -1,20 +1,6 @@
-# POST /api/shop/logo — validation error codes
-# Requires authentication. Run after setup or with a seeded server.
-# Uses variables: host, admin_email, admin_password
-
-# Step 1: Login
-POST http://{{host}}/api/auth/login
-Content-Type: application/json
-{
-    "email": "{{admin_email}}",
-    "password": "{{admin_password}}"
-}
-
-HTTP 200
-[Asserts]
-cookie "mokumo_session" exists
-
----
+# POST /api/shop/logo — validation error codes.
+# Reads admin session via --cookie from the cookie jar populated by
+# tests/api/_prelude/admin-login.hurl.
 
 # GIF upload → 422 logo_format_unsupported
 POST http://{{host}}/api/shop/logo
@@ -28,7 +14,6 @@ jsonpath "$.code" == "logo_format_unsupported"
 jsonpath "$.message" isString
 jsonpath "$.details" == null
 
----
 
 # Oversized upload (2MiB + 1 byte) → 422 logo_too_large
 POST http://{{host}}/api/shop/logo
@@ -42,7 +27,6 @@ jsonpath "$.code" == "logo_too_large"
 jsonpath "$.message" isString
 jsonpath "$.details" == null
 
----
 
 # Empty multipart body (no logo field) → 400 missing_field
 POST http://{{host}}/api/shop/logo

--- a/tests/api/shop/logo-upload.hurl
+++ b/tests/api/shop/logo-upload.hurl
@@ -5,7 +5,7 @@
 # Step 1: Upload a valid PNG logo
 POST http://{{host}}/api/shop/logo
 [MultipartFormData]
-logo: file,tests/api/shop/fixtures/logo-100x100.png; image/png
+logo: file,fixtures/logo-100x100.png; image/png
 
 HTTP 204
 

--- a/tests/api/shop/logo-upload.hurl
+++ b/tests/api/shop/logo-upload.hurl
@@ -1,31 +1,16 @@
-# POST /api/shop/logo — happy-path upload smoke test
-# Requires authentication. Run after setup or with a seeded server.
-# Uses variables: host, admin_email, admin_password
+# POST /api/shop/logo — happy-path upload smoke test.
+# Reads admin session via --cookie from the cookie jar populated by
+# tests/api/_prelude/admin-login.hurl.
 
-# Step 1: Login
-POST http://{{host}}/api/auth/login
-Content-Type: application/json
-{
-    "email": "{{admin_email}}",
-    "password": "{{admin_password}}"
-}
-
-HTTP 200
-[Asserts]
-cookie "mokumo_session" exists
-
----
-
-# Step 2: Upload a valid PNG logo
+# Step 1: Upload a valid PNG logo
 POST http://{{host}}/api/shop/logo
 [MultipartFormData]
 logo: file,tests/api/shop/fixtures/logo-100x100.png; image/png
 
 HTTP 204
 
----
 
-# Step 3: Verify setup-status reflects the new logo_url
+# Step 2: Verify setup-status reflects the new logo_url
 GET http://{{host}}/api/setup-status
 
 HTTP 200

--- a/tests/api/users/soft-delete-not-found.hurl
+++ b/tests/api/users/soft-delete-not-found.hurl
@@ -1,6 +1,7 @@
 # DELETE /api/users/:id — 404 when user does not exist.
 # Verifies route is registered and NotFound error maps to 404.
-# Runs in demo mode (auto-login as admin).
+# Reads admin session via --cookie from the cookie jar populated by
+# tests/api/_prelude/admin-login.hurl.
 DELETE http://{{host}}/api/users/99999
 
 HTTP 404

--- a/tests/api/users/update-role-not-found.hurl
+++ b/tests/api/users/update-role-not-found.hurl
@@ -1,6 +1,7 @@
 # PATCH /api/users/:id/role — 404 when user does not exist.
 # Verifies route is registered and NotFound error maps to 404.
-# Runs in demo mode (auto-login as admin).
+# Reads admin session via --cookie from the cookie jar populated by
+# tests/api/_prelude/admin-login.hurl.
 PATCH http://{{host}}/api/users/99999/role
 Content-Type: application/json
 {


### PR DESCRIPTION
Closes #723. Part of the mokumo#383 epic — Phase 2 of the smoke-suite re-attach plan.

## Summary

- Wires the HTTP setup wizard into `crates/mokumo-shop/moon.yml::shop:smoke` between Phase 1 (demo-auto-login carried) and Phase 2 (cookie-bearing). Captures `Setup token: <uuid>` from server stderr, POSTs `/api/setup` with admin credentials + shop_name, populates a shared cookie jar via the new `tests/api/_prelude/admin-login.hurl` prelude, then runs the explicit-admin suite.
- Re-attaches **10** Phase-2 `.hurl` files that were sitting darkened in the moon.yml exclusion ledger:
  - `tests/api/auth/login-success.hurl` + `platform/auth/login-success.hurl` (Phase 1.5a — admin now exists in the auth profile DB after the wizard runs)
  - `tests/api/auth/me.hurl` + `platform/auth/me.hurl`
  - `tests/api/customers/get.hurl` — rewritten to self-seed via POST so it works against a freshly-created production profile that has zero customer rows
  - `tests/api/users/soft-delete-not-found.hurl` + `update-role-not-found.hurl`
  - `tests/api/shop/logo-{upload,upload-errors,delete}.hurl`
- Pins the actual session cookie name (`id`, per `kikan::data_plane::session_layer::SESSION_COOKIE_NAME`) in the prelude and both `login-success.hurl` files. Three asserts had been written against the obsolete `mokumo_session` name and were latent until this PR re-attached the files.

## Why HTTP setup wizard, not `mokumo-server bootstrap`

The original PR-2.5 plan in #723 was a `kikan-cli seed-admin` subcommand or reuse of the existing `mokumo-server bootstrap` flow. Post-M00 (#705 / #706) the `bootstrap` path doesn't land the admin where the auth backend looks for it: the legacy-completed-install upgrade on the next boot moves rows from per-profile `users` into `meta.users` (see `crates/kikan/src/meta/upgrade.rs`), and `Backend::get_user` resolves user IDs through the auth profile pool which no longer carries the row.

The HTTP setup wizard is the post-M00-correct admin-creation path. It runs `kikan::control_plane::users::setup_admin` (atomic admin + recovery codes + `setup_completed` flag), writes `shop_settings.shop_name`, and atomically flips `<data_dir>/active_profile` to `production`. Demo auto-login is disabled from that point; cookie-bearing requests are required, which matches Phase 2's design.

## Architecture

```
boot mokumo-server (cold, MOKUMO_DATA_DIR=mktemp -d)
  → captures `Setup token: <uuid>` to $SERVER_STDERR (direct redirect — tee
    block-buffers and would swallow the line)

Phase 1 (active_profile=demo, no admin)
  → unauthenticated + demo-auto-login carried tests

POST /api/setup with token + admin@demo.local + Smoke Test Shop
  → admin lands in auth profile DB
  → active_profile flips to production on disk + in-memory

Phase 1.5a — login-success.hurl files
Phase 1.5b — _prelude/admin-login.hurl populates $COOKIE_JAR

Phase 2 (active_profile=production, cookie-bearing)
  → auth/me, platform/auth/me, customers/get, users/{soft-delete,update-role}-not-found,
    shop/logo-{upload,upload-errors,delete}
```

## Empirical verification

End-to-end discriminator run locally against `/tmp/mokumo-target/debug/mokumo-server` (curl-equivalent of every hurl call, since `hurl` is unavailable on this aarch64 runtime):

- ✓ Cold boot prints `Setup token: <uuid>` to stderr (one-line `eprintln!`, unbuffered)
- ✓ `POST /api/setup` returns 201 with 10 recovery codes; persists `shop_settings.shop_name`; flips `<data_dir>/active_profile` to `production`
- ✓ `POST /api/auth/login` (legacy alias) returns 200 + `set-cookie: id=...`
- ✓ `POST /api/platform/v1/auth/login` (canonical) returns 200 + `set-cookie: id=...`
- ✓ `GET /api/auth/me` with cookie returns 200 + admin payload
- ✓ `DELETE /api/users/99999` with cookie returns 404 + `{"code":"not_found",...}`
- ✓ `POST /api/customers` (Phase 2 self-seed) returns 201 against the empty production profile

## Test plan

- [ ] CI's api-smoke gate passes shop:smoke green with all 10 re-attached files
- [ ] No regressions in the 32 Phase 1 files (login-success removed from Phase 1, otherwise identical)
- [ ] `customers/get.hurl` self-seed is profile-agnostic (passes whether the active profile carries seed data or is empty)
- [ ] Cleanup hook dumps `$SERVER_STDERR` on failure for diagnosability

## Three-place agreement

- This PR (re-attach + wiring)
- `crates/mokumo-shop/moon.yml` exclusion ledger updated to mark login-success entries as resolved by the wizard
- mokumo#383 status update will follow merge

## Follow-ups (out of scope)

- kikan-internal ticket: drift between `bootstrap_admin_with_codes` (no `setup_completed` write) and `create_admin_with_setup` (writes the flag). Either bootstrap should write it too, or `setup_admin` should orchestrate both paths.
- Decide policy for the `mokumo-server bootstrap` subcommand post-M00 — it's still wired but now produces an install that the boot-time legacy-upgrade path mutates. Either repoint bootstrap at `meta.users` or document it as legacy-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced smoke test suite to validate production authentication setup and bootstrap process.
  * Improved test coverage by consolidating authentication and reusing sessions across related endpoint tests, including customer management, user operations, and shop configuration.

* **Chores**
  * Updated CI/CD smoke test task configuration with multi-phase authentication validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->