### PR TITLE
test(users): add PATCH /api/users/{id}/role happy-path smoke

### DIFF
--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -420,6 +420,19 @@ tasks:
       #     `cfg(debug_assertions)` only — the release binary the smoke
       #     harness boots does not register these routes.
       #
+      #   DELETE /api/users/{id} (happy-path)
+      #     The seeded admin is the only user, and the kikan service-layer
+      #     last-admin guard (`crates/kikan/src/auth/service.rs:28`)
+      #     blocks deleting the only admin. Mokumo has no public
+      #     user-creation API and no test-only seed mechanism, so a
+      #     non-admin subject cannot be brought into existence from a
+      #     hurl-only harness. The 404 contract is covered by
+      #     `tests/api/users/soft-delete-not-found.hurl`; the happy-path
+      #     wire shape is covered by Rust unit tests in
+      #     `crates/kikan/src/auth/service.rs` (`soft_delete_user_*`).
+      #     Re-attach when a user-seeding harness lands (mokumo#729
+      #     Piece 3 follow-up).
+      #
       # ---------------------------------------------------------------------
       # Phase 1 — unauthenticated paths and demo-auto-login-carried tests.
       # Excludes login-success.hurl: admin doesn't exist yet (setup wizard
@@ -513,6 +526,7 @@ tasks:
         tests/api/customers/restore.hurl \
         tests/api/users/soft-delete-not-found.hurl \
         tests/api/users/update-role-not-found.hurl \
+        tests/api/users/update-role-success.hurl \
         tests/api/shop/logo-upload.hurl \
         tests/api/shop/logo-upload-errors.hurl \
         tests/api/shop/logo-delete.hurl

--- a/tests/api/users/update-role-success.hurl
+++ b/tests/api/users/update-role-success.hurl
@@ -22,7 +22,7 @@ GET http://{{host}}/api/auth/me
 
 HTTP 200
 [Captures]
-admin_id: jsonpath "$.id"
+admin_id: jsonpath "$.user.id"
 
 
 PATCH http://{{host}}/api/users/{{admin_id}}/role

--- a/tests/api/users/update-role-success.hurl
+++ b/tests/api/users/update-role-success.hurl
@@ -23,6 +23,7 @@ GET http://{{host}}/api/auth/me
 HTTP 200
 [Captures]
 admin_id: jsonpath "$.user.id"
+admin_email: jsonpath "$.user.email"
 
 
 PATCH http://{{host}}/api/users/{{admin_id}}/role
@@ -34,8 +35,8 @@ Content-Type: application/json
 HTTP 200
 [Asserts]
 header "Content-Type" contains "application/json"
-jsonpath "$.id" isInteger
-jsonpath "$.email" exists
+jsonpath "$.id" == {{admin_id}}
+jsonpath "$.email" == "{{admin_email}}"
 jsonpath "$.role_name" == "Admin"
 jsonpath "$.is_active" == true
 jsonpath "$.updated_at" matches /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/

--- a/tests/api/users/update-role-success.hurl
+++ b/tests/api/users/update-role-success.hurl
@@ -1,0 +1,41 @@
+# PATCH /api/users/{id}/role — happy path: no-op flip on the seeded admin.
+#
+# Phase 2 (--jobs 1): touches `activity_log` via the user-admin write
+# path (CLAUDE.md item 12 — adapter-level invariant). Cookie threaded
+# by moon.yml from `tests/api/_prelude/admin-login.hurl`.
+#
+# Why a no-op flip: there is no public user-creation API and no
+# test-only seed mechanism for a non-admin user, so the seeded admin is
+# the only subject available. We assign Admin → Admin: the kikan
+# service-layer last-admin guard at
+# `crates/kikan/src/auth/service.rs:56` skips the demote count check
+# when `new_role == current_role`, so this exercises the full handler
+# stack (auth gate, path extraction, body parse, service call, repo
+# update, activity insert, response render) without breaking the
+# downstream Phase 2 cookie-jar admin.
+#
+# DELETE /api/users/{id} happy-path is deferred — see moon.yml ledger.
+#
+# Uses variables: host. Auth: --cookie populated by Phase 1.5b prelude.
+
+GET http://{{host}}/api/auth/me
+
+HTTP 200
+[Captures]
+admin_id: jsonpath "$.id"
+
+
+PATCH http://{{host}}/api/users/{{admin_id}}/role
+Content-Type: application/json
+{
+    "role_id": 1
+}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.id" isInteger
+jsonpath "$.email" exists
+jsonpath "$.role_name" == "Admin"
+jsonpath "$.is_active" == true
+jsonpath "$.updated_at" matches /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/


### PR DESCRIPTION
## Summary

Adds the user-admin happy-path Phase-2 smoke that the hurl-suite epic deferred:

- `tests/api/users/update-role-success.hurl` — `PATCH /api/users/{id}/role` happy path on the seeded admin (no-op flip Admin → Admin to satisfy the last-admin guard at `crates/kikan/src/auth/service.rs:56`).
- `crates/mokumo-shop/moon.yml` Phase 2 wires the new file in.
- Exclusion ledger documents why **DELETE `/api/users/{id}`** happy-path is deferred: there is no public POST `/api/users` endpoint and no kikan-cli create-user subcommand yet, so the demo seed's single admin can't be deleted without tripping the last-admin guard at `crates/kikan/src/auth/service.rs:28`. Re-attaching needs a user-seeding harness.

Phase 2 placement (`--jobs 1`) because the test mutates and writes to `activity_log` — see SQLITE_BUSY rule in `~/.claude/skills/hurl-test-author/SKILL.md`.

## Test plan

- [ ] CI runs `moon run shop:smoke` — Phase 2 sees the new file
- [ ] PaginatedList-style 5-field assertions present (id, email, role_name, is_active, updated_at)
- [ ] `updated_at` regex `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}` matches ISO-8601
- [ ] Error shape contract `{code, message, details}` not asserted here — happy-path only

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)