### PR TITLE
test(383): per-endpoint thin .hurl backfill (PR 3 / scope-bar D)

### DIFF
--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -453,9 +453,6 @@ tasks:
         tests/api/customers/not-found.hurl \
         tests/api/customers/list.hurl \
         tests/api/customers/create.hurl \
-        tests/api/customers/update.hurl \
-        tests/api/customers/delete.hurl \
-        tests/api/customers/restore.hurl \
         tests/api/activity/list.hurl \
         tests/api/settings/lan-access.hurl \
         tests/api/shop/logo-get.hurl \
@@ -492,12 +489,18 @@ tasks:
         tests/api/_prelude/admin-login.hurl
       # Phase 2 — explicit-admin tests reading the shared cookie jar.
       # `--jobs 1` is required: hurl --test runs files in parallel by
-      # default (one job per CPU), but the shop/logo-* trio mutates the
-      # same `shop_settings WHERE id = 1` row. Without serialization,
-      # logo-delete.hurl's DELETE can land between logo-upload.hurl's
-      # POST and its follow-up `/api/setup-status` read, blanking
-      # logo_extension/logo_epoch and turning logo_url back to null
-      # under hurl. Order: logo-upload first (leaves a logo),
+      # default (one job per CPU), but two collisions need serialization:
+      #   1. shop/logo-* mutate the same `shop_settings WHERE id = 1`
+      #      row; logo-delete.hurl's DELETE can land between logo-upload's
+      #      POST and its follow-up `/api/setup-status` read, blanking
+      #      logo_extension/logo_epoch and turning logo_url back to null.
+      #   2. customers/{update,delete,restore}.hurl each open a write
+      #      transaction that includes an activity_log INSERT; running
+      #      them concurrently with each other (and with customers/get's
+      #      seeding POST) starves the SeaORM transaction coordinator
+      #      and surfaces SQLITE_BUSY before the 5s busy_timeout retry
+      #      window can drain (PR 3 CI evidence).
+      # Order within the logo trio: logo-upload first (leaves a logo),
       # logo-upload-errors next (validation rejects, no state change),
       # logo-delete last (uploads + deletes; ends with no logo on disk).
       hurl --variables-file tests/api/envs/ci.env --cookie "$COOKIE_JAR" --jobs 1 --test \
@@ -505,6 +508,9 @@ tasks:
         tests/api/platform/auth/me.hurl \
         tests/api/account/recovery-codes-regenerate.hurl \
         tests/api/customers/get.hurl \
+        tests/api/customers/update.hurl \
+        tests/api/customers/delete.hurl \
+        tests/api/customers/restore.hurl \
         tests/api/users/soft-delete-not-found.hurl \
         tests/api/users/update-role-not-found.hurl \
         tests/api/shop/logo-upload.hurl \

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -390,6 +390,36 @@ tasks:
       #     Per-variant Rust unit tests for those wire shapes are tracked in
       #     mokumo#701.
       #
+      #   tests/api/auth/recover.hurl
+      #     Per the anti-enumeration design in
+      #     `crates/mokumo-shop/src/auth/recover.rs`, rate-limit / invalid
+      #     code / short-password all collapse to the same 400
+      #     `validation_error` wire shape. Hurl asserts that rejection
+      #     contract; the per-branch reasoning lives in Rust unit tests.
+      #
+      # Routes intentionally NOT covered by shop:smoke (PR 3 ledger):
+      #
+      #   POST /api/demo/reset
+      #     Always restarts the server (`crates/mokumo-shop/src/demo_reset.rs`
+      #     all paths). Calling it from the smoke harness would orphan the
+      #     captured stderr file and break every subsequent test. Covered
+      #     out-of-band by the Tauri `demo-smoke` desktop job.
+      #
+      #   POST /api/profile/switch
+      #     Flips `<data_dir>/active_profile` on disk and in memory
+      #     (`crates/mokumo-shop/src/profile_switch.rs`). Switching out of
+      #     production would invalidate the shared cookie jar and reshape
+      #     `/api/setup-status`, breaking every other Phase 2 file. Needs a
+      #     dedicated harness; not in PR 3 scope.
+      #
+      #   GET /ws
+      #     WebSocket upgrade — Hurl is HTTP-only by design. Covered by
+      #     Playwright BDD scenarios in `apps/web/tests`.
+      #
+      #   GET|POST /api/debug/*
+      #     `cfg(debug_assertions)` only — the release binary the smoke
+      #     harness boots does not register these routes.
+      #
       # ---------------------------------------------------------------------
       # Phase 1 — unauthenticated paths and demo-auto-login-carried tests.
       # Excludes login-success.hurl: admin doesn't exist yet (setup wizard
@@ -405,10 +435,14 @@ tasks:
         tests/api/bind/ephemeral-loopback.hurl \
         tests/api/security/host-allowlist.hurl \
         tests/api/kikan-version/kikan-version.hurl \
+        tests/api/server-info.hurl \
+        tests/api/setup-status.hurl \
         tests/api/auth/login-bad-credentials.hurl \
         tests/api/auth/login-rate-limit.hurl \
         tests/api/auth/forgot-password.hurl \
         tests/api/auth/reset-password.hurl \
+        tests/api/auth/recover.hurl \
+        tests/api/auth/logout.hurl \
         tests/api/platform/auth/login-bad-credentials.hurl \
         tests/api/platform/auth/login-rate-limit.hurl \
         tests/api/platform/auth/me-unauthenticated.hurl \
@@ -419,6 +453,10 @@ tasks:
         tests/api/customers/not-found.hurl \
         tests/api/customers/list.hurl \
         tests/api/customers/create.hurl \
+        tests/api/customers/update.hurl \
+        tests/api/customers/delete.hurl \
+        tests/api/customers/restore.hurl \
+        tests/api/activity/list.hurl \
         tests/api/settings/lan-access.hurl \
         tests/api/shop/logo-get.hurl \
         tests/api/shop/restore-validate.hurl \
@@ -465,6 +503,7 @@ tasks:
       hurl --variables-file tests/api/envs/ci.env --cookie "$COOKIE_JAR" --jobs 1 --test \
         tests/api/auth/me.hurl \
         tests/api/platform/auth/me.hurl \
+        tests/api/account/recovery-codes-regenerate.hurl \
         tests/api/customers/get.hurl \
         tests/api/users/soft-delete-not-found.hurl \
         tests/api/users/update-role-not-found.hurl \

--- a/tests/api/account/recovery-codes-regenerate.hurl
+++ b/tests/api/account/recovery-codes-regenerate.hurl
@@ -1,0 +1,19 @@
+# POST /api/account/recovery-codes/regenerate — admin re-confirms their
+# password to mint a fresh batch of 10 recovery codes; old codes are
+# invalidated atomically inside `regenerate_recovery_codes`
+# (`crates/mokumo-shop/src/auth/handlers.rs`). Phase 2 placement: needs a
+# real admin session (cookie jar populated by
+# `_prelude/admin-login.hurl`) and shares the same auth-profile DB as
+# every other Phase 2 file. State-mutating: lives inside the `--jobs 1`
+# serialized set so it cannot race other Phase 2 admin-side writes.
+POST http://{{host}}/api/account/recovery-codes/regenerate
+Content-Type: application/json
+{
+    "password": "{{admin_password}}"
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.recovery_codes" isCollection
+jsonpath "$.recovery_codes" count == 10

--- a/tests/api/activity/list.hurl
+++ b/tests/api/activity/list.hurl
@@ -1,0 +1,14 @@
+# GET /api/activity — paginated activity-log list. Protected by
+# `require_auth_with_demo_auto_login`, so demo auto-login carries the
+# call in Phase 1 without requiring a cookie jar. Asserts the
+# PaginatedList<ActivityEntryResponse> shape only — `items` MAY be empty
+# against a fresh demo profile, so we don't pin a count.
+GET http://{{host}}/api/activity
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.items" isCollection
+jsonpath "$.total" exists
+jsonpath "$.page" exists
+jsonpath "$.per_page" exists

--- a/tests/api/activity/list.hurl
+++ b/tests/api/activity/list.hurl
@@ -12,3 +12,4 @@ jsonpath "$.items" isCollection
 jsonpath "$.total" exists
 jsonpath "$.page" exists
 jsonpath "$.per_page" exists
+jsonpath "$.total_pages" exists

--- a/tests/api/auth/logout.hurl
+++ b/tests/api/auth/logout.hurl
@@ -1,0 +1,10 @@
+# POST /api/auth/logout — legacy alias mounted at `routes.rs:135`,
+# routing to the same canonical kikan handler as
+# `/api/platform/v1/auth/logout`. The handler always returns 204 whether
+# or not a session is attached (see
+# `crates/kikan/src/platform/v1/auth/logout.rs`), so Phase 1 placement
+# (anonymous, no cookie jar) exercises the alias mount without
+# invalidating the shared cookie jar Phase 2 tests rely on.
+POST http://{{host}}/api/auth/logout
+
+HTTP 204

--- a/tests/api/auth/recover.hurl
+++ b/tests/api/auth/recover.hurl
@@ -1,0 +1,25 @@
+# POST /api/auth/recover — vertical recovery-code → password reset.
+#
+# Happy path is impossible from a smoke harness (we don't have a real
+# recovery code at the moment of the call; the seeded production admin's
+# 10 codes are captured by `_prelude/setup-wizard.hurl` but consuming one
+# here would invalidate the post-setup state for downstream tests).
+#
+# Per `crates/mokumo-shop/src/auth/recover.rs`, the handler is
+# anti-enumeration: rate-limit, password-too-short, AND invalid-code all
+# return 400 `validation_error` with the same wire-shape. Asserting that
+# rejection contract IS the structural smoke per the bar D split.
+POST http://{{host}}/api/auth/recover
+Content-Type: application/json
+{
+    "email": "{{admin_email}}",
+    "recovery_code": "0000-0000-0000",
+    "new_password": "this-password-is-long-enough-1234"
+}
+
+HTTP 400
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "validation_error"
+jsonpath "$.message" exists
+jsonpath "$.details" == null

--- a/tests/api/customers/delete.hurl
+++ b/tests/api/customers/delete.hurl
@@ -1,0 +1,23 @@
+# DELETE /api/customers/{id} — soft-delete a customer. Self-seeds via
+# POST and asserts the response carries a populated `deleted_at`
+# timestamp; the row remains in the table (soft delete) and a follow-up
+# `restore` PATCH can revive it (see `restore.hurl`).
+POST http://{{host}}/api/customers
+Content-Type: application/json
+{
+    "display_name": "Hurl Delete-Test Shop"
+}
+
+HTTP 201
+[Captures]
+customer_id: jsonpath "$.id"
+
+
+DELETE http://{{host}}/api/customers/{{customer_id}}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.id" == "{{customer_id}}"
+jsonpath "$.deleted_at" exists
+jsonpath "$.deleted_at" != null

--- a/tests/api/customers/restore.hurl
+++ b/tests/api/customers/restore.hurl
@@ -1,0 +1,26 @@
+# PATCH /api/customers/{id}/restore — restore a soft-deleted customer.
+# Self-seeds via POST → DELETE → PATCH so the file is parallel-safe and
+# profile-agnostic.
+POST http://{{host}}/api/customers
+Content-Type: application/json
+{
+    "display_name": "Hurl Restore-Test Shop"
+}
+
+HTTP 201
+[Captures]
+customer_id: jsonpath "$.id"
+
+
+DELETE http://{{host}}/api/customers/{{customer_id}}
+
+HTTP 200
+
+
+PATCH http://{{host}}/api/customers/{{customer_id}}/restore
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.id" == "{{customer_id}}"
+jsonpath "$.deleted_at" == null

--- a/tests/api/customers/update.hurl
+++ b/tests/api/customers/update.hurl
@@ -1,0 +1,30 @@
+# PUT /api/customers/{id} — update an existing customer. Self-seeds via
+# POST so the file is profile-agnostic and parallel-safe (each parallel
+# run captures its own customer_id; the customers table has no unique
+# constraint on display_name per
+# `crates/mokumo-shop/src/migrations/m20260324_000001_customers_and_activity.rs`).
+POST http://{{host}}/api/customers
+Content-Type: application/json
+{
+    "display_name": "Hurl Update-Test Shop"
+}
+
+HTTP 201
+[Captures]
+customer_id: jsonpath "$.id"
+
+
+PUT http://{{host}}/api/customers/{{customer_id}}
+Content-Type: application/json
+{
+    "display_name": "Hurl Updated Shop",
+    "phone": "555-0199"
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.id" == "{{customer_id}}"
+jsonpath "$.display_name" == "Hurl Updated Shop"
+jsonpath "$.phone" == "555-0199"
+jsonpath "$.updated_at" exists

--- a/tests/api/customers/update.hurl
+++ b/tests/api/customers/update.hurl
@@ -27,4 +27,4 @@ header "Content-Type" contains "application/json"
 jsonpath "$.id" == "{{customer_id}}"
 jsonpath "$.display_name" == "Hurl Updated Shop"
 jsonpath "$.phone" == "555-0199"
-jsonpath "$.updated_at" exists
+jsonpath "$.updated_at" matches /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/

--- a/tests/api/server-info.hurl
+++ b/tests/api/server-info.hurl
@@ -1,0 +1,14 @@
+# GET /api/server-info — public endpoint exposing the bound host/port and
+# discovery (mDNS / LAN URL) shape. Thin structural smoke per the bar D
+# split: assert wire-shape only; ServerInfoResponse is in
+# `crates/kikan-types/src/lib.rs`.
+GET http://{{host}}/api/server-info
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.host" exists
+jsonpath "$.port" exists
+jsonpath "$.mdns_active" exists
+jsonpath "$.lan_url" exists
+jsonpath "$.ip_url" exists

--- a/tests/api/setup-status.hurl
+++ b/tests/api/setup-status.hurl
@@ -1,0 +1,16 @@
+# GET /api/setup-status — public endpoint reporting the bootstrap state
+# (active profile, setup_complete flag, shop_name, logo_url). Phase 1
+# placement: asserts shape only, never values, so the same file is valid
+# under cold-demo (pre-wizard) AND post-wizard production. SetupStatusResponse
+# is in `crates/kikan-types/src/setup.rs`.
+GET http://{{host}}/api/setup-status
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.setup_complete" exists
+jsonpath "$.is_first_launch" exists
+jsonpath "$.production_setup_complete" exists
+jsonpath "$.setup_mode" exists
+jsonpath "$.shop_name" exists
+jsonpath "$.logo_url" exists


### PR DESCRIPTION
## Summary

Final chunk of the mokumo#383 hurl-suite epic. Adds thin structural smoke for 9 previously-uncovered endpoints; closes the per-endpoint half of bar D from the frame doc (`~/Github/ops/workspace/mokumo/mokumo-20260426-383-hurl-suite/frame.md` row 251). Per the G3 split, Hurl asserts the wire shape and Rust unit tests own per-branch logical correctness.

Builds on top of PR-2.5 (#724) — multi-phase setup-wizard harness is now the steady state. No new infrastructure; this PR is purely .hurl files + moon.yml wiring.

## Coverage gap table

| Route | New file | Phase | Notes |
|---|---|---|---|
| `GET /api/server-info` | `tests/api/server-info.hurl` | 1 | Public; assert `ServerInfoResponse` shape. |
| `GET /api/setup-status` | `tests/api/setup-status.hurl` | 1 | Public; shape-only so it passes against both cold-demo (pre-wizard) and post-wizard production. |
| `POST /api/auth/recover` | `tests/api/auth/recover.hurl` | 1 | Vertical recovery-code → password reset. Anti-enumeration design collapses rate-limit/invalid-code/short-password to one 400 `validation_error` shape; that rejection contract IS the structural smoke. |
| `POST /api/auth/logout` (legacy alias) | `tests/api/auth/logout.hurl` | 1 | Same kikan handler as `/api/platform/v1/auth/logout`; returns 204 with or without a session. Phase 1 placement avoids cookie-jar invalidation. |
| `GET /api/activity` | `tests/api/activity/list.hurl` | 1 | Protected by `require_auth_with_demo_auto_login`; demo auto-login carries it. Asserts `PaginatedList` shape, doesn't pin item count. |
| `PUT /api/customers/{id}` | `tests/api/customers/update.hurl` | 1 | Self-seeds via POST. |
| `DELETE /api/customers/{id}` | `tests/api/customers/delete.hurl` | 1 | Self-seeds via POST; asserts `deleted_at` is populated (soft delete). |
| `PATCH /api/customers/{id}/restore` | `tests/api/customers/restore.hurl` | 1 | Self-seeds → POST → DELETE → PATCH; asserts `deleted_at` is null after restore. |
| `POST /api/account/recovery-codes/regenerate` | `tests/api/account/recovery-codes-regenerate.hurl` | 2 | Cookie-bearing; uses admin password from `ci.env`; lives in the `--jobs 1` serialized set. Asserts `recovery_codes` is an array of 10. |

Customers self-seed pattern is parallel-safe — each file captures its own `customer_id` and the `customers` table has no unique constraint on `display_name` (per `crates/mokumo-shop/src/migrations/m20260324_000001_customers_and_activity.rs`).

## Documented exclusions (moon.yml ledger)

Four routes intentionally not covered by `shop:smoke`. Ledger entries added so the gap is traceable instead of silent debt:

| Route | Why excluded | Alternative coverage |
|---|---|---|
| `POST /api/demo/reset` | Always restarts the server (`crates/mokumo-shop/src/demo_reset.rs`); calling it from this harness would orphan the captured-stderr file and break every subsequent test. | Tauri `demo-smoke` desktop job. |
| `POST /api/profile/switch` | Flips `<data_dir>/active_profile` on disk and in memory; switching out of production would invalidate the shared cookie jar and reshape `/api/setup-status`, breaking every other Phase 2 file. | Needs a dedicated harness; tracked separately if/when filed. |
| `GET /ws` | WebSocket upgrade — Hurl is HTTP-only by design. | Playwright BDD scenarios under `apps/web/tests`. |
| `GET\|POST /api/debug/*` | `cfg(debug_assertions)` only — release binary the smoke harness boots does not register these routes. | N/A — debug-build-only. |

## Local validation

Hurl binary on the dev container is x86_64 / host is aarch64 (same situation as PR-2.5), so `moon run shop:smoke` cannot run locally; CI is the validator. All new files mirror existing patterns (`session cookie name "id"`, `Content-Type contains "application/json"`, error shape `$.code`/`$.message`/`$.details`).

## Test plan

- [ ] `api-smoke` CI check green — Phase 1 (8 new files among 38 active) + Phase 2 (1 new file in `--jobs 1` serialized set) all pass.
- [ ] `verdict` CI check green.
- [ ] No new `*.hurl` paths leaked into workflow YAML (G1 guard via `scripts/check-no-hurl-in-workflows.sh`).
- [ ] `gh pr view --comments` after CI runs — address any CodeRabbit/Gemini findings before merge.

## Three-place agreement

On merge: post status comment on #383 mirroring PR-2.5's format; update the in-tree ledger above; update `frame.md` row 251 to "Merged".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded API test coverage with new regression and smoke tests for authentication recovery, customer management, activity listing, and server information endpoints.

* **Chores**
  * Updated test task configuration to include additional test files in the smoke test harness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->