### PR TITLE
test(setup): add POST /api/setup error-contract smoke

### DIFF
--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -437,6 +437,7 @@ tasks:
         tests/api/kikan-version/kikan-version.hurl \
         tests/api/server-info.hurl \
         tests/api/setup-status.hurl \
+        tests/api/setup/setup.hurl \
         tests/api/auth/login-bad-credentials.hurl \
         tests/api/auth/login-rate-limit.hurl \
         tests/api/auth/forgot-password.hurl \

--- a/tests/api/setup/setup.hurl
+++ b/tests/api/setup/setup.hurl
@@ -1,0 +1,56 @@
+# POST /api/setup — assert 4xx error contracts pre-setup-completion.
+#
+# Phase 1, ORDERED BEFORE `_prelude/setup-wizard.hurl` in moon.yml so
+# setup is still pending. Once the wizard completes, this endpoint
+# returns 403 `forbidden` ("Setup already completed") for every input
+# (per `crates/mokumo-shop/src/setup.rs:171` `Conflict` mapping),
+# which would mask the input-validation contracts this file exercises.
+#
+# Two scenarios:
+#   1. Empty `shop_name` with otherwise valid fields →
+#      422 `validation_error` (handler-level field check at
+#      `crates/mokumo-shop/src/setup.rs:64`).
+#   2. Bogus `setup_token` (UUID-shaped but never minted) →
+#      401 `invalid_token` (token validator returns
+#      `ControlPlaneError::PermissionDenied`, mapped at
+#      `crates/mokumo-shop/src/setup.rs:174`).
+#
+# Both calls fail before any DB write, so they leave the pending-setup
+# state untouched for the wizard prelude that runs after Phase 1.
+#
+# Uses variables: host. No auth.
+
+POST http://{{host}}/api/setup
+Content-Type: application/json
+{
+    "shop_name": "",
+    "admin_name": "Hurl Setup-Test Admin",
+    "admin_email": "hurl-setup-test@example.com",
+    "admin_password": "hurl-setup-password-1234567890",
+    "setup_token": "00000000-0000-0000-0000-000000000000"
+}
+
+HTTP 422
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "validation_error"
+jsonpath "$.message" exists
+jsonpath "$.details.form" isCollection
+
+
+POST http://{{host}}/api/setup
+Content-Type: application/json
+{
+    "shop_name": "Hurl Setup-Test Shop",
+    "admin_name": "Hurl Setup-Test Admin",
+    "admin_email": "hurl-setup-test@example.com",
+    "admin_password": "hurl-setup-password-1234567890",
+    "setup_token": "00000000-0000-0000-0000-000000000000"
+}
+
+HTTP 401
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.code" == "invalid_token"
+jsonpath "$.message" exists
+jsonpath "$.details" == null


### PR DESCRIPTION
## Summary

Backfills the missing per-endpoint thin file for `POST /api/setup/` — the wizard endpoint that the multi-phase harness depends on but never had an error-contract test of its own.

Two state-neutral 4xx scenarios:

1. Empty `shop_name` → **422 validation_error** with `details.form` populated.
2. Bogus `setup_token` UUID (`00000000-0000-0000-0000-000000000000`) → **401 invalid_token**.

Both calls fail before any DB write, so the file is safe in **Phase 1** and ordered **before** the setup-wizard prelude (so wizard preconditions remain undisturbed).

`crates/mokumo-shop/moon.yml` Phase 1 wires the new file in between `setup-status.hurl` and the wizard prelude invocation.

## Test plan

- [ ] CI runs `moon run shop:smoke` — Phase 1 sees the new file before wizard prelude
- [ ] Error shape contract `{code, message, details}` asserted on both responses
- [ ] `$.code == "validation_error"` and `$.code == "invalid_token"` per `adr-api-response-conventions.md`
- [ ] No state mutation (no Phase 2 placement needed)

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)