### PR TITLE
feat(scorecard): #768 — V3 threshold engine + quality.toml operator surface

### DIFF
--- a/.config/scorecard/quality.config.schema.json
+++ b/.config/scorecard/quality.config.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ThresholdConfig",
+  "description": "Operator-tunable threshold configuration.\n\nTop-level shape of `.config/scorecard/quality.toml`. Generates the operator-facing JSON Schema via `schemars::schema_for!` (no `cli` feature required), so a downstream `cargo build -p scorecard --no-default-features --bin emit-schema` succeeds. The JSON Schema derives drive the `quality.config.schema.json` artifact that ajv validates the committed example against.\n\n`deny_unknown_fields` so a typo in the operator's TOML (`warn_pp_dleta` etc.) fails the parse rather than being silently dropped.",
+  "type": "object",
+  "required": [
+    "rows"
+  ],
+  "properties": {
+    "rows": {
+      "description": "Per-row threshold tables. Currently a single `coverage` row; new row variants add sibling fields here in lockstep with the matching `resolve_*` free function in this module.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RowsConfig"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "CoverageThresholds": {
+      "description": "Warn / fail thresholds for the `Row::CoverageDelta` variant, expressed in percentage points (pp) of coverage delta vs base.\n\nBoth fields are signed: a regression is a negative delta, so warn and fail thresholds for \"drops\" are themselves negative numbers. Inclusive boundary semantics: `delta_pp == warn_pp_delta` resolves to [`Status::Yellow`]; `delta_pp == fail_pp_delta` resolves to [`Status::Red`]. See [`resolve_coverage_delta`] for the full table.",
+      "type": "object",
+      "required": [
+        "fail_pp_delta",
+        "warn_pp_delta"
+      ],
+      "properties": {
+        "fail_pp_delta": {
+          "description": "Threshold below (or equal) which a row reports [`Status::Red`]. Typically negative and more negative than `warn_pp_delta`.",
+          "type": "number"
+        },
+        "warn_pp_delta": {
+          "description": "Threshold below (or equal) which a row reports [`Status::Yellow`]. Typically negative.",
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RowsConfig": {
+      "description": "Per-row threshold tables. One field per `Row` variant kind.\n\nAdding a new row variant in `lib.rs` is paired with a new field here and a sibling `resolve_*` free function below — the four changes land together in the same commit.",
+      "type": "object",
+      "required": [
+        "coverage"
+      ],
+      "properties": {
+        "coverage": {
+          "description": "Thresholds for the `Row::CoverageDelta` variant.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CoverageThresholds"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/.config/scorecard/quality.toml
+++ b/.config/scorecard/quality.toml
@@ -1,0 +1,24 @@
+# Operator-tuned thresholds for the sticky PR scorecard.
+#
+# When this file is present the producer consumes it for per-row
+# warn/fail thresholds and resolves each row's status (Green / Yellow /
+# Red) accordingly. Removing or renaming the file falls back to the
+# starter-wheel defaults compiled into the producer; the renderer flags
+# fallback runs explicitly so verdicts cannot silently come from
+# defaults.
+#
+# Schema lives at `.config/scorecard/quality.config.schema.json` and is
+# kept in lockstep with this file by the `scorecard-drift` CI gate.
+#
+# Boundary semantics: `delta_pp == warn_pp_delta` resolves Yellow;
+# `delta_pp == fail_pp_delta` resolves Red. Both fields are signed
+# percentage points — a coverage drop is a negative number, so the
+# default warn/fail values are negative.
+
+[rows.coverage]
+# Coverage delta vs. base, in percentage points.
+#   delta_pp >  -1.0   → Green (within typical instrumentation noise)
+#   delta_pp <= -1.0   → Yellow (visible regression worth a soft signal)
+#   delta_pp <= -5.0   → Red (hard fail)
+warn_pp_delta = -1.0
+fail_pp_delta = -5.0

--- a/.config/scorecard/schema.json
+++ b/.config/scorecard/schema.json
@@ -19,7 +19,7 @@
       "pattern": "^https://"
     },
     "fallback_thresholds_active": {
-      "description": "`true` when the producer resolved row statuses using the hardcoded [`threshold::ThresholdConfig::fallback`] thresholds (no operator `quality.toml` was present or readable). The renderer keys off this flag to emit [`threshold::STARTER_PREAMBLE`] + [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`] so operators can tell at a glance that the verdict came from starter-wheel defaults rather than their tuned thresholds.",
+      "description": "`true` when the producer resolved row statuses using the hardcoded [`threshold::ThresholdConfig::fallback`] thresholds because the operator `quality.toml` was absent or empty. A present-but-malformed or unreadable `quality.toml` is a loud failure (non-zero exit, no artifact written), not a silent fallback — so this flag is `true` only for the deliberate \"operator hasn't tuned thresholds yet\" case.\n\nThe renderer keys off this flag to emit [`threshold::STARTER_PREAMBLE`] + [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`] so operators can tell at a glance that the verdict came from starter-wheel defaults rather than their tuned thresholds.",
       "type": "boolean"
     },
     "overall_status": {

--- a/.config/scorecard/schema.json
+++ b/.config/scorecard/schema.json
@@ -5,6 +5,7 @@
   "type": "object",
   "required": [
     "all_check_runs_url",
+    "fallback_thresholds_active",
     "overall_status",
     "pr",
     "rows",
@@ -16,6 +17,10 @@
       "type": "string",
       "format": "uri",
       "pattern": "^https://"
+    },
+    "fallback_thresholds_active": {
+      "description": "`true` when the producer resolved row statuses using the hardcoded [`threshold::ThresholdConfig::fallback`] thresholds (no operator `quality.toml` was present or readable). The renderer keys off this flag to emit [`threshold::STARTER_PREAMBLE`] + [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`] so operators can tell at a glance that the verdict came from starter-wheel defaults rather than their tuned thresholds.",
+      "type": "boolean"
     },
     "overall_status": {
       "description": "Resolved status across all rows. The renderer's banner reads this directly; per the .feature spec the banner status is the worst status across all rows.",
@@ -136,6 +141,7 @@
           },
           "required": [
             "anchor",
+            "delta_pp",
             "delta_text",
             "id",
             "label",
@@ -146,6 +152,11 @@
             "anchor": {
               "description": "Anchor fragment for jump-linking from the comment.",
               "type": "string"
+            },
+            "delta_pp": {
+              "description": "Raw coverage delta in percentage points vs. the base branch. The constructor records this alongside the status that was minted from it; the renderer keeps using `delta_text` for display, but downstream tooling (and future trend dashboards) can read `delta_pp` without reparsing the formatted string.",
+              "type": "number",
+              "format": "double"
             },
             "delta_text": {
               "description": "Display string for the delta (e.g. `\"+0.3 pp\"` or `\"-4.2 pp\"`).",

--- a/.github/scripts/scorecard/__tests__/render.test.js
+++ b/.github/scripts/scorecard/__tests__/render.test.js
@@ -102,7 +102,7 @@ describe("renderScorecardMarkdown", () => {
     expect(md).toContain("(detail missing — see workflow logs)");
   });
 
-  // ── Fallback-threshold signals (V3 doc-drift gate) ──────────────────
+  // ── Fallback-threshold signals (doc-drift gate) ─────────────────────
   //
   // Every byte of the three fallback signals is pinned by these
   // assertions. Drift between the renderer's emitted markdown and the
@@ -359,11 +359,11 @@ describe("renderer dependency hygiene", () => {
 });
 
 describe("bin/render-cli.js", () => {
-  // The render-cli wrapper lets non-Node callers (BDD step-defs, the
-  // V3-PR Red-smoke workflow, ad-hoc shell pipelines) feed a JSON
-  // artifact through the same renderer the production sticky-comment
-  // poster uses, without bouncing through `actions/github-script`.
-  // These tests pin its behavior end-to-end via a child process so a
+  // The render-cli wrapper lets non-Node callers (BDD step-defs,
+  // smoke workflows, ad-hoc shell pipelines) feed a JSON artifact
+  // through the same renderer the production sticky-comment poster
+  // uses, without bouncing through `actions/github-script`. These
+  // tests pin its behavior end-to-end via a child process so a
   // regression in stdin reading or stdout writing surfaces immediately.
 
   function runCli(jsonString) {

--- a/.github/scripts/scorecard/__tests__/render.test.js
+++ b/.github/scripts/scorecard/__tests__/render.test.js
@@ -22,11 +22,13 @@ const baseScorecard = {
       label: "Coverage",
       anchor: "coverage",
       status: "Green",
-      delta_text: "stub — V1 walking skeleton",
+      delta_pp: 0.3,
+      delta_text: "+0.3 pp",
     },
   ],
   top_failures: [],
   all_check_runs_url: "https://github.com/breezy-bays-labs/mokumo/runs",
+  fallback_thresholds_active: true,
 };
 
 describe("renderScorecardMarkdown", () => {
@@ -49,7 +51,7 @@ describe("renderScorecardMarkdown", () => {
   it("renders the row label and delta_text", () => {
     const md = renderScorecardMarkdown(baseScorecard);
     expect(md).toContain("Coverage");
-    expect(md).toContain("stub — V1 walking skeleton");
+    expect(md).toContain("+0.3 pp");
   });
 
   it("includes the abbreviated head SHA", () => {

--- a/.github/scripts/scorecard/__tests__/render.test.js
+++ b/.github/scripts/scorecard/__tests__/render.test.js
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   STICKY_MARKER,
+  FALLBACK_MARKER,
+  STARTER_PREAMBLE,
+  PATH_HINT_COMMENT,
   renderScorecardMarkdown,
   renderFailClosedMarkdown,
   postStickyComment,
@@ -92,6 +100,56 @@ describe("renderScorecardMarkdown", () => {
     };
     const md = renderScorecardMarkdown(sc);
     expect(md).toContain("(detail missing — see workflow logs)");
+  });
+
+  // ── Fallback-threshold signals (V3 doc-drift gate) ──────────────────
+  //
+  // Every byte of the three fallback signals is pinned by these
+  // assertions. Drift between the renderer's emitted markdown and the
+  // exported constants — or between the constants and the producer-side
+  // mirror in `crates/scorecard/src/threshold.rs` — surfaces as a test
+  // diff on PR review.
+
+  it("emits FALLBACK_MARKER + STARTER_PREAMBLE + PATH_HINT_COMMENT for fallback artifacts", () => {
+    const sc = { ...baseScorecard, fallback_thresholds_active: true };
+    const md = renderScorecardMarkdown(sc);
+    expect(md).toContain(FALLBACK_MARKER);
+    expect(md).toContain(STARTER_PREAMBLE);
+    expect(md).toContain(PATH_HINT_COMMENT);
+  });
+
+  it("emits no fallback signals when fallback_thresholds_active is false", () => {
+    const sc = { ...baseScorecard, fallback_thresholds_active: false };
+    const md = renderScorecardMarkdown(sc);
+    expect(md).not.toContain(FALLBACK_MARKER);
+    expect(md).not.toContain(STARTER_PREAMBLE);
+    expect(md).not.toContain(PATH_HINT_COMMENT);
+  });
+
+  it("frames a fallback body with the preamble before the banner and the marker after the table", () => {
+    const sc = { ...baseScorecard, fallback_thresholds_active: true };
+    const md = renderScorecardMarkdown(sc);
+    const preambleIdx = md.indexOf(STARTER_PREAMBLE);
+    const bannerIdx = md.indexOf("CI status:");
+    const tableEnd = md.indexOf("+0.3 pp"); // last table row content
+    const markerIdx = md.indexOf(FALLBACK_MARKER);
+    const hintIdx = md.indexOf(PATH_HINT_COMMENT);
+    expect(preambleIdx).toBeGreaterThan(-1);
+    expect(preambleIdx).toBeLessThan(bannerIdx);
+    expect(markerIdx).toBeGreaterThan(tableEnd);
+    expect(hintIdx).toBeGreaterThan(markerIdx);
+  });
+
+  it("FALLBACK_MARKER + PATH_HINT_COMMENT are HTML comments (do not render visibly)", () => {
+    expect(FALLBACK_MARKER).toMatch(/^<!--.*-->$/);
+    expect(PATH_HINT_COMMENT).toMatch(/^<!--.*-->$/);
+  });
+
+  it("STARTER_PREAMBLE is italic markdown linking the operator config", () => {
+    expect(STARTER_PREAMBLE.startsWith("_")).toBe(true);
+    expect(STARTER_PREAMBLE.endsWith("_")).toBe(true);
+    expect(STARTER_PREAMBLE).toContain("`quality.toml`");
+    expect(STARTER_PREAMBLE).toContain("QUALITY.md#threshold-tuning");
   });
 });
 
@@ -273,5 +331,106 @@ describe("postStickyComment", () => {
     expect(updateComment).toHaveBeenCalledTimes(1);
     expect(createComment).not.toHaveBeenCalled();
     expect(paginate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("renderer dependency hygiene", () => {
+  // The producer (Rust) owns TOML parsing — see ADR §Threshold
+  // resolution lives in the producer. The renderer must NEVER pick up
+  // a TOML parser as a dep, even transitively. This regex enumerates
+  // the parsers that have appeared in the npm ecosystem; extend if a
+  // new one surfaces.
+  const FORBIDDEN_TOML_PARSERS =
+    /^(@iarna\/toml|@ltd\/j-toml|toml|smol-toml|js-toml|toml-js|tomlify|tomlify-j0\.4)$/;
+
+  it("renderer package.json declares no TOML parser", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkgPath = join(here, "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    const allDeps = Object.keys({
+      ...(pkg.dependencies ?? {}),
+      ...(pkg.devDependencies ?? {}),
+      ...(pkg.peerDependencies ?? {}),
+      ...(pkg.optionalDependencies ?? {}),
+    });
+    const hits = allDeps.filter((d) => FORBIDDEN_TOML_PARSERS.test(d));
+    expect(hits).toEqual([]);
+  });
+});
+
+describe("bin/render-cli.js", () => {
+  // The render-cli wrapper lets non-Node callers (BDD step-defs, the
+  // V3-PR Red-smoke workflow, ad-hoc shell pipelines) feed a JSON
+  // artifact through the same renderer the production sticky-comment
+  // poster uses, without bouncing through `actions/github-script`.
+  // These tests pin its behavior end-to-end via a child process so a
+  // regression in stdin reading or stdout writing surfaces immediately.
+
+  function runCli(jsonString) {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const cliPath = join(here, "..", "bin", "render-cli.js");
+    const tmp = mkdtempSync(join(tmpdir(), "render-cli-"));
+    const inputPath = join(tmp, "input.json");
+    writeFileSync(inputPath, jsonString);
+    const stdout = execFileSync("node", [cliPath], {
+      input: readFileSync(inputPath),
+      encoding: "utf8",
+    });
+    return stdout;
+  }
+
+  function fixture(extra) {
+    return JSON.stringify({
+      schema_version: 0,
+      pr: {
+        pr_number: 768,
+        head_sha: "deadbeef0000000",
+        base_sha: "cafefeed0000000",
+        is_fork: false,
+      },
+      overall_status: "Yellow",
+      rows: [
+        {
+          type: "CoverageDelta",
+          id: "coverage",
+          label: "Coverage",
+          anchor: "coverage",
+          status: "Yellow",
+          delta_pp: -2.5,
+          delta_text: "-2.5 pp",
+        },
+      ],
+      top_failures: [],
+      all_check_runs_url: "https://example.test/checks",
+      fallback_thresholds_active: true,
+      ...extra,
+    });
+  }
+
+  it("reads JSON stdin and writes the rendered markdown to stdout", () => {
+    const stdout = runCli(fixture());
+    expect(stdout).toContain(STICKY_MARKER);
+    expect(stdout).toContain("CI status: Yellow");
+  });
+
+  it("matches the in-process renderer output byte-for-byte", () => {
+    const json = fixture();
+    const stdout = runCli(json);
+    const inProcess = renderScorecardMarkdown(JSON.parse(json));
+    expect(stdout).toBe(inProcess);
+  });
+
+  it("emits the fallback signals when fallback_thresholds_active is true", () => {
+    const stdout = runCli(fixture({ fallback_thresholds_active: true }));
+    expect(stdout).toContain(STARTER_PREAMBLE);
+    expect(stdout).toContain(FALLBACK_MARKER);
+    expect(stdout).toContain(PATH_HINT_COMMENT);
+  });
+
+  it("omits the fallback signals when fallback_thresholds_active is false", () => {
+    const stdout = runCli(fixture({ fallback_thresholds_active: false }));
+    expect(stdout).not.toContain(STARTER_PREAMBLE);
+    expect(stdout).not.toContain(FALLBACK_MARKER);
+    expect(stdout).not.toContain(PATH_HINT_COMMENT);
   });
 });

--- a/.github/scripts/scorecard/__tests__/validate.test.js
+++ b/.github/scripts/scorecard/__tests__/validate.test.js
@@ -24,11 +24,13 @@ const validScorecard = {
       label: "Coverage",
       anchor: "coverage",
       status: "Green",
-      delta_text: "stub",
+      delta_pp: 0.0,
+      delta_text: "+0.0 pp",
     },
   ],
   top_failures: [],
   all_check_runs_url: "https://github.com/x/y/runs",
+  fallback_thresholds_active: true,
 };
 
 describe("validateScorecard", () => {

--- a/.github/scripts/scorecard/bin/render-cli.js
+++ b/.github/scripts/scorecard/bin/render-cli.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Tiny stdin → stdout wrapper around `renderScorecardMarkdown`.
+//
+// Reads a scorecard artifact JSON from stdin (file descriptor 0),
+// renders the sticky-comment markdown body, and writes it to stdout.
+// The wrapper exists so CI steps and ad-hoc scripts can pipe a JSON
+// artifact through without bouncing through `actions/github-script`'s
+// inline JavaScript or starting a Node REPL.
+//
+// The renderer module's `module.exports` surface is intentionally
+// unchanged; this wrapper is additive.
+//
+// Usage:
+//   node .github/scripts/scorecard/bin/render-cli.js < scorecard.json > comment.md
+
+"use strict";
+
+const { renderScorecardMarkdown } = require("../render.js");
+const fs = require("node:fs");
+
+const data = JSON.parse(fs.readFileSync(0, "utf8"));
+process.stdout.write(renderScorecardMarkdown(data));

--- a/.github/scripts/scorecard/render.js
+++ b/.github/scripts/scorecard/render.js
@@ -20,6 +20,32 @@
 
 const STICKY_MARKER = "<!-- ci-scorecard -->";
 
+// ── Fallback-threshold signals ─────────────────────────────────────────
+//
+// The renderer surfaces three byte-stable strings whenever the producer
+// ran without an operator `quality.toml`. Both sides (this file and
+// `crates/scorecard/src/threshold.rs`) declare these constants
+// independently — a vitest snapshot in `__tests__/render.test.js`
+// asserts byte-equality on the rendered markdown, and a cucumber-rs
+// step-def asserts the Rust side stays in lockstep with the Gherkin
+// literal in `crates/scorecard/tests/features/scorecard_display.feature`.
+// If either constant changes, the matching test fails first.
+
+/** HTML marker the renderer emits when fallback thresholds are active.
+ *  Mirror of `scorecard::threshold::FALLBACK_MARKER`. */
+const FALLBACK_MARKER = "<!-- fallback-thresholds:hardcoded -->";
+
+/** Italic preamble the renderer prepends to the body when fallback
+ *  thresholds are active. Mirror of
+ *  `scorecard::threshold::STARTER_PREAMBLE`. */
+const STARTER_PREAMBLE =
+  "_Using starter-wheels fallback thresholds. Tune them in [`quality.toml`](QUALITY.md#threshold-tuning)._";
+
+/** HTML comment pointing operators at the config path. Mirror of
+ *  `scorecard::threshold::PATH_HINT_COMMENT`. */
+const PATH_HINT_COMMENT =
+  "<!-- tune at .config/scorecard/quality.toml — see QUALITY.md#threshold-tuning -->";
+
 /** @type {Record<import("./types").Status, string>} */
 const STATUS_ICON = {
   Green: "🟢",
@@ -58,6 +84,13 @@ function renderFailureDetail(row) {
 
 /** Build the full sticky-comment body for a valid scorecard artifact.
  *
+ *  When `scorecard.fallback_thresholds_active` is `true`, the body is
+ *  framed with `STARTER_PREAMBLE` (visible italic line above the
+ *  banner) and trailed by `FALLBACK_MARKER` + `PATH_HINT_COMMENT`
+ *  (HTML comments after the row table) so operators can tell at a
+ *  glance the verdict came from starter-wheel defaults rather than
+ *  their tuned thresholds.
+ *
  *  @param {import("./types").Scorecard} scorecard
  *  @returns {string}
  */
@@ -69,8 +102,12 @@ function renderScorecardMarkdown(scorecard) {
     .join("");
   const headerLine = `_PR #${scorecard.pr.pr_number} • head ${scorecard.pr.head_sha.slice(0, 7)}_`;
 
-  return [
-    STICKY_MARKER,
+  const fallback = scorecard.fallback_thresholds_active === true;
+  const lines = [STICKY_MARKER];
+  if (fallback) {
+    lines.push(STARTER_PREAMBLE, "");
+  }
+  lines.push(
     banner,
     "",
     headerLine,
@@ -79,7 +116,11 @@ function renderScorecardMarkdown(scorecard) {
     "| --- | --- | --- |",
     rows,
     detailBlocks,
-  ].join("\n");
+  );
+  if (fallback) {
+    lines.push(FALLBACK_MARKER, PATH_HINT_COMMENT);
+  }
+  return lines.join("\n");
 }
 
 /** Build the fail-closed comment body when the artifact fails schema
@@ -223,6 +264,9 @@ async function postStickyComment({
 
 module.exports = {
   STICKY_MARKER,
+  FALLBACK_MARKER,
+  STARTER_PREAMBLE,
+  PATH_HINT_COMMENT,
   renderScorecardMarkdown,
   renderFailClosedMarkdown,
   postStickyComment,

--- a/.github/scripts/scorecard/types.d.ts
+++ b/.github/scripts/scorecard/types.d.ts
@@ -62,7 +62,9 @@ export interface Scorecard {
    */
   all_check_runs_url: string;
   /**
-   * `true` when the producer resolved row statuses using the hardcoded [`threshold::ThresholdConfig::fallback`] thresholds (no operator `quality.toml` was present or readable). The renderer keys off this flag to emit [`threshold::STARTER_PREAMBLE`] + [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`] so operators can tell at a glance that the verdict came from starter-wheel defaults rather than their tuned thresholds.
+   * `true` when the producer resolved row statuses using the hardcoded [`threshold::ThresholdConfig::fallback`] thresholds because the operator `quality.toml` was absent or empty. A present-but-malformed or unreadable `quality.toml` is a loud failure (non-zero exit, no artifact written), not a silent fallback — so this flag is `true` only for the deliberate "operator hasn't tuned thresholds yet" case.
+   *
+   * The renderer keys off this flag to emit [`threshold::STARTER_PREAMBLE`] + [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`] so operators can tell at a glance that the verdict came from starter-wheel defaults rather than their tuned thresholds.
    */
   fallback_thresholds_active: boolean;
   /**

--- a/.github/scripts/scorecard/types.d.ts
+++ b/.github/scripts/scorecard/types.d.ts
@@ -24,6 +24,10 @@ export type Row = {
    */
   anchor: string;
   /**
+   * Raw coverage delta in percentage points vs. the base branch. The constructor records this alongside the status that was minted from it; the renderer keeps using `delta_text` for display, but downstream tooling (and future trend dashboards) can read `delta_pp` without reparsing the formatted string.
+   */
+  delta_pp: number;
+  /**
    * Display string for the delta (e.g. `"+0.3 pp"` or `"-4.2 pp"`).
    */
   delta_text: string;
@@ -57,6 +61,10 @@ export interface Scorecard {
    * External link to the full Check Runs page on the head commit, so the comment can satisfy "every failing gate is one click away" even when more than three gates fail.
    */
   all_check_runs_url: string;
+  /**
+   * `true` when the producer resolved row statuses using the hardcoded [`threshold::ThresholdConfig::fallback`] thresholds (no operator `quality.toml` was present or readable). The renderer keys off this flag to emit [`threshold::STARTER_PREAMBLE`] + [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`] so operators can tell at a glance that the verdict came from starter-wheel defaults rather than their tuned thresholds.
+   */
+  fallback_thresholds_active: boolean;
   /**
    * Resolved status across all rows. The renderer's banner reads this directly; per the .feature spec the banner status is the worst status across all rows.
    */

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -860,14 +860,17 @@ jobs:
   scorecard-drift:
     # Cross-process complement to the in-process
     # `crates/scorecard/tests/schema_drift.rs` byte-identity test:
-    # regenerates the committed `.config/scorecard/schema.json` and the
-    # renderer's `.github/scripts/scorecard/types.d.ts` from source, then
-    # `git diff --exit-code` fails on any uncommitted drift. Catches direct
-    # edits to either file that the path-filtered `test-rust` job would
-    # otherwise skip. The trailing `tsc --noEmit` step locks the renderer
-    # JS's JSDoc annotations to the generated types — see ADR
-    # `decisions/mokumo/adr-scorecard-crate-shape.md` for the full
-    # three-layer enforcement story.
+    # regenerates the committed wire schema (`.config/scorecard/schema.json`),
+    # the operator schema (`.config/scorecard/quality.config.schema.json`),
+    # and the renderer's `.github/scripts/scorecard/types.d.ts` from source,
+    # then `git diff --exit-code` fails on any uncommitted drift. Catches
+    # direct edits to any of those files that the path-filtered `test-rust`
+    # job would otherwise skip. The renderer JSDoc `tsc --noEmit` locks the
+    # renderer JS to the generated types; the trailing ajv-cli step closes
+    # the loop on the operator config by validating the committed
+    # `quality.toml` (after `tomllib` projects it to JSON) against the
+    # operator schema. See ADR `decisions/mokumo/adr-scorecard-crate-shape.md`
+    # for the full three-layer enforcement story.
     needs: [changes]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -891,10 +894,12 @@ jobs:
           save-if: "false"
       - name: Install renderer dependencies
         run: pnpm install --frozen-lockfile --filter @mokumo/scorecard-renderer...
-      - name: Regenerate schema from Rust source
-        run: cargo run -p scorecard --bin emit-schema -- --out .config/scorecard/schema.json
+      - name: Regenerate wire + operator schemas from Rust source
+        run: cargo run -p scorecard --bin emit-schema
       - name: Assert .config/scorecard/schema.json is unchanged
         run: git diff --exit-code .config/scorecard/schema.json
+      - name: Assert .config/scorecard/quality.config.schema.json is unchanged
+        run: git diff --exit-code .config/scorecard/quality.config.schema.json
       - name: Regenerate renderer types from schema
         working-directory: .github/scripts/scorecard
         run: pnpm regen-types
@@ -903,6 +908,20 @@ jobs:
       - name: Renderer JSDoc type-check
         working-directory: .github/scripts/scorecard
         run: pnpm typecheck
+      - name: Convert committed quality.toml to JSON for ajv
+        run: |
+          python3 - <<'PY' > /tmp/quality.config.json
+          import sys, tomllib, json
+          with open('.config/scorecard/quality.toml', 'rb') as f:
+              data = tomllib.load(f)
+          json.dump(data, sys.stdout)
+          PY
+      - name: Validate quality.toml against operator schema (ajv-cli)
+        working-directory: .github/scripts/scorecard
+        run: |
+          pnpm dlx ajv-cli@5.0.0 validate \
+            -s ../../../.config/scorecard/quality.config.schema.json \
+            -d /tmp/quality.config.json
 
   verdict:
     if: always()

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -841,10 +841,17 @@ jobs:
             > tmp/pr-meta.json
           cat tmp/pr-meta.json
       - name: Run aggregate
+        # `--coverage-delta-pp 0.0` is a placeholder until the producer is
+        # wired to a real delta from `cargo-llvm-cov` against the base
+        # branch. With 0.0 the row resolves Green, which keeps the sticky
+        # comment readable while the upstream measurement plumbing is
+        # built. `--quality-toml` defaults to `.config/scorecard/quality.toml`
+        # so the configured-thresholds path is exercised on every PR.
         run: |
           mkdir -p tmp
           ./target/release/aggregate \
             --pr-meta tmp/pr-meta.json \
+            --coverage-delta-pp 0.0 \
             --out tmp/scorecard.json
           cat tmp/scorecard.json
       - name: Upload scorecard artifact

--- a/.github/workflows/v3-red-smoke.yml
+++ b/.github/workflows/v3-red-smoke.yml
@@ -62,11 +62,18 @@ jobs:
           "
 
       - name: Aggregate Red-branch synthetic
+        # `--quality-toml` points at a non-existent path on purpose: the
+        # smoke needs to demonstrate the fallback signals (italic
+        # preamble + HTML marker + path-hint comment) end-to-end, so the
+        # producer must take the absent-file branch and mark
+        # `fallback_thresholds_active = true`. Pointing at the committed
+        # `.config/scorecard/quality.toml` would suppress those signals
+        # because the configured-thresholds branch hides them.
         run: |
           cargo run -p scorecard --features cli --bin aggregate -- \
             --pr-meta /tmp/red-smoke-pr.json \
             --coverage-delta-pp -7.5 \
-            --quality-toml .config/scorecard/quality.toml \
+            --quality-toml /tmp/red-smoke-no-such-quality.toml \
             --out /tmp/red-smoke.json
 
       - name: Render markdown

--- a/.github/workflows/v3-red-smoke.yml
+++ b/.github/workflows/v3-red-smoke.yml
@@ -1,0 +1,81 @@
+# Smoke workflow for the V3 PR. Renders a synthetic Red-row scorecard
+# inline against the live PR metadata and posts the rendered markdown as
+# a one-shot comment on the PR. Provides reviewers with visual proof
+# that the Red branch of the producer + the fallback signals on the
+# renderer round-trip end-to-end before V3 merges. Triggered exactly
+# once per PR via the `v3-red-smoke` label.
+#
+# Lifecycle: this file lives only on the V3 PR branch. The final commit
+# of the V3 PR deletes it; future PRs exercise the Red path through the
+# unit tests in `crates/scorecard/src/threshold.rs::tests` and the
+# vitest snapshots in `.github/scripts/scorecard/__tests__/`.
+#
+# Security: PR-controlled values (`head.sha`, `base.sha`, `head.repo.fork`,
+# `pull_request.number`) are passed via `env:` rather than interpolated
+# directly into `run:` blocks so the templating happens once at job-step
+# boundary instead of at shell-expansion time.
+
+name: V3 Red-smoke
+
+on:
+  pull_request:
+    types: [opened, labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  red-smoke:
+    if: contains(github.event.pull_request.labels.*.name, 'v3-red-smoke')
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      PR_IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "mokumo-rust"
+          save-if: "false"
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Generate inline PR-meta fixture
+        run: |
+          python3 -c "
+          import json, os
+          json.dump({
+              'pr_number': int(os.environ['PR_NUMBER']),
+              'head_sha':  os.environ['PR_HEAD_SHA'],
+              'base_sha':  os.environ['PR_BASE_SHA'],
+              'is_fork':   os.environ['PR_IS_FORK'].lower() == 'true',
+          }, open('/tmp/red-smoke-pr.json', 'w'))
+          "
+
+      - name: Aggregate Red-branch synthetic
+        run: |
+          cargo run -p scorecard --features cli --bin aggregate -- \
+            --pr-meta /tmp/red-smoke-pr.json \
+            --coverage-delta-pp -7.5 \
+            --quality-toml .config/scorecard/quality.toml \
+            --out /tmp/red-smoke.json
+
+      - name: Render markdown
+        working-directory: .github/scripts/scorecard
+        run: |
+          pnpm install --frozen-lockfile
+          node bin/render-cli.js < /tmp/red-smoke.json > /tmp/red-comment.md
+
+      - name: Post smoke comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "$PR_NUMBER" --body-file /tmp/red-comment.md

--- a/.github/workflows/v3-red-smoke.yml
+++ b/.github/workflows/v3-red-smoke.yml
@@ -82,7 +82,24 @@ jobs:
           pnpm install --frozen-lockfile
           node bin/render-cli.js < /tmp/red-smoke.json > /tmp/red-comment.md
 
-      - name: Post smoke comment
+      - name: Post or update smoke comment
+        # Idempotent under relabel + workflow rerun: the marker-anchored
+        # body lets a second run find the previous smoke comment by id
+        # and patch it in place rather than stacking duplicates. The
+        # smoke marker is intentionally distinct from the sticky
+        # `<!-- ci-scorecard -->` marker so the two comments don't
+        # clobber each other on a PR that has both.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment "$PR_NUMBER" --body-file /tmp/red-comment.md
+          SMOKE_MARKER: "<!-- v3-red-smoke -->"
+        run: |
+          BODY=$(printf '%s\n\n' "$SMOKE_MARKER"; cat /tmp/red-comment.md)
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"$SMOKE_MARKER\")) | .id" \
+            | head -n1)
+          if [ -n "$EXISTING" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
+              -X PATCH -F body="$BODY"
+          else
+            printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Scorecard threshold engine — `quality.toml` operator surface for tunable per-row warn/fail thresholds; hardcoded fallback when absent.** When the operator config is missing, the producer marks the artifact as fallback and the renderer surfaces a starter-wheels note above the banner so reviewers can tell at a glance whether the verdict came from tuned thresholds or hardcoded defaults. A typo in `quality.toml` is a loud failure (non-zero exit, no artifact written) rather than a silent slide into fallback. See [`QUALITY.md#threshold-tuning`](QUALITY.md#threshold-tuning).
+
 - **Sticky scorecard V2 — drift gate + renderer types pipeline** (mokumo#767, quality): new `scorecard-drift` job in `.github/workflows/quality.yml` regenerates `.config/scorecard/schema.json` from the Rust producer and `.github/scripts/scorecard/types.d.ts` from the schema (via `json-schema-to-typescript`), then `git diff --exit-code` fails the PR on any uncommitted drift. A trailing `tsc --noEmit` step locks the renderer JS's `// @ts-check` + JSDoc `@param {import("./types").X}` annotations to the generated types, closing the remaining V1 drift windows: hand-edits to `schema.json`, hand-edits to `types.d.ts`, and JSDoc/types desync (the in-process `crates/scorecard/tests/schema_drift.rs` byte-identity test continues to catch Rust→schema drift). Local regen via new `tools/regen-types.sh`; documented in `crates/scorecard/README.md` § Renderer types. `json-schema-to-typescript@15.0.4` and `typescript@5.6.3` pinned exactly so `git diff` is stable across runners.
 
 - **Bundle backup with strict-atomic restore** (M00 PR A wave A2.2, kikan):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6492,10 +6492,13 @@ name = "scorecard"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "cucumber",
  "jsonschema",
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "tempfile",
+ "tokio",
  "toml 0.8.2",
  "trybuild",
  "walkdir",

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -47,7 +47,34 @@ Beyond pass/fail gates, we track metrics whose direction matters as much as the 
 - Module size (longest function; count of modules over 300 lines — convention, not currently enforced).
 - Architecture violations (must be zero).
 
-Shipping soon: a PR comment bot that surfaces these deltas inline so every change makes its effect on the codebase visible.
+## Threshold tuning
+
+The sticky scorecard's per-row verdicts (Green / Yellow / Red) are produced by comparing measured deltas against thresholds. Operators tune those thresholds in [`.config/scorecard/quality.toml`](.config/scorecard/quality.toml) — no Rust source edits required.
+
+Each row table in `quality.toml` declares a `warn_pp_delta` and a `fail_pp_delta`:
+
+- A delta worse than `warn_pp_delta` flips the row to Yellow.
+- A delta worse than `fail_pp_delta` flips it to Red.
+- Thresholds are inclusive on the worse side, so a delta exactly at the threshold trips the corresponding status.
+
+When `quality.toml` is absent or empty, the producer falls back to a hardcoded **starter-wheels** configuration: a sensible warn/fail pair that catches obvious regressions without the operator having to commit a config first. The sticky comment surfaces this state with a short italic note above the banner and an `<!-- fallback-thresholds:hardcoded -->` HTML marker after the row table — a reviewer can tell at a glance whether the verdict came from tuned thresholds or starter-wheels defaults.
+
+A typo in `quality.toml` is a **loud failure**: the producer aborts with a non-zero exit and no scorecard artifact is written, so an operator never silently slides into fallback because of an unparseable config. The drift-check job additionally pipes the committed `quality.toml` through `ajv-cli` against the schema in `.config/scorecard/quality.config.schema.json` to catch shape-level mistakes before they reach the producer.
+
+The committed `quality.toml`, the operator schema, and the wire schema all live under `.config/scorecard/` so an operator can see the entire surface in one directory listing. The schemas are generated from the Rust source — direct edits to either schema file fail CI on the next push.
+
+### What V3 covers vs defers
+
+V3 ships the threshold engine for the **coverage-delta** row variant only. Two follow-ups are intentionally deferred:
+
+- **Absolute-coverage row variant.** A second row that compares absolute coverage against an absolute floor (rather than the delta against the base branch). Lands in V4 and inherits the same `[rows.<name>]` table shape.
+- **Conditional gating between coverage-delta and absolute coverage.** When the absolute-coverage row variant lands, the warn/fail thresholds for `CoverageDelta` should apply only if absolute coverage passes its own threshold — a regression on a project that's already under its absolute floor should be reported as Red regardless of delta. This is tracked alongside V4 (see [mokumo#769](https://github.com/breezy-bays-labs/mokumo/issues/769)).
+
+The Red branch of the threshold resolver is unit-tested in `crates/scorecard/src/threshold.rs::tests` against the fallback config; the BDD scenarios in `crates/scorecard/tests/features/scorecard_display.feature` assert the producer side of the Yellow + fallback-marker contract, and vitest snapshots in `.github/scripts/scorecard/__tests__/` lock the renderer's byte output for `STARTER_PREAMBLE`, `FALLBACK_MARKER`, and `PATH_HINT_COMMENT`. A drift on either side fails CI before merge.
+
+### Vendored ajv refresh cadence
+
+The drift-check job validates `quality.toml` via a vendored ajv bundle at `.github/scripts/scorecard/ajv-bundle.js`. Per the scorecard ADR, the bundle is refreshed on a quarterly cadence (Q1/Q2/Q3/Q4 calendar review) — see [`tools/update-vendored-ajv.sh`](tools/update-vendored-ajv.sh) for the regenerator script.
 
 ## What's planned
 

--- a/crates/scorecard/Cargo.toml
+++ b/crates/scorecard/Cargo.toml
@@ -22,10 +22,19 @@ jsonschema = { workspace = true, optional = true }
 
 [dev-dependencies]
 trybuild = { workspace = true }
+cucumber = { workspace = true }
+tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = []
 cli = ["dep:toml", "dep:walkdir", "dep:clap", "dep:jsonschema"]
+# `bdd` gates the cucumber-rs integration test (tests/bdd.rs). Step-defs
+# under tests/bdd_world/ exercise the producer (aggregate.rs), which lives
+# behind `cli`; `bdd` therefore implies `cli` so a single
+#   cargo test -p scorecard --features bdd --test bdd
+# is enough to run the suite.
+bdd = ["cli"]
 
 # emit-schema needs only the lib's deps (serde + schemars + serde_json) — no
 # `required-features` so the drift-check workflow can run it without `--features cli`.
@@ -39,3 +48,12 @@ name = "emit-schema"
 [[bin]]
 name = "aggregate"
 required-features = ["cli"]
+
+# Cucumber-rs test target (V5). `harness = false` because cucumber owns
+# its own `#[tokio::main]`; `required-features = ["bdd"]` keeps the
+# default `cargo test -p scorecard` lightweight (lib + trybuild +
+# schema_drift) without pulling cucumber/tempfile into every run.
+[[test]]
+name = "bdd"
+harness = false
+required-features = ["bdd"]

--- a/crates/scorecard/README.md
+++ b/crates/scorecard/README.md
@@ -60,16 +60,35 @@ If the .stderr drift is more than whitespace, audit it before accepting —
 the tests are supposed to catch typestate violations, not "compiler
 reformatted its output".
 
-## Regenerating the committed schema
+## Regenerating the committed schemas
 
 ```bash
-cargo run -p scorecard --bin emit-schema -- --out .config/scorecard/schema.json
+cargo run -p scorecard --bin emit-schema
 ```
 
+The default `--target both` writes two artifacts in one pass:
+
+- `.config/scorecard/schema.json` — wire schema validated by the renderer.
+- `.config/scorecard/quality.config.schema.json` — operator schema for
+  `.config/scorecard/quality.toml`, validated by ajv on the
+  `scorecard-drift` CI gate.
+
+Single-target runs are also supported:
+
+```bash
+cargo run -p scorecard --bin emit-schema -- --target scorecard --out path/to/schema.json
+cargo run -p scorecard --bin emit-schema -- --target quality --out path/to/quality.config.schema.json
+```
+
+`--target scorecard` matches pre-V3 invocations: an explicit `--out`
+without `--target` defaults to `scorecard` for backwards compatibility.
+
 `emit-schema` uses only the lib's deps (no `--features cli` needed) so a
-drift-check workflow can regenerate the schema cheaply. The integration
+drift-check workflow can regenerate both schemas cheaply. The integration
 test `tests/schema_drift.rs` enforces byte-identity between the binary's
-output and the committed file on every `cargo test` run.
+wire-schema output and the committed file on every `cargo test` run; the
+`scorecard-drift` CI job extends that gate to the operator schema and
+adds an ajv-cli validation pass over the committed `quality.toml`.
 
 ## Vendored ajv bundle
 
@@ -136,31 +155,35 @@ render time).
 tools/regen-types.sh
 ```
 
-The script runs the two regenerations in sequence:
+The script runs three regenerations in sequence:
 
-1. `cargo run -p scorecard --bin emit-schema -- --out .config/scorecard/schema.json`
-   — emits the canonical schema from `schemars` derive output.
+1. `cargo run -p scorecard --bin emit-schema` — emits the wire schema
+   `.config/scorecard/schema.json` and the operator schema
+   `.config/scorecard/quality.config.schema.json` from `schemars` derive
+   output. Default `--target both` writes both with one invocation.
 2. `pnpm dlx json-schema-to-typescript@<pinned> .config/scorecard/schema.json --output .github/scripts/scorecard/types.d.ts`
-   — projects the schema into TypeScript declarations.
+   — projects the wire schema into TypeScript declarations.
 
 Run before pushing if you've touched the Rust scorecard types or
-edited the schema by hand. The renderer-side `pnpm typecheck`
+edited a schema by hand. The renderer-side `pnpm typecheck`
 (invokes `tsc --noEmit` over `render.js` + `validate.js`) catches
 JSDoc/types desync.
 
 ### CI gate
 
 The `scorecard-drift` job in `.github/workflows/quality.yml` runs the
-same two regenerations on every PR and fails on any uncommitted diff.
-Together with the in-process `tests/schema_drift.rs` byte-identity test
-this closes four desync paths:
+same regenerations on every PR and fails on any uncommitted diff.
+Together with the in-process `tests/schema_drift.rs` byte-identity
+test this closes the desync paths surfaced during V1/V2/V3:
 
 | Desync | Gate that catches it |
 |---|---|
-| Rust source change without schema regen | `schema_drift.rs` (in-process) |
+| Rust source change without wire-schema regen | `schema_drift.rs` (in-process) |
 | Hand-edit `.config/scorecard/schema.json` | `scorecard-drift` (also `schema_drift.rs`) |
-| Hand-edit `.github/scripts/scorecard/types.d.ts` | `scorecard-drift` only |
+| Hand-edit `.config/scorecard/quality.config.schema.json` | `scorecard-drift` (operator-schema diff step) |
+| Hand-edit `.github/scripts/scorecard/types.d.ts` | `scorecard-drift` (types.d.ts diff step) |
 | JSDoc disagrees with `types.d.ts` | `scorecard-drift` `tsc --noEmit` step |
+| `quality.toml` violates the operator schema | `scorecard-drift` ajv-cli step |
 
 The `json-schema-to-typescript` and `typescript` versions are pinned
 exactly in `.github/scripts/scorecard/package.json` so `git diff

--- a/crates/scorecard/moon.yml
+++ b/crates/scorecard/moon.yml
@@ -1,2 +1,21 @@
 language: rust
 stack: backend
+
+tasks:
+  test-bdd:
+    # Cucumber-rs BDD harness for the threshold-engine scenarios in
+    # tests/features/scorecard_display.feature. Step-defs live in
+    # tests/bdd_world/ so bdd-lint discovers them via its rust glob
+    # (crates/*/tests/bdd_world/**/*.rs). The `bdd` feature implies
+    # `cli` so the in-process producer (aggregate.rs) is reachable.
+    command: cargo test --package scorecard --features bdd --test bdd
+    inputs:
+      - src/**/*
+      - tests/bdd.rs
+      - tests/bdd_world/**/*.rs
+      - tests/features/**/*.feature
+      - Cargo.toml
+      - /Cargo.toml
+      - /Cargo.lock
+    options:
+      runFromWorkspaceRoot: true

--- a/crates/scorecard/src/aggregate.rs
+++ b/crates/scorecard/src/aggregate.rs
@@ -19,6 +19,7 @@ use clap::Parser;
 use jsonschema::JSONSchema;
 use serde_json::Value;
 
+use crate::threshold::{self, CoverageThresholds, ThresholdConfig};
 use crate::{PrMeta, Row, RowCommon, Scorecard, Status};
 
 /// Embedded copy of `.config/scorecard/schema.json`. Embedding (vs. a
@@ -28,18 +29,21 @@ use crate::{PrMeta, Row, RowCommon, Scorecard, Status};
 /// guarantees byte-identity between this string and the committed file.
 const COMMITTED_SCHEMA: &str = include_str!("../../../.config/scorecard/schema.json");
 
-const STUB_DELTA_TEXT: &str = "stub — V1 walking skeleton";
-
 #[derive(Debug, Parser)]
-#[command(
-    name = "aggregate",
-    about = "Walking-skeleton scorecard.json producer (V1)."
-)]
+#[command(name = "aggregate", about = "Sticky scorecard.json producer.")]
 struct Cli {
     /// Path to a JSON file matching the `PrMeta` shape:
     ///   { "pr_number": u64, "head_sha": "...", "base_sha": "...", "is_fork": bool }
     #[arg(long)]
     pr_meta: PathBuf,
+
+    /// Coverage delta vs. base, in percentage points (signed). The
+    /// producer feeds this through [`threshold::resolve_coverage_delta`]
+    /// against the resolved [`ThresholdConfig`] to mint the row's
+    /// status. `allow_hyphen_values` so a regression like `-2.5` is
+    /// not mis-parsed as a short flag.
+    #[arg(long, allow_hyphen_values = true)]
+    coverage_delta_pp: f64,
 
     /// Path to write the resulting scorecard.json artifact. Parent
     /// directories are created if missing.
@@ -47,18 +51,72 @@ struct Cli {
     out: PathBuf,
 }
 
-/// Build the V1 stub scorecard from the parsed PR metadata.
+/// Format a coverage delta (in percentage points) for display.
 ///
-/// Pure function: no I/O, no panics, deterministic.
-pub fn build_stub_scorecard(pr: PrMeta) -> Scorecard {
-    let row = Row::coverage_delta_green(
-        RowCommon {
-            id: "coverage".into(),
-            label: "Coverage".into(),
-            anchor: "coverage".into(),
-        },
-        STUB_DELTA_TEXT.to_string(),
-    );
+/// Positive deltas carry an explicit `+` sign so a glance at the row
+/// makes the direction unambiguous; negative deltas pick up the sign
+/// from `f64`'s default formatting. One decimal place keeps the row
+/// table from drifting columns when the delta crosses thresholds.
+pub fn format_delta_text(delta_pp: f64) -> String {
+    if delta_pp >= 0.0 {
+        format!("+{delta_pp:.1} pp")
+    } else {
+        format!("{delta_pp:.1} pp")
+    }
+}
+
+/// Render the inline failure detail for a Red coverage row.
+///
+/// The renderer wraps this string as the body of a markdown blockquote
+/// keyed by the row label, so the prose reads as a complete sentence
+/// after the label-colon prefix the renderer adds. Both numbers are
+/// reported in absolute magnitude (operators read "6.0 pp drop" more
+/// fluently than "-6.0 pp delta").
+fn coverage_failure_detail(delta_pp: f64, fail_pp_delta: f64) -> String {
+    format!(
+        "Coverage dropped {drop:.1} pp — below the {fail:.1} pp fail threshold.",
+        drop = -delta_pp,
+        fail = -fail_pp_delta,
+    )
+}
+
+/// Build a coverage row from the raw delta + the thresholds in effect.
+fn build_coverage_row(delta_pp: f64, thresholds: &CoverageThresholds) -> Row {
+    let common = RowCommon {
+        id: "coverage".into(),
+        label: "Coverage".into(),
+        anchor: "coverage".into(),
+    };
+    let delta_text = format_delta_text(delta_pp);
+    match threshold::resolve_coverage_delta(delta_pp, thresholds) {
+        Status::Green => Row::coverage_delta_green(common, delta_pp, delta_text),
+        Status::Yellow => Row::coverage_delta_yellow(common, delta_pp, delta_text),
+        Status::Red => Row::coverage_delta_red(
+            common,
+            delta_pp,
+            delta_text,
+            coverage_failure_detail(delta_pp, thresholds.fail_pp_delta),
+        ),
+    }
+}
+
+/// Build the scorecard artifact from parsed PR metadata, raw
+/// measurements, and the resolved threshold config.
+///
+/// Pure function: no I/O, no panics, deterministic. `fallback_active`
+/// records whether the supplied [`ThresholdConfig`] came from
+/// [`ThresholdConfig::fallback`] (no operator config) so the renderer
+/// can surface the starter-wheels affordance.
+pub fn build_scorecard(
+    pr: PrMeta,
+    coverage_delta_pp: f64,
+    thresholds: &ThresholdConfig,
+    fallback_active: bool,
+) -> Scorecard {
+    let row = build_coverage_row(coverage_delta_pp, &thresholds.rows.coverage);
+    let overall_status = match &row {
+        Row::CoverageDelta { status, .. } => *status,
+    };
 
     let head_sha = pr.head_sha.clone();
     let all_check_runs_url =
@@ -67,10 +125,11 @@ pub fn build_stub_scorecard(pr: PrMeta) -> Scorecard {
     Scorecard {
         schema_version: 0,
         pr,
-        overall_status: Status::Green,
+        overall_status,
         rows: vec![row],
         top_failures: Vec::new(),
         all_check_runs_url,
+        fallback_thresholds_active: fallback_active,
     }
 }
 
@@ -213,7 +272,8 @@ pub fn run(args: impl IntoIterator<Item = OsString>) -> ExitCode {
         }
     };
 
-    let scorecard = build_stub_scorecard(pr);
+    let thresholds = ThresholdConfig::fallback();
+    let scorecard = build_scorecard(pr, cli.coverage_delta_pp, &thresholds, true);
     if let Err(msg) = write_scorecard(&scorecard, &cli.out) {
         eprintln!("{msg}");
         return ExitCode::from(1);
@@ -234,48 +294,115 @@ mod tests {
         }
     }
 
+    fn fallback() -> ThresholdConfig {
+        ThresholdConfig::fallback()
+    }
+
+    fn build_with_delta(delta_pp: f64) -> Scorecard {
+        build_scorecard(pr_meta(), delta_pp, &fallback(), true)
+    }
+
     #[test]
-    fn build_stub_scorecard_returns_one_green_row() {
-        let sc = build_stub_scorecard(pr_meta());
+    fn build_scorecard_yields_one_coverage_row() {
+        let sc = build_with_delta(0.3);
         assert_eq!(sc.rows.len(), 1);
-        // `Row` is non_exhaustive externally but exhaustive in-crate (one variant
-        // today), so a destructuring `let` is sufficient — `let-else` is irrefutable
-        // here. When V4 adds variants, switch back to `let-else { panic! }`.
         let Row::CoverageDelta {
-            status, delta_text, ..
+            status,
+            delta_pp,
+            delta_text,
+            ..
         } = &sc.rows[0];
         assert_eq!(*status, Status::Green);
-        assert_eq!(delta_text, STUB_DELTA_TEXT);
+        assert_eq!(*delta_pp, 0.3);
+        assert_eq!(delta_text, "+0.3 pp");
     }
 
     #[test]
-    fn build_stub_scorecard_overall_status_is_green() {
-        let sc = build_stub_scorecard(pr_meta());
-        assert_eq!(sc.overall_status, Status::Green);
+    fn build_scorecard_overall_status_mirrors_row_status() {
+        // Single-row scorecard: overall = row. When V4+ adds rows the
+        // overall computation becomes worst-of-rows; a regression here
+        // surfaces immediately.
+        assert_eq!(build_with_delta(0.5).overall_status, Status::Green);
+        assert_eq!(build_with_delta(-2.5).overall_status, Status::Yellow);
+        assert_eq!(build_with_delta(-6.0).overall_status, Status::Red);
     }
 
     #[test]
-    fn build_stub_scorecard_url_uses_https_and_head_sha() {
-        let sc = build_stub_scorecard(pr_meta());
+    fn build_scorecard_marks_fallback_thresholds_active() {
+        // V1 always passes `fallback_active = true` to `build_scorecard`,
+        // so the produced artifact carries the flag the renderer keys
+        // off.
+        let sc = build_with_delta(-2.5);
+        assert!(sc.fallback_thresholds_active);
+    }
+
+    #[test]
+    fn build_scorecard_records_fallback_active_false_when_passed() {
+        // Independent test of the parameter — V2 will pass `false`
+        // when an operator config is loaded; V1's plumbing must
+        // honour the argument.
+        let sc = build_scorecard(pr_meta(), -2.5, &fallback(), false);
+        assert!(!sc.fallback_thresholds_active);
+    }
+
+    #[test]
+    fn build_scorecard_red_row_carries_failure_detail() {
+        let sc = build_with_delta(-7.5);
+        let Row::CoverageDelta {
+            status,
+            failure_detail_md,
+            ..
+        } = &sc.rows[0];
+        assert_eq!(*status, Status::Red);
+        let detail = failure_detail_md
+            .as_ref()
+            .expect("Red rows carry failure_detail_md by Layer-1 invariant");
+        assert!(detail.contains("7.5 pp"), "got: {detail}");
+        assert!(detail.contains("5.0 pp"), "got: {detail}");
+    }
+
+    #[test]
+    fn build_scorecard_url_uses_https_and_head_sha() {
+        let sc = build_with_delta(0.0);
         assert!(sc.all_check_runs_url.starts_with("https://"));
         assert!(sc.all_check_runs_url.contains("abc123"));
     }
 
     #[test]
-    fn stub_scorecard_validates_against_committed_schema() {
-        let sc = build_stub_scorecard(pr_meta());
-        let value = serde_json::to_value(&sc).expect("serialize");
-        validate_against_schema(&value)
-            .expect("stub scorecard must validate against committed schema");
+    fn build_scorecard_validates_against_committed_schema_for_all_three_branches() {
+        // Layer 2 defense: every branch the producer can mint must
+        // pass schema validation. Catches a future field addition that
+        // forgets to add `failure_detail_md` to a Red branch.
+        for delta in [0.5_f64, -2.5, -7.5] {
+            let sc = build_with_delta(delta);
+            let value = serde_json::to_value(&sc).expect("serialize");
+            validate_against_schema(&value)
+                .unwrap_or_else(|e| panic!("schema validation failed for delta={delta}: {e}"));
+        }
     }
 
     #[test]
     fn validate_rejects_invalid_overall_status() {
-        let sc = build_stub_scorecard(pr_meta());
+        let sc = build_with_delta(0.0);
         let mut value = serde_json::to_value(&sc).expect("serialize");
         value["overall_status"] = serde_json::json!("Magenta");
         let err = validate_against_schema(&value).unwrap_err();
         assert!(err.contains("schema validation"), "got: {err}");
+    }
+
+    #[test]
+    fn format_delta_text_signs_match_direction() {
+        assert_eq!(format_delta_text(0.3), "+0.3 pp");
+        assert_eq!(format_delta_text(-2.5), "-2.5 pp");
+        assert_eq!(format_delta_text(0.0), "+0.0 pp");
+        assert_eq!(format_delta_text(-7.5), "-7.5 pp");
+    }
+
+    #[test]
+    fn coverage_failure_detail_reports_absolute_drop_and_threshold() {
+        let detail = coverage_failure_detail(-6.2, -5.0);
+        assert!(detail.contains("6.2 pp"), "got: {detail}");
+        assert!(detail.contains("5.0 pp"), "got: {detail}");
     }
 
     /// Minimal scoped tempdir without pulling in a dev-dep — mirrors the
@@ -305,7 +432,7 @@ mod tests {
     fn write_scorecard_creates_parent_dirs_and_emits_json() {
         let dir = tempdir();
         let out = dir.path.join("nested/out/scorecard.json");
-        let sc = build_stub_scorecard(pr_meta());
+        let sc = build_with_delta(0.0);
         write_scorecard(&sc, &out).expect("write");
         let content = fs::read_to_string(&out).expect("read back");
         let parsed: Value = serde_json::from_str(&content).expect("valid json");
@@ -319,7 +446,7 @@ mod tests {
         // .tmp.<pid> sidecars on the happy path.
         let dir = tempdir();
         let out = dir.path.join("scorecard.json");
-        let sc = build_stub_scorecard(pr_meta());
+        let sc = build_with_delta(0.0);
         write_scorecard(&sc, &out).expect("write");
         let entries: Vec<_> = fs::read_dir(&dir.path)
             .expect("read tmpdir")
@@ -354,7 +481,7 @@ mod tests {
 
     #[test]
     fn render_scorecard_appends_trailing_newline() {
-        let sc = build_stub_scorecard(pr_meta());
+        let sc = build_with_delta(0.0);
         let s = render_scorecard(&sc).expect("render");
         assert!(s.ends_with('\n'));
     }
@@ -407,12 +534,41 @@ mod tests {
         let cli = parse_cli([
             OsString::from("--pr-meta"),
             OsString::from("/tmp/pr.json"),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("-2.5"),
             OsString::from("--out"),
             OsString::from("/tmp/out.json"),
         ])
         .expect("parsed");
         assert_eq!(cli.pr_meta, PathBuf::from("/tmp/pr.json"));
+        assert_eq!(cli.coverage_delta_pp, -2.5);
         assert_eq!(cli.out, PathBuf::from("/tmp/out.json"));
+    }
+
+    #[test]
+    fn parse_cli_rejects_missing_coverage_delta_flag() {
+        let code = parse_cli([
+            OsString::from("--pr-meta"),
+            OsString::from("/tmp/pr.json"),
+            OsString::from("--out"),
+            OsString::from("/tmp/out.json"),
+        ])
+        .unwrap_err();
+        assert_eq!(code, ExitCode::from(2));
+    }
+
+    #[test]
+    fn parse_cli_rejects_non_numeric_coverage_delta() {
+        let code = parse_cli([
+            OsString::from("--pr-meta"),
+            OsString::from("/tmp/pr.json"),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("not-a-number"),
+            OsString::from("--out"),
+            OsString::from("/tmp/out.json"),
+        ])
+        .unwrap_err();
+        assert_eq!(code, ExitCode::from(2));
     }
 
     #[test]
@@ -422,6 +578,8 @@ mod tests {
         let code = run([
             OsString::from("--pr-meta"),
             OsString::from("/tmp/does-not-exist-aggregate.json"),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("0.0"),
             OsString::from("--out"),
             OsString::from(out.as_os_str()),
         ]);
@@ -453,10 +611,18 @@ mod tests {
         let code = run([
             OsString::from("--pr-meta"),
             OsString::from(pr_path.as_os_str()),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("-2.5"),
             OsString::from("--out"),
             OsString::from(out_path.as_os_str()),
         ]);
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(out_path.exists());
+        // Round-trip sanity: the artifact carries the new fields and
+        // resolves to the expected status for the supplied delta.
+        let content = fs::read_to_string(&out_path).expect("read back");
+        let parsed: Value = serde_json::from_str(&content).expect("valid json");
+        assert_eq!(parsed["overall_status"], "Yellow");
+        assert_eq!(parsed["fallback_thresholds_active"], true);
     }
 }

--- a/crates/scorecard/src/aggregate.rs
+++ b/crates/scorecard/src/aggregate.rs
@@ -110,8 +110,10 @@ pub fn format_delta_text(delta_pp: f64) -> String {
 /// reported in absolute magnitude (operators read "6.0 pp drop" more
 /// fluently than "-6.0 pp delta").
 fn coverage_failure_detail(delta_pp: f64, fail_pp_delta: f64) -> String {
+    // "at or below" matches the resolver's inclusive boundary: a delta
+    // exactly at `fail_pp_delta` lands Red.
     format!(
-        "Coverage dropped {drop:.1} pp — below the {fail:.1} pp fail threshold.",
+        "Coverage dropped {drop:.1} pp — at or below the {fail:.1} pp fail threshold.",
         drop = -delta_pp,
         fail = -fail_pp_delta,
     )
@@ -238,6 +240,12 @@ pub fn resolve_threshold_source(path: &Path) -> Result<ThresholdSource, String> 
                     path.display()
                 )
             })?;
+            validate_threshold_config(&config).map_err(|e| {
+                format!(
+                    "aggregate: --quality-toml {} has invalid thresholds: {e}",
+                    path.display()
+                )
+            })?;
             Ok(ThresholdSource::Configured {
                 config,
                 path: path.to_path_buf(),
@@ -251,6 +259,46 @@ pub fn resolve_threshold_source(path: &Path) -> Result<ThresholdSource, String> 
             path.display()
         )),
     }
+}
+
+/// Reject operator-tuned threshold configs that would silently break
+/// the verdict surface even though they parse cleanly.
+///
+/// TOML's `nan` / `inf` / `-inf` literals all deserialize into `f64`
+/// without complaint, but a non-finite warn or fail threshold makes
+/// the comparison rules in [`threshold::resolve_coverage_delta`]
+/// nonsensical: NaN comparisons are always false (everything resolves
+/// Green) and infinity collapses one of the two transitions.
+///
+/// Likewise, `fail_pp_delta` greater than `warn_pp_delta` is logically
+/// inverted: the resolver's `delta_pp <= warn_pp_delta` first arm
+/// would catch the Red case before the Yellow check ran, making
+/// Yellow unreachable and turning ordinary regressions Red.
+///
+/// Both cases produce a verdict the operator did not ask for. Loud-fail
+/// at config-load time keeps the producer honest.
+fn validate_threshold_config(config: &ThresholdConfig) -> Result<(), String> {
+    let coverage = &config.rows.coverage;
+    if !coverage.warn_pp_delta.is_finite() {
+        return Err(format!(
+            "rows.coverage.warn_pp_delta must be finite, got {}",
+            coverage.warn_pp_delta
+        ));
+    }
+    if !coverage.fail_pp_delta.is_finite() {
+        return Err(format!(
+            "rows.coverage.fail_pp_delta must be finite, got {}",
+            coverage.fail_pp_delta
+        ));
+    }
+    if coverage.fail_pp_delta > coverage.warn_pp_delta {
+        return Err(format!(
+            "rows.coverage.fail_pp_delta ({}) must be <= warn_pp_delta ({}); \
+             with fail above warn, Yellow is unreachable and ordinary regressions land Red",
+            coverage.fail_pp_delta, coverage.warn_pp_delta
+        ));
+    }
+    Ok(())
 }
 
 /// Read + parse `--pr-meta`. Returns a clear error message on missing
@@ -536,6 +584,10 @@ mod tests {
         let detail = coverage_failure_detail(-6.2, -5.0);
         assert!(detail.contains("6.2 pp"), "got: {detail}");
         assert!(detail.contains("5.0 pp"), "got: {detail}");
+        // The wording must match the resolver's inclusive boundary —
+        // a delta exactly at `fail_pp_delta` lands Red, so the detail
+        // says "at or below" rather than "below".
+        assert!(detail.contains("at or below"), "got: {detail}");
     }
 
     // ── --quality-toml resolution ──────────────────────────────────
@@ -593,6 +645,66 @@ mod tests {
         let cfg = source.config();
         assert_eq!(cfg.rows.coverage.warn_pp_delta, -0.5);
         assert_eq!(cfg.rows.coverage.fail_pp_delta, -3.0);
+    }
+
+    #[test]
+    fn resolve_threshold_source_rejects_inverted_thresholds() {
+        // fail above warn would make Yellow unreachable; loud-fail.
+        let dir = tempdir();
+        let path = dir.path.join("inverted.toml");
+        fs::write(
+            &path,
+            "[rows.coverage]\nwarn_pp_delta = -5.0\nfail_pp_delta = -1.0\n",
+        )
+        .expect("write");
+        let err = resolve_threshold_source(&path).unwrap_err();
+        assert!(err.contains("inverted.toml"), "got: {err}");
+        assert!(err.contains("Yellow is unreachable"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_threshold_source_rejects_non_finite_warn() {
+        let dir = tempdir();
+        let path = dir.path.join("nan.toml");
+        fs::write(
+            &path,
+            "[rows.coverage]\nwarn_pp_delta = nan\nfail_pp_delta = -5.0\n",
+        )
+        .expect("write");
+        let err = resolve_threshold_source(&path).unwrap_err();
+        assert!(err.contains("warn_pp_delta must be finite"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_threshold_source_rejects_non_finite_fail() {
+        let dir = tempdir();
+        let path = dir.path.join("inf.toml");
+        fs::write(
+            &path,
+            "[rows.coverage]\nwarn_pp_delta = -1.0\nfail_pp_delta = -inf\n",
+        )
+        .expect("write");
+        let err = resolve_threshold_source(&path).unwrap_err();
+        assert!(err.contains("fail_pp_delta must be finite"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_threshold_source_accepts_equal_warn_and_fail() {
+        // `fail == warn` is allowed: the resolver's `delta_pp <= warn`
+        // arm fires first, so a delta exactly at the threshold lands
+        // Yellow, never Red. That's a degenerate but legal config —
+        // it collapses Yellow into a single tripwire point and skips
+        // straight to Red below it. Operators may want this for tight
+        // gates; reject only the strict-inversion case.
+        let dir = tempdir();
+        let path = dir.path.join("equal.toml");
+        fs::write(
+            &path,
+            "[rows.coverage]\nwarn_pp_delta = -2.0\nfail_pp_delta = -2.0\n",
+        )
+        .expect("write");
+        let source = resolve_threshold_source(&path).expect("equal thresholds are legal");
+        assert!(!source.fallback_active());
     }
 
     #[test]

--- a/crates/scorecard/src/aggregate.rs
+++ b/crates/scorecard/src/aggregate.rs
@@ -42,7 +42,13 @@ struct Cli {
     /// against the resolved [`ThresholdConfig`] to mint the row's
     /// status. `allow_hyphen_values` so a regression like `-2.5` is
     /// not mis-parsed as a short flag.
-    #[arg(long, allow_hyphen_values = true)]
+    ///
+    /// Rejected at parse time: `NaN`, `inf`, `-inf`. `f64::from_str`
+    /// accepts those literals, but a non-finite delta has no defensible
+    /// position in the warn/fail ordering and would silently resolve
+    /// Green under the default comparison rules. Loud-fail at the CLI
+    /// boundary keeps the verdict honest.
+    #[arg(long, allow_hyphen_values = true, value_parser = parse_finite_f64)]
     coverage_delta_pp: f64,
 
     /// Path to the operator-tuned `quality.toml`. When the file is
@@ -59,6 +65,27 @@ struct Cli {
     /// directories are created if missing.
     #[arg(long)]
     out: PathBuf,
+}
+
+/// `clap` value-parser that accepts an `f64` and rejects non-finite
+/// values (`NaN`, `+inf`, `-inf`).
+///
+/// `f64::from_str` itself accepts those literals, so a producer
+/// invocation like `--coverage-delta-pp NaN` would otherwise satisfy
+/// clap's default parser and silently resolve Green under the
+/// `delta_pp <= warn_pp_delta` comparison. Rejecting at the boundary
+/// converts an invalid input into a non-zero exit with a clear message
+/// instead of a silent verdict.
+fn parse_finite_f64(raw: &str) -> Result<f64, String> {
+    let parsed: f64 = raw
+        .parse()
+        .map_err(|e| format!("not a valid floating-point number: {e}"))?;
+    if !parsed.is_finite() {
+        return Err(format!(
+            "must be a finite number (NaN and infinity are not allowed), got {raw}",
+        ));
+    }
+    Ok(parsed)
 }
 
 /// Format a coverage delta (in percentage points) for display.
@@ -185,17 +212,25 @@ impl ThresholdSource {
 /// Resolve the [`ThresholdConfig`] for a producer run from the
 /// `--quality-toml` path.
 ///
-/// Three outcomes:
-/// - File present, parses → [`ThresholdSource::Configured`].
-/// - File absent (any [`io::ErrorKind::NotFound`] from `fs::read`) →
-///   [`ThresholdSource::Fallback`]. Operators who never write a
-///   `quality.toml` and just want the starter-wheel verdict get a
-///   green CI run, not an error.
+/// Four outcomes:
+/// - File present, non-empty, parses → [`ThresholdSource::Configured`].
+/// - File absent (any [`std::io::ErrorKind::NotFound`] from
+///   `fs::read`) → [`ThresholdSource::Fallback`]. Operators who never
+///   write a `quality.toml` and just want the starter-wheel verdict
+///   get a green CI run, not an error.
+/// - File present but empty (zero bytes, or only whitespace) →
+///   [`ThresholdSource::Fallback`]. The schema rejects an empty file
+///   because `[rows.coverage]` is required; treating empty as absent
+///   keeps the operator-facing contract aligned with the rendered
+///   surface ("absent or empty falls back to hardcoded thresholds").
 /// - File present but unreadable, invalid UTF-8, or unparseable as TOML
 ///   → `Err(...)` with a message naming the path and the underlying
 ///   cause. Fail-loud so a typo never silently degrades to fallback.
 pub fn resolve_threshold_source(path: &Path) -> Result<ThresholdSource, String> {
     match fs::read_to_string(path) {
+        Ok(text) if text.trim().is_empty() => Ok(ThresholdSource::Fallback {
+            path: path.to_path_buf(),
+        }),
         Ok(text) => {
             let config = threshold::parse_quality_toml(&text).map_err(|e| {
                 format!(
@@ -415,9 +450,10 @@ mod tests {
 
     #[test]
     fn build_scorecard_overall_status_mirrors_row_status() {
-        // Single-row scorecard: overall = row. When V4+ adds rows the
-        // overall computation becomes worst-of-rows; a regression here
-        // surfaces immediately.
+        // Single-row scorecard: `overall_status` mirrors the row's
+        // status. When other row variants land their `build_*_row`
+        // helpers the overall computation grows into worst-of-rows; a
+        // regression on the single-row contract surfaces immediately.
         assert_eq!(build_with_delta(0.5).overall_status, Status::Green);
         assert_eq!(build_with_delta(-2.5).overall_status, Status::Yellow);
         assert_eq!(build_with_delta(-6.0).overall_status, Status::Red);
@@ -425,18 +461,19 @@ mod tests {
 
     #[test]
     fn build_scorecard_marks_fallback_thresholds_active() {
-        // V1 always passes `fallback_active = true` to `build_scorecard`,
-        // so the produced artifact carries the flag the renderer keys
-        // off.
+        // The `fallback_active` argument round-trips into the produced
+        // artifact's `fallback_thresholds_active` field — that's the
+        // flag the renderer keys off when it decides whether to surface
+        // the starter-wheels preamble + HTML markers.
         let sc = build_with_delta(-2.5);
         assert!(sc.fallback_thresholds_active);
     }
 
     #[test]
     fn build_scorecard_records_fallback_active_false_when_passed() {
-        // Independent test of the parameter — V2 will pass `false`
-        // when an operator config is loaded; V1's plumbing must
-        // honour the argument.
+        // Independent test of the parameter — `false` flows through
+        // the same path so a contributor cannot accidentally hardwire
+        // the field to `true` and pass the previous test by coincidence.
         let sc = build_scorecard(pr_meta(), -2.5, &fallback(), false);
         assert!(!sc.fallback_thresholds_active);
     }
@@ -515,6 +552,34 @@ mod tests {
     }
 
     #[test]
+    fn resolve_threshold_source_returns_fallback_for_empty_file() {
+        // Operator surface contract: "absent or empty falls back to
+        // hardcoded thresholds". Without this branch, `parse_quality_toml`
+        // rejects empty input because `[rows.coverage]` is required, and
+        // an operator who creates the file but hasn't filled it in yet
+        // gets a loud parse failure instead of the starter-wheels verdict.
+        let dir = tempdir();
+        let path = dir.path.join("empty.toml");
+        fs::write(&path, "").expect("write empty");
+        let source = resolve_threshold_source(&path).expect("empty file is fallback");
+        assert!(source.fallback_active());
+        let cfg = source.config();
+        assert_eq!(cfg.rows.coverage.warn_pp_delta, -1.0);
+        assert_eq!(cfg.rows.coverage.fail_pp_delta, -5.0);
+    }
+
+    #[test]
+    fn resolve_threshold_source_returns_fallback_for_whitespace_only_file() {
+        // Same contract as above — a file with only blank lines /
+        // comments-without-tables / spaces is operationally empty.
+        let dir = tempdir();
+        let path = dir.path.join("whitespace.toml");
+        fs::write(&path, "\n   \n\t\n").expect("write whitespace");
+        let source = resolve_threshold_source(&path).expect("whitespace file is fallback");
+        assert!(source.fallback_active());
+    }
+
+    #[test]
     fn resolve_threshold_source_parses_well_formed_toml() {
         let dir = tempdir();
         let path = dir.path.join("quality.toml");
@@ -556,7 +621,9 @@ mod tests {
 
     #[test]
     fn configured_thresholds_flip_status_at_smaller_drop() {
-        // Round-trip the V2 acceptance: tightened warn flips Green→Yellow.
+        // Tightened-warn round trip: with `warn_pp_delta = -0.5`, a
+        // drop of -0.8 lands Yellow even though it would land Green
+        // under the fallback's -1.0 warn threshold.
         let dir = tempdir();
         let path = dir.path.join("tight.toml");
         fs::write(
@@ -572,7 +639,9 @@ mod tests {
 
     #[test]
     fn fallback_path_yields_yellow_at_two_point_five_drop() {
-        // Round-trip the V2 acceptance for the absent-file case.
+        // Absent-file round trip: a drop of -2.5 against the fallback
+        // thresholds (warn = -1.0, fail = -5.0) lands Yellow and flags
+        // the artifact as fallback-active.
         let dir = tempdir();
         let missing = dir.path.join("absent.toml");
         let source = resolve_threshold_source(&missing).expect("fallback");
@@ -826,6 +895,37 @@ mod tests {
             OsString::from("/tmp/pr.json"),
             OsString::from("--coverage-delta-pp"),
             OsString::from("not-a-number"),
+            OsString::from("--out"),
+            OsString::from("/tmp/out.json"),
+        ])
+        .unwrap_err();
+        assert_eq!(code, ExitCode::from(2));
+    }
+
+    #[test]
+    fn parse_finite_f64_accepts_finite_inputs() {
+        assert_eq!(parse_finite_f64("0.0").unwrap(), 0.0);
+        assert_eq!(parse_finite_f64("-2.5").unwrap(), -2.5);
+        assert_eq!(parse_finite_f64("12345.6789").unwrap(), 12345.6789);
+    }
+
+    #[test]
+    fn parse_finite_f64_rejects_non_finite_inputs() {
+        for bad in ["NaN", "nan", "inf", "+inf", "-inf", "Infinity"] {
+            match parse_finite_f64(bad) {
+                Ok(v) => panic!("expected error for {bad}, got {v}"),
+                Err(err) => assert!(err.contains("finite"), "for {bad}: {err}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_cli_rejects_nan_coverage_delta() {
+        let code = parse_cli([
+            OsString::from("--pr-meta"),
+            OsString::from("/tmp/pr.json"),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("NaN"),
             OsString::from("--out"),
             OsString::from("/tmp/out.json"),
         ])

--- a/crates/scorecard/src/aggregate.rs
+++ b/crates/scorecard/src/aggregate.rs
@@ -45,6 +45,16 @@ struct Cli {
     #[arg(long, allow_hyphen_values = true)]
     coverage_delta_pp: f64,
 
+    /// Path to the operator-tuned `quality.toml`. When the file is
+    /// absent the producer falls back to the hardcoded
+    /// [`ThresholdConfig::fallback`] thresholds and marks
+    /// `fallback_thresholds_active = true` on the artifact. When the
+    /// file is present but cannot be parsed, the producer fails with
+    /// a non-zero exit so an operator typo never silently slides into
+    /// fallback mode and produces a different verdict than intended.
+    #[arg(long, default_value = ".config/scorecard/quality.toml")]
+    quality_toml: PathBuf,
+
     /// Path to write the resulting scorecard.json artifact. Parent
     /// directories are created if missing.
     #[arg(long)]
@@ -130,6 +140,81 @@ pub fn build_scorecard(
         top_failures: Vec::new(),
         all_check_runs_url,
         fallback_thresholds_active: fallback_active,
+    }
+}
+
+/// Outcome of resolving operator thresholds from a `--quality-toml` path.
+///
+/// The pair `(config, fallback_active)` flows directly into
+/// [`build_scorecard`]; the renderer keys off `fallback_active` to
+/// surface the starter-wheels affordance. Surfacing the source as a
+/// distinct enum (rather than a bare bool) makes intent legible at the
+/// call site and keeps the fallback semantics consistent across
+/// callers (CLI today, BDD step-defs in a later slice).
+#[derive(Debug)]
+pub enum ThresholdSource {
+    /// The operator config at `path` was read and parsed successfully.
+    Configured {
+        config: ThresholdConfig,
+        path: PathBuf,
+    },
+    /// The operator config at `path` was not present on disk; the
+    /// producer fell back to [`ThresholdConfig::fallback`].
+    Fallback { path: PathBuf },
+}
+
+impl ThresholdSource {
+    /// Borrow the resolved [`ThresholdConfig`]. Configured sources
+    /// return their parsed config; fallback sources mint
+    /// [`ThresholdConfig::fallback`] on demand.
+    pub fn config(&self) -> ThresholdConfig {
+        match self {
+            ThresholdSource::Configured { config, .. } => config.clone(),
+            ThresholdSource::Fallback { .. } => ThresholdConfig::fallback(),
+        }
+    }
+
+    /// `true` when the producer is using the hardcoded fallback
+    /// thresholds rather than an operator-tuned config. Flows into the
+    /// `fallback_thresholds_active` artifact field.
+    pub fn fallback_active(&self) -> bool {
+        matches!(self, ThresholdSource::Fallback { .. })
+    }
+}
+
+/// Resolve the [`ThresholdConfig`] for a producer run from the
+/// `--quality-toml` path.
+///
+/// Three outcomes:
+/// - File present, parses → [`ThresholdSource::Configured`].
+/// - File absent (any [`io::ErrorKind::NotFound`] from `fs::read`) →
+///   [`ThresholdSource::Fallback`]. Operators who never write a
+///   `quality.toml` and just want the starter-wheel verdict get a
+///   green CI run, not an error.
+/// - File present but unreadable, invalid UTF-8, or unparseable as TOML
+///   → `Err(...)` with a message naming the path and the underlying
+///   cause. Fail-loud so a typo never silently degrades to fallback.
+pub fn resolve_threshold_source(path: &Path) -> Result<ThresholdSource, String> {
+    match fs::read_to_string(path) {
+        Ok(text) => {
+            let config = threshold::parse_quality_toml(&text).map_err(|e| {
+                format!(
+                    "aggregate: --quality-toml {} failed to parse: {e}",
+                    path.display()
+                )
+            })?;
+            Ok(ThresholdSource::Configured {
+                config,
+                path: path.to_path_buf(),
+            })
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(ThresholdSource::Fallback {
+            path: path.to_path_buf(),
+        }),
+        Err(e) => Err(format!(
+            "aggregate: --quality-toml {} could not be read: {e}",
+            path.display()
+        )),
     }
 }
 
@@ -272,8 +357,19 @@ pub fn run(args: impl IntoIterator<Item = OsString>) -> ExitCode {
         }
     };
 
-    let thresholds = ThresholdConfig::fallback();
-    let scorecard = build_scorecard(pr, cli.coverage_delta_pp, &thresholds, true);
+    let source = match resolve_threshold_source(&cli.quality_toml) {
+        Ok(s) => s,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(1);
+        }
+    };
+    let scorecard = build_scorecard(
+        pr,
+        cli.coverage_delta_pp,
+        &source.config(),
+        source.fallback_active(),
+    );
     if let Err(msg) = write_scorecard(&scorecard, &cli.out) {
         eprintln!("{msg}");
         return ExitCode::from(1);
@@ -403,6 +499,172 @@ mod tests {
         let detail = coverage_failure_detail(-6.2, -5.0);
         assert!(detail.contains("6.2 pp"), "got: {detail}");
         assert!(detail.contains("5.0 pp"), "got: {detail}");
+    }
+
+    // ── --quality-toml resolution ──────────────────────────────────
+
+    #[test]
+    fn resolve_threshold_source_returns_fallback_for_missing_file() {
+        let dir = tempdir();
+        let missing = dir.path.join("does-not-exist.toml");
+        let source = resolve_threshold_source(&missing).expect("absent file is fallback");
+        assert!(source.fallback_active());
+        let cfg = source.config();
+        assert_eq!(cfg.rows.coverage.warn_pp_delta, -1.0);
+        assert_eq!(cfg.rows.coverage.fail_pp_delta, -5.0);
+    }
+
+    #[test]
+    fn resolve_threshold_source_parses_well_formed_toml() {
+        let dir = tempdir();
+        let path = dir.path.join("quality.toml");
+        fs::write(
+            &path,
+            "[rows.coverage]\nwarn_pp_delta = -0.5\nfail_pp_delta = -3.0\n",
+        )
+        .expect("write");
+        let source = resolve_threshold_source(&path).expect("parse");
+        assert!(!source.fallback_active());
+        let cfg = source.config();
+        assert_eq!(cfg.rows.coverage.warn_pp_delta, -0.5);
+        assert_eq!(cfg.rows.coverage.fail_pp_delta, -3.0);
+    }
+
+    #[test]
+    fn resolve_threshold_source_errors_on_malformed_toml() {
+        let dir = tempdir();
+        let path = dir.path.join("bad.toml");
+        fs::write(&path, "[rows.coverage]\nwarn_pp_delta = \"tight\"\n").expect("write");
+        let err = resolve_threshold_source(&path).unwrap_err();
+        assert!(err.contains("bad.toml"), "got: {err}");
+        assert!(err.contains("--quality-toml"), "got: {err}");
+        assert!(err.contains("failed to parse"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_threshold_source_errors_on_unknown_field() {
+        let dir = tempdir();
+        let path = dir.path.join("typo.toml");
+        fs::write(
+            &path,
+            "[rows.coverage]\nwarn_pp_delta = -1.0\nfail_pp_delta = -5.0\nfail_pp_dleta = -7.0\n",
+        )
+        .expect("write");
+        let err = resolve_threshold_source(&path).unwrap_err();
+        assert!(err.contains("unknown field"), "got: {err}");
+    }
+
+    #[test]
+    fn configured_thresholds_flip_status_at_smaller_drop() {
+        // Round-trip the V2 acceptance: tightened warn flips Green→Yellow.
+        let dir = tempdir();
+        let path = dir.path.join("tight.toml");
+        fs::write(
+            &path,
+            "[rows.coverage]\nwarn_pp_delta = -0.5\nfail_pp_delta = -5.0\n",
+        )
+        .expect("write");
+        let source = resolve_threshold_source(&path).expect("parse");
+        let sc = build_scorecard(pr_meta(), -0.8, &source.config(), source.fallback_active());
+        assert_eq!(sc.overall_status, Status::Yellow);
+        assert!(!sc.fallback_thresholds_active);
+    }
+
+    #[test]
+    fn fallback_path_yields_yellow_at_two_point_five_drop() {
+        // Round-trip the V2 acceptance for the absent-file case.
+        let dir = tempdir();
+        let missing = dir.path.join("absent.toml");
+        let source = resolve_threshold_source(&missing).expect("fallback");
+        let sc = build_scorecard(pr_meta(), -2.5, &source.config(), source.fallback_active());
+        assert_eq!(sc.overall_status, Status::Yellow);
+        assert!(sc.fallback_thresholds_active);
+    }
+
+    #[test]
+    fn run_emits_configured_path_artifact_when_quality_toml_present() {
+        let dir = tempdir();
+        let pr_path = dir.path.join("pr.json");
+        let toml_path = dir.path.join("quality.toml");
+        let out_path = dir.path.join("scorecard.json");
+        fs::write(
+            &pr_path,
+            r#"{"pr_number":1,"head_sha":"x","base_sha":"y","is_fork":false}"#,
+        )
+        .unwrap();
+        fs::write(
+            &toml_path,
+            "[rows.coverage]\nwarn_pp_delta = -0.5\nfail_pp_delta = -5.0\n",
+        )
+        .unwrap();
+        let code = run([
+            OsString::from("--pr-meta"),
+            OsString::from(pr_path.as_os_str()),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("-0.8"),
+            OsString::from("--quality-toml"),
+            OsString::from(toml_path.as_os_str()),
+            OsString::from("--out"),
+            OsString::from(out_path.as_os_str()),
+        ]);
+        assert_eq!(code, ExitCode::SUCCESS);
+        let parsed: Value = serde_json::from_str(&fs::read_to_string(&out_path).unwrap()).unwrap();
+        assert_eq!(parsed["overall_status"], "Yellow");
+        assert_eq!(parsed["fallback_thresholds_active"], false);
+    }
+
+    #[test]
+    fn run_emits_fallback_artifact_when_quality_toml_absent() {
+        let dir = tempdir();
+        let pr_path = dir.path.join("pr.json");
+        let out_path = dir.path.join("scorecard.json");
+        let missing_toml = dir.path.join("absent.toml");
+        fs::write(
+            &pr_path,
+            r#"{"pr_number":1,"head_sha":"x","base_sha":"y","is_fork":false}"#,
+        )
+        .unwrap();
+        let code = run([
+            OsString::from("--pr-meta"),
+            OsString::from(pr_path.as_os_str()),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("-2.5"),
+            OsString::from("--quality-toml"),
+            OsString::from(missing_toml.as_os_str()),
+            OsString::from("--out"),
+            OsString::from(out_path.as_os_str()),
+        ]);
+        assert_eq!(code, ExitCode::SUCCESS);
+        let parsed: Value = serde_json::from_str(&fs::read_to_string(&out_path).unwrap()).unwrap();
+        assert_eq!(parsed["overall_status"], "Yellow");
+        assert_eq!(parsed["fallback_thresholds_active"], true);
+    }
+
+    #[test]
+    fn run_returns_one_for_malformed_quality_toml() {
+        let dir = tempdir();
+        let pr_path = dir.path.join("pr.json");
+        let toml_path = dir.path.join("bad.toml");
+        let out_path = dir.path.join("scorecard.json");
+        fs::write(
+            &pr_path,
+            r#"{"pr_number":1,"head_sha":"x","base_sha":"y","is_fork":false}"#,
+        )
+        .unwrap();
+        fs::write(&toml_path, "[rows.coverage]\nwarn_pp_delta = \"tight\"\n").unwrap();
+        let code = run([
+            OsString::from("--pr-meta"),
+            OsString::from(pr_path.as_os_str()),
+            OsString::from("--coverage-delta-pp"),
+            OsString::from("-2.5"),
+            OsString::from("--quality-toml"),
+            OsString::from(toml_path.as_os_str()),
+            OsString::from("--out"),
+            OsString::from(out_path.as_os_str()),
+        ]);
+        assert_eq!(code, ExitCode::from(1));
+        // Malformed TOML must NOT silently produce a fallback artifact.
+        assert!(!out_path.exists());
     }
 
     /// Minimal scoped tempdir without pulling in a dev-dep — mirrors the
@@ -600,9 +862,13 @@ mod tests {
 
     #[test]
     fn run_writes_valid_scorecard_for_good_pr_meta() {
+        // Routes through the fallback path explicitly via --quality-toml
+        // so the test stays cwd-independent regardless of whether the
+        // default `.config/scorecard/quality.toml` exists in the repo.
         let dir = tempdir();
         let pr_path = dir.path.join("pr.json");
         let out_path = dir.path.join("scorecard.json");
+        let absent_toml = dir.path.join("absent.toml");
         fs::write(
             &pr_path,
             r#"{"pr_number":1,"head_sha":"x","base_sha":"y","is_fork":false}"#,
@@ -613,6 +879,8 @@ mod tests {
             OsString::from(pr_path.as_os_str()),
             OsString::from("--coverage-delta-pp"),
             OsString::from("-2.5"),
+            OsString::from("--quality-toml"),
+            OsString::from(absent_toml.as_os_str()),
             OsString::from("--out"),
             OsString::from(out_path.as_os_str()),
         ]);

--- a/crates/scorecard/src/bin/aggregate.rs
+++ b/crates/scorecard/src/bin/aggregate.rs
@@ -1,4 +1,4 @@
-//! `aggregate` — V1 walking-skeleton producer for `scorecard.json`.
+//! `aggregate` — producer binary that emits `scorecard.json`.
 //!
 //! All testable logic (CLI parsing, scorecard construction, schema
 //! validation, file writing) lives in [`scorecard::aggregate`]. This

--- a/crates/scorecard/src/emit_schema.rs
+++ b/crates/scorecard/src/emit_schema.rs
@@ -115,12 +115,11 @@ where
     }
     let target = match (target, &out) {
         (Some(t), _) => t,
-        // Back-compat for the V1/V2 CI invocation `emit-schema --out
-        // .config/scorecard/schema.json`: `--out` alone implies
-        // `--target scorecard`. Pre-V3 callers don't know the operator
-        // schema exists; treating `--out` as a single-target hint keeps
-        // their semantics intact while letting V3+ callers drop the
-        // flag for the default `both` behavior.
+        // `--out <PATH>` without `--target` is the single-artifact
+        // shorthand: it implies `--target scorecard` because the wire
+        // schema is the only artifact that ships at a caller-chosen
+        // path. The default (no flags) writes both artifacts at their
+        // canonical paths under `.config/scorecard/`.
         (None, Some(_)) => Target::Scorecard,
         (None, None) => Target::Both,
     };
@@ -286,10 +285,10 @@ mod tests {
 
     #[test]
     fn parse_args_back_compat_out_alone_implies_target_scorecard() {
-        // Locks the V1/V2 invocation `emit-schema --out
-        // .config/scorecard/schema.json` against silent regression: `--out`
-        // alone (without `--target`) keeps writing the wire schema only,
-        // matching pre-V3 behavior.
+        // Single-artifact shorthand: `--out <PATH>` without `--target`
+        // writes the wire schema only. Operators and CI invocations
+        // that name a single output path get the wire schema there;
+        // dropping `--target` is the default-both behavior.
         let parsed = parse_args(argv(["--out", "/tmp/schema.json"])).unwrap();
         assert_eq!(
             parsed,
@@ -370,6 +369,32 @@ mod tests {
         assert!(s.contains("ThresholdConfig"));
         assert!(s.contains("warn_pp_delta"));
         assert!(s.contains("fail_pp_delta"));
+    }
+
+    /// Regression test for the operator-schema typo-rejection contract.
+    ///
+    /// `serde(deny_unknown_fields)` on every `ThresholdConfig` /
+    /// `RowsConfig` / `CoverageThresholds` struct emits
+    /// `additionalProperties: false` at three nesting levels (root,
+    /// `definitions/RowsConfig`, `definitions/CoverageThresholds`). The
+    /// scorecard-drift CI step validates the committed `quality.toml`
+    /// against this schema via `ajv-cli`; if a future schema-postprocess
+    /// or schemars upgrade ever weakens any of those three levels, an
+    /// operator typo at that level would silently slide past the gate
+    /// and into the producer (which would then loud-fail at parse, but
+    /// after CI has already gone green).
+    ///
+    /// Pinning the count at three keeps the gate's reach honest.
+    #[test]
+    fn operator_schema_rejects_unknown_fields_at_every_nesting_level() {
+        let s = render_quality_config_schema_string();
+        let occurrences = s.matches("\"additionalProperties\": false").count();
+        assert_eq!(
+            occurrences, 3,
+            "operator schema must declare additionalProperties:false at the root, \
+             RowsConfig, and CoverageThresholds — got {occurrences}. \
+             Schema body:\n{s}",
+        );
     }
 
     #[test]

--- a/crates/scorecard/src/emit_schema.rs
+++ b/crates/scorecard/src/emit_schema.rs
@@ -4,6 +4,20 @@
 //!
 //! The bin target is a one-line wrapper around [`main_entry`]; everything
 //! testable lives here.
+//!
+//! The binary emits two JSON Schema artifacts:
+//!
+//! - `.config/scorecard/schema.json` — wire schema for the `scorecard.json`
+//!   artifact the producer writes for the renderer.
+//! - `.config/scorecard/quality.config.schema.json` — operator-facing schema
+//!   for `.config/scorecard/quality.toml`, validated against by ajv on the
+//!   `scorecard-drift` CI gate.
+//!
+//! The two artifacts have different audiences (the renderer vs. operators)
+//! but share the deps-zero invariant: both are derived from `schemars`
+//! `JsonSchema` derives in the lib, so `cargo build -p scorecard
+//! --no-default-features --bin emit-schema` keeps `toml` out of the
+//! transitive dep tree.
 
 #![doc(hidden)]
 
@@ -16,18 +30,51 @@ use std::process::ExitCode;
 use schemars::schema_for;
 
 use crate::Scorecard;
-use crate::schema_postprocess::{inject_red_requires_detail, tighten_url_fields};
+use crate::schema_postprocess::{
+    inject_red_requires_detail, strip_nonstandard_number_formats, tighten_url_fields,
+};
+use crate::threshold::ThresholdConfig;
 
-/// Outcome of [`parse_args`] — either a path to write the schema to, or a
-/// `--help` request.
+/// Default committed path for the wire schema (the artifact the
+/// renderer validates against).
+pub const SCORECARD_SCHEMA_DEFAULT_PATH: &str = ".config/scorecard/schema.json";
+
+/// Default committed path for the operator-facing schema (the artifact
+/// ajv validates the committed `quality.toml` against).
+pub const QUALITY_CONFIG_SCHEMA_DEFAULT_PATH: &str = ".config/scorecard/quality.config.schema.json";
+
+/// Which schema the binary should write on this invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+    /// Wire schema for `scorecard.json`.
+    Scorecard,
+    /// Operator schema for `quality.toml`.
+    Quality,
+    /// Both wire and operator schemas, each to its default committed path.
+    Both,
+}
+
+/// Outcome of [`parse_args`] — either an emit request (target + optional
+/// override path), or a `--help` request.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ParsedArgs {
-    Run(PathBuf),
+    /// Emit `target` to `out` if provided, otherwise to that target's
+    /// default path. `out` is rejected when `target == Target::Both` —
+    /// two outputs to one path is ill-defined.
+    Run {
+        target: Target,
+        out: Option<PathBuf>,
+    },
     Help,
 }
 
-/// Parse `--out <path>` / `--help` / `-h` from an iterator of raw OS args
-/// (the caller passes `std::env::args_os().skip(1)`).
+/// Parse `--target`, `--out`, `--help`, `-h` from an iterator of raw OS
+/// args (the caller passes `std::env::args_os().skip(1)`).
+///
+/// `--target` is optional and defaults to [`Target::Both`] when absent.
+/// `--out PATH` overrides the default committed path; it is rejected
+/// when paired with `--target both` because two artifacts cannot share
+/// one output path.
 ///
 /// Returned errors carry the exact human-readable message printed by the
 /// binary, so callers can `eprintln!` them directly.
@@ -37,6 +84,7 @@ where
 {
     let mut iter = args.into_iter();
     let mut out: Option<PathBuf> = None;
+    let mut target: Option<Target> = None;
     while let Some(arg) = iter.next() {
         match arg.to_string_lossy().as_ref() {
             "--out" => {
@@ -45,17 +93,50 @@ where
                     .ok_or_else(|| "--out requires a path".to_string())?;
                 out = Some(PathBuf::from(v));
             }
+            "--target" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| "--target requires a value".to_string())?;
+                let parsed = match v.to_string_lossy().as_ref() {
+                    "scorecard" => Target::Scorecard,
+                    "quality" => Target::Quality,
+                    "both" => Target::Both,
+                    other => {
+                        return Err(format!(
+                            "--target must be one of `scorecard`, `quality`, `both`; got `{other}`"
+                        ));
+                    }
+                };
+                target = Some(parsed);
+            }
             "--help" | "-h" => return Ok(ParsedArgs::Help),
             other => return Err(format!("unknown argument: {other}")),
         }
     }
-    out.map(ParsedArgs::Run)
-        .ok_or_else(|| "--out is required".to_string())
+    let target = match (target, &out) {
+        (Some(t), _) => t,
+        // Back-compat for the V1/V2 CI invocation `emit-schema --out
+        // .config/scorecard/schema.json`: `--out` alone implies
+        // `--target scorecard`. Pre-V3 callers don't know the operator
+        // schema exists; treating `--out` as a single-target hint keeps
+        // their semantics intact while letting V3+ callers drop the
+        // flag for the default `both` behavior.
+        (None, Some(_)) => Target::Scorecard,
+        (None, None) => Target::Both,
+    };
+    if matches!(target, Target::Both) && out.is_some() {
+        return Err(
+            "--out cannot be combined with --target both (two artifacts cannot share one path)"
+                .to_string(),
+        );
+    }
+    Ok(ParsedArgs::Run { target, out })
 }
 
-/// Render the post-processed JSON Schema for [`Scorecard`] as a UTF-8
-/// string. Trailing newline included so the committed file is POSIX-clean
-/// (most editors and `git diff` flag missing trailing newlines).
+/// Render the post-processed wire JSON Schema for [`Scorecard`] as a
+/// UTF-8 string. Trailing newline included so the committed file is
+/// POSIX-clean (most editors and `git diff` flag missing trailing
+/// newlines).
 pub fn render_schema_string() -> String {
     let mut schema = schema_for!(Scorecard);
     inject_red_requires_detail(&mut schema);
@@ -66,20 +147,82 @@ pub fn render_schema_string() -> String {
     content
 }
 
-/// Write the rendered schema to `out_path`, creating parent directories
-/// as needed. Surfaces I/O errors to the caller for reporting.
+/// Render the operator-facing JSON Schema for [`ThresholdConfig`] as a
+/// UTF-8 string.
+///
+/// Uses `schemars` derives (deps-zero) plus a single post-process step
+/// that strips schemars' non-standard numeric `format` annotations
+/// (`"double"`, `"uint32"`, ...). ajv-cli treats those as unrecognized
+/// schema formats and degrades validation; removing them keeps ajv
+/// strict and the shape drift it surfaces sharp. `deny_unknown_fields`
+/// from the type derives carries through to the JSON Schema's
+/// `additionalProperties: false`, which is sufficient for ajv to
+/// reject typos and drift in the committed `quality.toml` (after
+/// `tomllib` projects it to JSON on the drift gate).
+pub fn render_quality_config_schema_string() -> String {
+    let mut schema = schema_for!(ThresholdConfig);
+    strip_nonstandard_number_formats(&mut schema);
+    let mut content = serde_json::to_string_pretty(&schema)
+        .expect("quality config schema serializes to a JSON string");
+    content.push('\n');
+    content
+}
+
+/// Write the wire schema (post-processed [`Scorecard`] derive) to
+/// `out_path`, creating parent directories as needed.
 pub fn write_schema(out_path: &Path) -> io::Result<()> {
+    write_string_to_path(out_path, &render_schema_string())
+}
+
+/// Write the operator-facing schema (plain [`ThresholdConfig`] derive)
+/// to `out_path`, creating parent directories as needed.
+pub fn write_quality_config_schema(out_path: &Path) -> io::Result<()> {
+    write_string_to_path(out_path, &render_quality_config_schema_string())
+}
+
+fn write_string_to_path(out_path: &Path, content: &str) -> io::Result<()> {
     if let Some(parent) = out_path.parent()
         && !parent.as_os_str().is_empty()
     {
         fs::create_dir_all(parent)?;
     }
-    fs::write(out_path, render_schema_string())
+    fs::write(out_path, content)
 }
 
+fn emit(target: Target, out: Option<PathBuf>) -> Result<(), String> {
+    match target {
+        Target::Scorecard => {
+            let path = out.unwrap_or_else(|| PathBuf::from(SCORECARD_SCHEMA_DEFAULT_PATH));
+            write_schema(&path).map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+        }
+        Target::Quality => {
+            let path = out.unwrap_or_else(|| PathBuf::from(QUALITY_CONFIG_SCHEMA_DEFAULT_PATH));
+            write_quality_config_schema(&path)
+                .map_err(|e| format!("failed to write {}: {e}", path.display()))?;
+        }
+        Target::Both => {
+            // `--out` is rejected for `--target both` at parse time, so
+            // `out` is `None` here; both schemas land at their defaults.
+            let scorecard_path = PathBuf::from(SCORECARD_SCHEMA_DEFAULT_PATH);
+            let quality_path = PathBuf::from(QUALITY_CONFIG_SCHEMA_DEFAULT_PATH);
+            write_schema(&scorecard_path)
+                .map_err(|e| format!("failed to write {}: {e}", scorecard_path.display()))?;
+            write_quality_config_schema(&quality_path)
+                .map_err(|e| format!("failed to write {}: {e}", quality_path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+const USAGE: &str = "usage: emit-schema [--target scorecard|quality|both] [--out <path>]\n\
+     \n\
+     Default `--target both` writes the wire schema to .config/scorecard/schema.json\n\
+     and the operator schema to .config/scorecard/quality.config.schema.json.\n\
+     `--out` overrides the destination for single-target invocations only.";
+
 /// Entry-point used by `bin/emit-schema.rs`. Drives [`parse_args`] and
-/// [`write_schema`], handling output framing and exit codes:
-/// - `0` (`SUCCESS`) — schema written, or `--help` printed.
+/// the per-target writers, handling output framing and exit codes:
+/// - `0` (`SUCCESS`) — schema(s) written, or `--help` printed.
 /// - `1` — I/O failure during write.
 /// - `2` — invalid arguments.
 pub fn main_entry<I>(args: I) -> ExitCode
@@ -87,22 +230,22 @@ where
     I: IntoIterator<Item = OsString>,
 {
     match parse_args(args) {
-        Ok(ParsedArgs::Run(out_path)) => match write_schema(&out_path) {
+        Ok(ParsedArgs::Run { target, out }) => match emit(target, out) {
             Ok(()) => ExitCode::SUCCESS,
-            Err(e) => {
-                eprintln!("emit-schema: failed to write {}: {e}", out_path.display());
+            Err(msg) => {
+                eprintln!("emit-schema: {msg}");
                 ExitCode::from(1)
             }
         },
         Ok(ParsedArgs::Help) => {
             // GNU-style: --help is a success invocation, output goes to
             // stdout so users can pipe `emit-schema --help | less`.
-            println!("usage: emit-schema --out <path>");
+            println!("{USAGE}");
             ExitCode::SUCCESS
         }
         Err(msg) => {
             eprintln!("emit-schema: {msg}");
-            eprintln!("usage: emit-schema --out <path>");
+            eprintln!("{USAGE}");
             ExitCode::from(2)
         }
     }
@@ -117,9 +260,69 @@ mod tests {
     }
 
     #[test]
-    fn parse_args_returns_run_for_valid_out() {
+    fn parse_args_returns_run_with_explicit_target_and_out() {
+        let parsed =
+            parse_args(argv(["--target", "scorecard", "--out", "/tmp/schema.json"])).unwrap();
+        assert_eq!(
+            parsed,
+            ParsedArgs::Run {
+                target: Target::Scorecard,
+                out: Some(PathBuf::from("/tmp/schema.json")),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_defaults_to_target_both_when_no_flags() {
+        let parsed = parse_args(Vec::<OsString>::new()).unwrap();
+        assert_eq!(
+            parsed,
+            ParsedArgs::Run {
+                target: Target::Both,
+                out: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_back_compat_out_alone_implies_target_scorecard() {
+        // Locks the V1/V2 invocation `emit-schema --out
+        // .config/scorecard/schema.json` against silent regression: `--out`
+        // alone (without `--target`) keeps writing the wire schema only,
+        // matching pre-V3 behavior.
         let parsed = parse_args(argv(["--out", "/tmp/schema.json"])).unwrap();
-        assert_eq!(parsed, ParsedArgs::Run(PathBuf::from("/tmp/schema.json")));
+        assert_eq!(
+            parsed,
+            ParsedArgs::Run {
+                target: Target::Scorecard,
+                out: Some(PathBuf::from("/tmp/schema.json")),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_accepts_target_quality() {
+        let parsed = parse_args(argv(["--target", "quality"])).unwrap();
+        assert_eq!(
+            parsed,
+            ParsedArgs::Run {
+                target: Target::Quality,
+                out: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_args_rejects_target_both_with_out() {
+        let err = parse_args(argv(["--target", "both", "--out", "/tmp/x.json"])).unwrap_err();
+        assert!(err.contains("--out cannot be combined"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_target_value() {
+        let err = parse_args(argv(["--target", "bogus"])).unwrap_err();
+        assert!(err.contains("--target must be one of"), "got: {err}");
+        assert!(err.contains("bogus"), "got: {err}");
     }
 
     #[test]
@@ -141,6 +344,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_args_rejects_missing_target_value() {
+        let err = parse_args(argv(["--target"])).unwrap_err();
+        assert!(err.contains("--target requires a value"), "got: {err}");
+    }
+
+    #[test]
     fn parse_args_rejects_unknown_arg() {
         let err = parse_args(argv(["--bogus"])).unwrap_err();
         assert!(err.contains("unknown argument"), "got: {err}");
@@ -148,16 +357,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_args_requires_out() {
-        let err = parse_args(Vec::<OsString>::new()).unwrap_err();
-        assert!(err.contains("--out is required"), "got: {err}");
-    }
-
-    #[test]
     fn render_schema_string_ends_with_newline() {
         let s = render_schema_string();
         assert!(s.ends_with('\n'));
         assert!(s.contains("\"Scorecard\""));
+    }
+
+    #[test]
+    fn render_quality_config_schema_string_describes_threshold_config() {
+        let s = render_quality_config_schema_string();
+        assert!(s.ends_with('\n'));
+        assert!(s.contains("ThresholdConfig"));
+        assert!(s.contains("warn_pp_delta"));
+        assert!(s.contains("fail_pp_delta"));
     }
 
     #[test]
@@ -170,12 +382,49 @@ mod tests {
     }
 
     #[test]
-    fn main_entry_run_writes_file_and_returns_success() {
+    fn write_quality_config_schema_creates_parent_dirs() {
+        let dir = tempdir();
+        let target = dir.path.join("nested/dir/quality.config.schema.json");
+        write_quality_config_schema(&target).expect("write_quality_config_schema");
+        let on_disk = fs::read_to_string(&target).expect("read back");
+        assert_eq!(on_disk, render_quality_config_schema_string());
+    }
+
+    #[test]
+    fn main_entry_target_scorecard_with_explicit_out_writes_only_scorecard() {
         let dir = tempdir();
         let target = dir.path.join("schema.json");
-        let code = main_entry(argv(["--out", target.to_str().unwrap()]));
+        let code = main_entry(argv([
+            "--target",
+            "scorecard",
+            "--out",
+            target.to_str().unwrap(),
+        ]));
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(target.exists());
+        let body = fs::read_to_string(&target).unwrap();
+        assert!(body.contains("\"Scorecard\""));
+        // No quality schema landed under the test dir.
+        assert!(
+            !dir.path.join("quality.config.schema.json").exists(),
+            "quality schema should not be emitted with --target scorecard"
+        );
+    }
+
+    #[test]
+    fn main_entry_target_quality_with_explicit_out_writes_only_quality() {
+        let dir = tempdir();
+        let target = dir.path.join("quality.config.schema.json");
+        let code = main_entry(argv([
+            "--target",
+            "quality",
+            "--out",
+            target.to_str().unwrap(),
+        ]));
+        assert_eq!(code, ExitCode::SUCCESS);
+        let body = fs::read_to_string(&target).unwrap();
+        assert!(body.contains("ThresholdConfig"));
+        assert!(body.contains("warn_pp_delta"));
     }
 
     #[test]
@@ -191,12 +440,29 @@ mod tests {
     }
 
     #[test]
+    fn main_entry_target_both_with_out_returns_two() {
+        let code = main_entry(argv(["--target", "both", "--out", "/tmp/x.json"]));
+        assert_eq!(code, ExitCode::from(2));
+    }
+
+    #[test]
+    fn main_entry_unknown_target_returns_two() {
+        let code = main_entry(argv(["--target", "bogus"]));
+        assert_eq!(code, ExitCode::from(2));
+    }
+
+    #[test]
     fn main_entry_write_failure_returns_one() {
         // Use a path whose parent component is an existing *file*, so
         // create_dir_all fails. /etc/hosts is present on macOS + Linux
         // and the test process cannot create children under it.
         let target = PathBuf::from("/etc/hosts/schema.json");
-        let code = main_entry(argv(["--out", target.to_str().unwrap()]));
+        let code = main_entry(argv([
+            "--target",
+            "scorecard",
+            "--out",
+            target.to_str().unwrap(),
+        ]));
         assert_eq!(code, ExitCode::from(1));
     }
 

--- a/crates/scorecard/src/lib.rs
+++ b/crates/scorecard/src/lib.rs
@@ -77,8 +77,13 @@ pub struct Scorecard {
 
     /// `true` when the producer resolved row statuses using the
     /// hardcoded [`threshold::ThresholdConfig::fallback`] thresholds
-    /// (no operator `quality.toml` was present or readable). The
-    /// renderer keys off this flag to emit
+    /// because the operator `quality.toml` was absent or empty. A
+    /// present-but-malformed or unreadable `quality.toml` is a loud
+    /// failure (non-zero exit, no artifact written), not a silent
+    /// fallback — so this flag is `true` only for the deliberate
+    /// "operator hasn't tuned thresholds yet" case.
+    ///
+    /// The renderer keys off this flag to emit
     /// [`threshold::STARTER_PREAMBLE`] +
     /// [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`]
     /// so operators can tell at a glance that the verdict came from

--- a/crates/scorecard/src/lib.rs
+++ b/crates/scorecard/src/lib.rs
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod emit_schema;
 pub mod schema_postprocess;
+pub mod threshold;
 
 #[cfg(feature = "cli")]
 pub mod aggregate;
@@ -73,6 +74,16 @@ pub struct Scorecard {
     /// the comment can satisfy "every failing gate is one click away" even
     /// when more than three gates fail.
     pub all_check_runs_url: String,
+
+    /// `true` when the producer resolved row statuses using the
+    /// hardcoded [`threshold::ThresholdConfig::fallback`] thresholds
+    /// (no operator `quality.toml` was present or readable). The
+    /// renderer keys off this flag to emit
+    /// [`threshold::STARTER_PREAMBLE`] +
+    /// [`threshold::FALLBACK_MARKER`] + [`threshold::PATH_HINT_COMMENT`]
+    /// so operators can tell at a glance that the verdict came from
+    /// starter-wheel defaults rather than their tuned thresholds.
+    pub fallback_thresholds_active: bool,
 }
 
 /// GitHub PR number. Newtype rather than `u64` so a method that wants
@@ -189,6 +200,13 @@ pub enum Row {
         /// callers cannot supply this directly because `Row::CoverageDelta`
         /// is `#[non_exhaustive]`.
         status: Status,
+        /// Raw coverage delta in percentage points vs. the base
+        /// branch. The constructor records this alongside the
+        /// status that was minted from it; the renderer keeps using
+        /// `delta_text` for display, but downstream tooling (and
+        /// future trend dashboards) can read `delta_pp` without
+        /// reparsing the formatted string.
+        delta_pp: f64,
         /// Display string for the delta (e.g. `"+0.3 pp"` or `"-4.2 pp"`).
         delta_text: String,
         /// Inline failure detail rendered below the row when status is Red.
@@ -203,10 +221,11 @@ pub enum Row {
 impl Row {
     /// Construct a Green `CoverageDelta` row. No `failure_detail_md`
     /// because the row is not Red. Status is minted internally.
-    pub fn coverage_delta_green(common: RowCommon, delta_text: String) -> Self {
+    pub fn coverage_delta_green(common: RowCommon, delta_pp: f64, delta_text: String) -> Self {
         Row::CoverageDelta {
             common,
             status: Status::Green,
+            delta_pp,
             delta_text,
             failure_detail_md: None,
         }
@@ -216,10 +235,11 @@ impl Row {
     /// because the row is not Red. Yellow surfaces as a regression but
     /// not a hard failure per the empty-quality.toml fallback rule.
     /// Status is minted internally.
-    pub fn coverage_delta_yellow(common: RowCommon, delta_text: String) -> Self {
+    pub fn coverage_delta_yellow(common: RowCommon, delta_pp: f64, delta_text: String) -> Self {
         Row::CoverageDelta {
             common,
             status: Status::Yellow,
+            delta_pp,
             delta_text,
             failure_detail_md: None,
         }
@@ -233,12 +253,14 @@ impl Row {
     /// internally; callers cannot supply a wrong status.
     pub fn coverage_delta_red(
         common: RowCommon,
+        delta_pp: f64,
         delta_text: String,
         failure_detail_md: String,
     ) -> Self {
         Row::CoverageDelta {
             common,
             status: Status::Red,
+            delta_pp,
             delta_text,
             failure_detail_md: Some(failure_detail_md),
         }
@@ -269,37 +291,64 @@ mod tests {
 
     #[test]
     fn red_constructor_sets_status_and_failure_detail() {
-        let row = Row::coverage_delta_red(common(), "-4.2 pp".into(), "detail".into());
+        let row = Row::coverage_delta_red(common(), -4.2, "-4.2 pp".into(), "detail".into());
         let Row::CoverageDelta {
             status,
+            delta_pp,
             failure_detail_md,
             ..
         } = row;
         assert_eq!(status, Status::Red);
+        assert_eq!(delta_pp, -4.2);
         assert_eq!(failure_detail_md.as_deref(), Some("detail"));
     }
 
     #[test]
     fn green_constructor_sets_status_and_omits_failure_detail() {
-        let row = Row::coverage_delta_green(common(), "+0.3 pp".into());
+        let row = Row::coverage_delta_green(common(), 0.3, "+0.3 pp".into());
         let Row::CoverageDelta {
             status,
+            delta_pp,
             failure_detail_md,
             ..
         } = row;
         assert_eq!(status, Status::Green);
+        assert_eq!(delta_pp, 0.3);
         assert!(failure_detail_md.is_none());
     }
 
     #[test]
     fn yellow_constructor_sets_status_and_omits_failure_detail() {
-        let row = Row::coverage_delta_yellow(common(), "-0.6 pp".into());
+        let row = Row::coverage_delta_yellow(common(), -0.6, "-0.6 pp".into());
         let Row::CoverageDelta {
             status,
+            delta_pp,
             failure_detail_md,
             ..
         } = row;
         assert_eq!(status, Status::Yellow);
+        assert_eq!(delta_pp, -0.6);
         assert!(failure_detail_md.is_none());
+    }
+
+    #[test]
+    fn scorecard_round_trips_with_fallback_thresholds_active_flag() {
+        let sc = Scorecard {
+            schema_version: 0,
+            pr: PrMeta {
+                pr_number: 1.into(),
+                head_sha: "deadbeef".into(),
+                base_sha: "cafefeed".into(),
+                is_fork: false,
+            },
+            overall_status: Status::Yellow,
+            rows: vec![Row::coverage_delta_yellow(common(), -2.5, "-2.5 pp".into())],
+            top_failures: Vec::new(),
+            all_check_runs_url: "https://example.test/x/checks".into(),
+            fallback_thresholds_active: true,
+        };
+        let json = serde_json::to_string(&sc).expect("serialize");
+        let parsed: Scorecard = serde_json::from_str(&json).expect("round-trip");
+        assert!(parsed.fallback_thresholds_active);
     }
 }

--- a/crates/scorecard/src/schema_postprocess.rs
+++ b/crates/scorecard/src/schema_postprocess.rs
@@ -221,39 +221,76 @@ pub fn strip_nonstandard_number_formats(schema: &mut RootSchema) {
 }
 
 fn strip_nonstandard_number_formats_in(obj: &mut SchemaObject) {
-    let is_numeric = matches!(
-        obj.instance_type.as_ref(),
-        Some(schemars::schema::SingleOrVec::Single(boxed))
-            if matches!(**boxed, schemars::schema::InstanceType::Number | schemars::schema::InstanceType::Integer)
-    );
-    if is_numeric
-        && let Some(format) = obj.format.as_deref()
-        && !STANDARD_STRING_FORMATS.contains(&format)
-    {
-        obj.format = None;
+    strip_format_if_nonstandard_numeric(obj);
+    recurse_into_object_properties(obj);
+    recurse_into_subschema_branches(obj);
+}
+
+/// Returns true when this schema's `instance_type` is a single
+/// numeric type (`Number` or `Integer`). Composite/array types are
+/// left alone — the strip targets schemars' default per-numeric-leaf
+/// `format` annotation, not synthetic union types.
+fn is_single_numeric_type(obj: &SchemaObject) -> bool {
+    use schemars::schema::{InstanceType, SingleOrVec};
+    let Some(SingleOrVec::Single(boxed)) = obj.instance_type.as_ref() else {
+        return false;
+    };
+    matches!(**boxed, InstanceType::Number | InstanceType::Integer)
+}
+
+/// Drop the `format` field on this schema when it carries a schemars
+/// numeric-type idiom (`double`, `uint32`, …). Standard string formats
+/// listed in [`STANDARD_STRING_FORMATS`] are preserved unconditionally
+/// so a string-typed leaf with `format: "uri"` is never disturbed by
+/// this pass.
+fn strip_format_if_nonstandard_numeric(obj: &mut SchemaObject) {
+    if !is_single_numeric_type(obj) {
+        return;
     }
-    if let Some(object_validation) = obj.object.as_mut() {
-        for prop in object_validation.properties.values_mut() {
-            if let Schema::Object(child) = prop {
-                strip_nonstandard_number_formats_in(child);
-            }
+    let Some(format) = obj.format.as_deref() else {
+        return;
+    };
+    if STANDARD_STRING_FORMATS.contains(&format) {
+        return;
+    }
+    obj.format = None;
+}
+
+/// Recurse into `obj.properties.*` and run the strip on each child
+/// `SchemaObject`. `Schema::Bool` properties are skipped — they carry
+/// no `format` field and nothing to recurse into.
+fn recurse_into_object_properties(obj: &mut SchemaObject) {
+    let Some(object_validation) = obj.object.as_mut() else {
+        return;
+    };
+    for prop in object_validation.properties.values_mut() {
+        if let Schema::Object(child) = prop {
+            strip_nonstandard_number_formats_in(child);
         }
     }
-    if let Some(subs) = obj.subschemas.as_mut() {
-        for branch in subs.all_of.iter_mut().flatten() {
-            if let Schema::Object(child) = branch {
-                strip_nonstandard_number_formats_in(child);
-            }
-        }
-        for branch in subs.one_of.iter_mut().flatten() {
-            if let Schema::Object(child) = branch {
-                strip_nonstandard_number_formats_in(child);
-            }
-        }
-        for branch in subs.any_of.iter_mut().flatten() {
-            if let Schema::Object(child) = branch {
-                strip_nonstandard_number_formats_in(child);
-            }
+}
+
+/// Recurse into `obj.subschemas.{all_of, one_of, any_of}` and run the
+/// strip on every `Schema::Object` branch. The three keywords are
+/// walked uniformly via [`recurse_into_subschema_branch_list`]; a new
+/// subschema keyword would just need one more call site here.
+fn recurse_into_subschema_branches(obj: &mut SchemaObject) {
+    let Some(subs) = obj.subschemas.as_mut() else {
+        return;
+    };
+    recurse_into_subschema_branch_list(subs.all_of.as_mut());
+    recurse_into_subschema_branch_list(subs.one_of.as_mut());
+    recurse_into_subschema_branch_list(subs.any_of.as_mut());
+}
+
+/// Run the strip on every `Schema::Object` entry in a single subschema
+/// branch list (i.e. one of `all_of`, `one_of`, `any_of`). `None` means
+/// the keyword is absent from the parent; nothing to do.
+fn recurse_into_subschema_branch_list(branches: Option<&mut Vec<Schema>>) {
+    let Some(list) = branches else { return };
+    for branch in list {
+        if let Schema::Object(child) = branch {
+            strip_nonstandard_number_formats_in(child);
         }
     }
 }

--- a/crates/scorecard/src/schema_postprocess.rs
+++ b/crates/scorecard/src/schema_postprocess.rs
@@ -191,6 +191,96 @@ pub fn tighten_url_fields(schema: &mut RootSchema) {
     tighten_string_property(gate_run_obj, "url");
 }
 
+/// Strip non-standard JSON Schema `format` annotations from numeric
+/// properties throughout the schema.
+///
+/// schemars annotates `f64` with `format: "double"`, `u32` with
+/// `format: "uint32"`, and similar for other numeric types. These are
+/// schemars idioms, not draft-07 standard formats, and ajv emits a
+/// warning + degraded validation when it encounters them. Removing the
+/// hint is harmless for our schemas: numeric range constraints are
+/// expressed via `minimum` / `maximum` keywords (which ajv supports),
+/// not via the format hint.
+///
+/// String formats (`uri`, `date-time`, ...) are NOT stripped — those
+/// are standard JSON Schema and ajv understands them.
+///
+/// Used by the operator-facing schema (`quality.config.schema.json`)
+/// which ajv-cli validates the committed `quality.toml` against. The
+/// wire schema (`schema.json`) is validated by the `jsonschema` crate
+/// in the producer, which silently ignores unknown formats, so the
+/// strip is unnecessary there — and intentionally not applied — to
+/// preserve the format hints as type-discovery aids for hand-readers.
+pub fn strip_nonstandard_number_formats(schema: &mut RootSchema) {
+    strip_nonstandard_number_formats_in(&mut schema.schema);
+    for value in schema.definitions.values_mut() {
+        if let Schema::Object(obj) = value {
+            strip_nonstandard_number_formats_in(obj);
+        }
+    }
+}
+
+fn strip_nonstandard_number_formats_in(obj: &mut SchemaObject) {
+    let is_numeric = matches!(
+        obj.instance_type.as_ref(),
+        Some(schemars::schema::SingleOrVec::Single(boxed))
+            if matches!(**boxed, schemars::schema::InstanceType::Number | schemars::schema::InstanceType::Integer)
+    );
+    if is_numeric
+        && let Some(format) = obj.format.as_deref()
+        && !STANDARD_STRING_FORMATS.contains(&format)
+    {
+        obj.format = None;
+    }
+    if let Some(object_validation) = obj.object.as_mut() {
+        for prop in object_validation.properties.values_mut() {
+            if let Schema::Object(child) = prop {
+                strip_nonstandard_number_formats_in(child);
+            }
+        }
+    }
+    if let Some(subs) = obj.subschemas.as_mut() {
+        for branch in subs.all_of.iter_mut().flatten() {
+            if let Schema::Object(child) = branch {
+                strip_nonstandard_number_formats_in(child);
+            }
+        }
+        for branch in subs.one_of.iter_mut().flatten() {
+            if let Schema::Object(child) = branch {
+                strip_nonstandard_number_formats_in(child);
+            }
+        }
+        for branch in subs.any_of.iter_mut().flatten() {
+            if let Schema::Object(child) = branch {
+                strip_nonstandard_number_formats_in(child);
+            }
+        }
+    }
+}
+
+/// JSON Schema draft-07 standard string formats that ajv recognizes by
+/// default. Anything else on a numeric type is a schemars idiom we
+/// strip from operator-facing schemas.
+const STANDARD_STRING_FORMATS: &[&str] = &[
+    "date-time",
+    "time",
+    "date",
+    "email",
+    "idn-email",
+    "hostname",
+    "idn-hostname",
+    "ipv4",
+    "ipv6",
+    "uri",
+    "uri-reference",
+    "iri",
+    "iri-reference",
+    "uri-template",
+    "json-pointer",
+    "relative-json-pointer",
+    "regex",
+];
+
 /// Set `format: "uri"` and `pattern: HTTPS_URL_PATTERN` on `obj.properties[prop]`.
 fn tighten_string_property(obj: &mut SchemaObject, prop: &str) {
     let Some(object_validation) = obj.object.as_mut() else {
@@ -334,5 +424,40 @@ mod tests {
         // shape may legitimately mix Bool branches with Object ones.
         let outer = schema_with_all_of(vec![Schema::Bool(true)]);
         assert!(!variant_defines_failure_detail(&outer));
+    }
+
+    #[test]
+    fn strip_removes_double_format_from_threshold_config_f64_fields() {
+        // schemars annotates f64 with `format: "double"` by default.
+        // Before strip: present at every numeric leaf. After strip:
+        // absent. The serialized schema is the easiest place to check
+        // because nested SchemaObject traversal is verbose.
+        let mut schema = schemars::schema_for!(crate::threshold::ThresholdConfig);
+        let before = serde_json::to_string(&schema).expect("serialize");
+        assert!(
+            before.contains("\"format\":\"double\""),
+            "schemars baseline: f64 should carry `format: double` before strip"
+        );
+        strip_nonstandard_number_formats(&mut schema);
+        let after = serde_json::to_string(&schema).expect("serialize");
+        assert!(
+            !after.contains("\"format\":\"double\""),
+            "strip must remove `format: double` from numeric leaves; got: {after}"
+        );
+    }
+
+    #[test]
+    fn strip_preserves_standard_string_formats() {
+        // Sanity: a uri-typed property in the wire schema (post URL
+        // tightening) must NOT have its `format: "uri"` stripped. The
+        // strip targets numeric formats only.
+        let mut schema = schemars::schema_for!(crate::Scorecard);
+        tighten_url_fields(&mut schema);
+        strip_nonstandard_number_formats(&mut schema);
+        let after = serde_json::to_string(&schema).expect("serialize");
+        assert!(
+            after.contains("\"format\":\"uri\""),
+            "strip must preserve standard string formats (uri); got: {after}"
+        );
     }
 }

--- a/crates/scorecard/src/threshold.rs
+++ b/crates/scorecard/src/threshold.rs
@@ -1,0 +1,429 @@
+//! Threshold resolution — producer-side mapping from raw measurements to
+//! [`Status`](crate::Status) (`Green` / `Yellow` / `Red`).
+//!
+//! The module owns the operator-tunable surface that turns a raw
+//! measurement (e.g. coverage delta in percentage points) into the
+//! status icon the renderer paints on the sticky comment. Resolution
+//! lives in the producer (Rust) so the renderer stays a dumb formatter
+//! — see `decisions/mokumo/adr-scorecard-crate-shape.md` §Threshold
+//! resolution lives in the producer for the architectural rationale.
+//!
+//! # Dependencies
+//!
+//! `serde + schemars + serde_json` only. The TOML parser sits behind
+//! the `cli` feature so a downstream `cargo add scorecard` does not
+//! pull `toml` transitively, and `cargo check -p scorecard
+//! --no-default-features` keeps compiling [`ThresholdConfig`] +
+//! [`schemars::schema_for!`] without a TOML dependency anywhere in the
+//! transitive tree.
+//!
+//! # In-crate Layer-1 discipline
+//!
+//! `Row` and each variant are `#[non_exhaustive]`, blocking external
+//! crates from struct-literal construction or non-wildcard pattern
+//! matches. Inside `scorecard` both remain reachable: the rule that
+//! rows are constructed via the `Row::coverage_delta_{green,yellow,red}`
+//! constructors only is convention, enforced by code review. New row
+//! variants gain a sibling free function in this module (one
+//! `resolve_*` per `Row` variant); resolver dispatch is by call site,
+//! not by trait. See the ADR for the dispatch convention rationale.
+//!
+//! # Doc-drift markers
+//!
+//! [`FALLBACK_MARKER`], [`STARTER_PREAMBLE`], and [`PATH_HINT_COMMENT`]
+//! are the three byte-stable strings the renderer emits when the
+//! producer ran without an operator config. They are pinned by vitest
+//! snapshots so any drift between the renderer's emitted bytes and
+//! these constants surfaces as a snapshot diff on PR review.
+
+use crate::Status;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// HTML comment marker the renderer emits when the producer ran with
+/// hardcoded fallback thresholds (no operator `quality.toml` was found
+/// or it was empty). The renderer's fail-closed branch keys off this
+/// constant so a single source of truth governs the marker bytes.
+pub const FALLBACK_MARKER: &str = "<!-- fallback-thresholds:hardcoded -->";
+
+/// Italic preamble the renderer prepends to the comment body when
+/// fallback thresholds are active. The phrase "starter-wheels" is
+/// deliberate: the operator can replace the defaults at any time by
+/// writing a `quality.toml`, and the language signals provisional /
+/// tunable rather than authoritative.
+pub const STARTER_PREAMBLE: &str = "_Using starter-wheels fallback thresholds. Tune them in [`quality.toml`](QUALITY.md#threshold-tuning)._";
+
+/// HTML comment the renderer emits immediately after [`FALLBACK_MARKER`]
+/// pointing operators at the config path. Plain comment so it does not
+/// render visibly in the body — the visible affordance is
+/// [`STARTER_PREAMBLE`].
+pub const PATH_HINT_COMMENT: &str =
+    "<!-- tune at .config/scorecard/quality.toml — see QUALITY.md#threshold-tuning -->";
+
+/// Operator-tunable threshold configuration.
+///
+/// Top-level shape of `.config/scorecard/quality.toml`. Generates the
+/// operator-facing JSON Schema via `schemars::schema_for!` (no `cli`
+/// feature required), so a downstream `cargo build -p scorecard
+/// --no-default-features --bin emit-schema` succeeds. The JSON Schema
+/// derives drive the `quality.config.schema.json` artifact that ajv
+/// validates the committed example against.
+///
+/// `deny_unknown_fields` so a typo in the operator's TOML
+/// (`warn_pp_dleta` etc.) fails the parse rather than being silently
+/// dropped.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ThresholdConfig {
+    /// Per-row threshold tables. Currently a single `coverage` row;
+    /// new row variants add sibling fields here in lockstep with the
+    /// matching `resolve_*` free function in this module.
+    pub rows: RowsConfig,
+}
+
+/// Per-row threshold tables. One field per `Row` variant kind.
+///
+/// Adding a new row variant in `lib.rs` is paired with a new field
+/// here and a sibling `resolve_*` free function below — the four
+/// changes land together in the same commit.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RowsConfig {
+    /// Thresholds for the `Row::CoverageDelta` variant.
+    pub coverage: CoverageThresholds,
+}
+
+/// Warn / fail thresholds for the `Row::CoverageDelta` variant,
+/// expressed in percentage points (pp) of coverage delta vs base.
+///
+/// Both fields are signed: a regression is a negative delta, so warn
+/// and fail thresholds for "drops" are themselves negative numbers.
+/// Inclusive boundary semantics: `delta_pp == warn_pp_delta` resolves
+/// to [`Status::Yellow`]; `delta_pp == fail_pp_delta` resolves to
+/// [`Status::Red`]. See [`resolve_coverage_delta`] for the full table.
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CoverageThresholds {
+    /// Threshold below (or equal) which a row reports
+    /// [`Status::Yellow`]. Typically negative.
+    pub warn_pp_delta: f64,
+    /// Threshold below (or equal) which a row reports [`Status::Red`].
+    /// Typically negative and more negative than `warn_pp_delta`.
+    pub fail_pp_delta: f64,
+}
+
+impl ThresholdConfig {
+    /// Defensible hardcoded fallback thresholds.
+    ///
+    /// Drops < 1 pp resolve [`Status::Green`] (within the noise floor
+    /// for typical coverage instrumentation), drops ∈ [1, 5) pp
+    /// resolve [`Status::Yellow`] (visible regression worth a soft
+    /// signal), drops ≥ 5 pp resolve [`Status::Red`] (hard failure).
+    /// Used when no operator `quality.toml` is present or readable.
+    pub fn fallback() -> Self {
+        Self {
+            rows: RowsConfig {
+                coverage: CoverageThresholds {
+                    warn_pp_delta: -1.0,
+                    fail_pp_delta: -5.0,
+                },
+            },
+        }
+    }
+}
+
+/// Resolve a coverage delta (in percentage points) to a [`Status`]
+/// using the supplied [`CoverageThresholds`].
+///
+/// # Boundary semantics
+///
+/// | `delta_pp`                         | Result            |
+/// |------------------------------------|-------------------|
+/// | `delta_pp <= fail_pp_delta`        | [`Status::Red`]    |
+/// | `fail_pp_delta < delta_pp <= warn_pp_delta` | [`Status::Yellow`] |
+/// | `warn_pp_delta < delta_pp`         | [`Status::Green`]  |
+///
+/// Both threshold boundaries are inclusive on the worse side: a delta
+/// exactly equal to `warn_pp_delta` is [`Status::Yellow`]; a delta
+/// exactly equal to `fail_pp_delta` is [`Status::Red`]. This matches
+/// operator intent ("fail at -5 pp" means -5 pp itself is failing).
+///
+/// # NaN handling
+///
+/// `NaN` participates in no IEEE 754 ordered comparison: `NaN <= x`
+/// is always `false`. A `NaN` delta therefore falls through both
+/// `<=` checks and resolves [`Status::Green`]. This is documented
+/// rather than fixed because the producer constructs `delta_pp` from
+/// a numeric CLI flag; `NaN` is not a value clap will yield. If a
+/// future delta source can produce `NaN`, the caller is responsible
+/// for rejecting it before calling this function.
+pub fn resolve_coverage_delta(delta_pp: f64, cfg: &CoverageThresholds) -> Status {
+    if delta_pp <= cfg.fail_pp_delta {
+        Status::Red
+    } else if delta_pp <= cfg.warn_pp_delta {
+        Status::Yellow
+    } else {
+        Status::Green
+    }
+}
+
+/// Parse an operator `quality.toml` document into a [`ThresholdConfig`].
+///
+/// Behind `cli` feature so the lib stays deps-zero. The drift workflow
+/// runs `cargo run -p scorecard --bin emit-schema` (no `cli` needed)
+/// for schema regeneration; the aggregate binary runs with
+/// `--features cli` and pulls `toml` transitively only there.
+#[cfg(feature = "cli")]
+pub fn parse_quality_toml(input: &str) -> Result<ThresholdConfig, toml::de::Error> {
+    toml::from_str(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fallback_coverage() -> CoverageThresholds {
+        ThresholdConfig::fallback().rows.coverage
+    }
+
+    // ── Boundary table per CLAUDE.md item 16 ─────────────────────────
+
+    #[test]
+    fn fallback_thresholds_match_documented_values() {
+        let cfg = fallback_coverage();
+        assert_eq!(cfg.warn_pp_delta, -1.0);
+        assert_eq!(cfg.fail_pp_delta, -5.0);
+    }
+
+    #[test]
+    fn delta_at_warn_threshold_resolves_yellow() {
+        // Inclusive boundary on the warn side: -1.0 == warn → Yellow.
+        assert_eq!(
+            resolve_coverage_delta(-1.0, &fallback_coverage()),
+            Status::Yellow
+        );
+    }
+
+    #[test]
+    fn delta_at_fail_threshold_resolves_red() {
+        // Inclusive boundary on the fail side: -5.0 == fail → Red.
+        assert_eq!(
+            resolve_coverage_delta(-5.0, &fallback_coverage()),
+            Status::Red
+        );
+    }
+
+    #[test]
+    fn delta_just_above_warn_resolves_green() {
+        // The "almost wrong" case (CLAUDE.md item 16): a regression
+        // smaller than the warn threshold is still Green.
+        assert_eq!(
+            resolve_coverage_delta(-0.999, &fallback_coverage()),
+            Status::Green
+        );
+    }
+
+    #[test]
+    fn delta_between_warn_and_fail_resolves_yellow() {
+        assert_eq!(
+            resolve_coverage_delta(-2.5, &fallback_coverage()),
+            Status::Yellow
+        );
+    }
+
+    #[test]
+    fn delta_just_above_fail_resolves_yellow() {
+        // Fail boundary is inclusive on the fail side; immediately
+        // less negative than fail must still be Yellow, not Red.
+        assert_eq!(
+            resolve_coverage_delta(-4.999, &fallback_coverage()),
+            Status::Yellow
+        );
+    }
+
+    #[test]
+    fn synthetic_red_below_fail_threshold_resolves_red() {
+        // The synthetic Red unit test required by impl-plan §DG —
+        // documents the Red branch behavior in the absence of an
+        // absolute-coverage row variant (V4+ territory).
+        assert_eq!(
+            resolve_coverage_delta(-7.5, &fallback_coverage()),
+            Status::Red
+        );
+    }
+
+    #[test]
+    fn zero_delta_resolves_green() {
+        assert_eq!(
+            resolve_coverage_delta(0.0, &fallback_coverage()),
+            Status::Green
+        );
+    }
+
+    #[test]
+    fn positive_delta_resolves_green() {
+        assert_eq!(
+            resolve_coverage_delta(2.5, &fallback_coverage()),
+            Status::Green
+        );
+    }
+
+    #[test]
+    fn nan_delta_resolves_green_documented_behavior() {
+        // IEEE 754: NaN compares false against everything, including
+        // itself. Both `<=` checks fall through, landing in Green.
+        // This is documented behavior, not a feature: the producer
+        // constructs `delta_pp` from a clap-parsed numeric flag, which
+        // never yields NaN.
+        assert_eq!(
+            resolve_coverage_delta(f64::NAN, &fallback_coverage()),
+            Status::Green
+        );
+    }
+
+    #[test]
+    fn negative_infinity_delta_resolves_red() {
+        // Sanity check: extreme regression is unambiguously Red.
+        assert_eq!(
+            resolve_coverage_delta(f64::NEG_INFINITY, &fallback_coverage()),
+            Status::Red
+        );
+    }
+
+    #[test]
+    fn positive_infinity_delta_resolves_green() {
+        assert_eq!(
+            resolve_coverage_delta(f64::INFINITY, &fallback_coverage()),
+            Status::Green
+        );
+    }
+
+    // ── Configured-thresholds round-trip ─────────────────────────────
+
+    #[test]
+    fn tightened_warn_flips_status_at_smaller_drop() {
+        // Operator tightens warn from -1.0 to -0.5; a drop of -0.8
+        // now resolves Yellow where it was Green under fallback.
+        let configured = CoverageThresholds {
+            warn_pp_delta: -0.5,
+            fail_pp_delta: -5.0,
+        };
+        assert_eq!(
+            resolve_coverage_delta(-0.8, &fallback_coverage()),
+            Status::Green
+        );
+        assert_eq!(resolve_coverage_delta(-0.8, &configured), Status::Yellow);
+    }
+
+    // ── Doc-drift constants ──────────────────────────────────────────
+
+    #[test]
+    fn fallback_marker_is_html_comment_form() {
+        assert!(FALLBACK_MARKER.starts_with("<!--"));
+        assert!(FALLBACK_MARKER.ends_with("-->"));
+    }
+
+    #[test]
+    fn path_hint_comment_is_html_comment_form() {
+        assert!(PATH_HINT_COMMENT.starts_with("<!--"));
+        assert!(PATH_HINT_COMMENT.ends_with("-->"));
+    }
+
+    #[test]
+    fn starter_preamble_is_italic_markdown() {
+        // Single-underscore italic. Surfaces a regression if someone
+        // converts to asterisks (CommonMark allows both, but the
+        // surrounding renderer prose conventions use underscores).
+        assert!(STARTER_PREAMBLE.starts_with('_'));
+        assert!(STARTER_PREAMBLE.ends_with('_'));
+    }
+
+    #[test]
+    fn starter_preamble_links_quality_toml_anchor() {
+        // Link target must resolve to the docs section
+        // STARTER_PREAMBLE points operators at.
+        assert!(STARTER_PREAMBLE.contains("QUALITY.md#threshold-tuning"));
+        assert!(STARTER_PREAMBLE.contains("`quality.toml`"));
+    }
+
+    // ── Schema generation under deps-zero (CAO-1 acceptance gate) ────
+
+    #[test]
+    fn threshold_config_schema_compiles_without_cli_feature() {
+        // Compiles under `--no-default-features` because schemars +
+        // serde + serde_json are unconditional deps. If this test
+        // fails to compile, the deps-zero invariant has regressed and
+        // the cli-feature gate has leaked into the lib path.
+        let _schema = schemars::schema_for!(ThresholdConfig);
+    }
+
+    #[test]
+    fn threshold_config_round_trips_through_serde_json() {
+        // A round-trip through serde_json (always-available dep)
+        // exercises the Serialize + Deserialize derives without
+        // pulling toml. Confirms the JSON shape stays stable for the
+        // operator-schema artifact ajv validates against.
+        let cfg = ThresholdConfig::fallback();
+        let json = serde_json::to_string(&cfg).expect("serialize fallback config");
+        let parsed: ThresholdConfig =
+            serde_json::from_str(&json).expect("round-trip fallback config");
+        assert_eq!(parsed.rows.coverage.warn_pp_delta, -1.0);
+        assert_eq!(parsed.rows.coverage.fail_pp_delta, -5.0);
+    }
+
+    #[test]
+    fn deny_unknown_fields_rejects_typo_at_root() {
+        // Operator typo at the root must fail-loud rather than be
+        // silently dropped.
+        let bad =
+            r#"{"rows": {"coverage": {"warn_pp_delta": -1.0, "fail_pp_delta": -5.0}}, "rowz": {}}"#;
+        let err = serde_json::from_str::<ThresholdConfig>(bad).unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "got: {err}");
+    }
+
+    #[test]
+    fn deny_unknown_fields_rejects_typo_in_coverage_thresholds() {
+        let bad = r#"{"rows": {"coverage": {"warn_pp_delta": -1.0, "fail_pp_delta": -5.0, "fail_pp_dleta": -7.0}}}"#;
+        let err = serde_json::from_str::<ThresholdConfig>(bad).unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "got: {err}");
+    }
+
+    // ── TOML parser (cli feature only) ───────────────────────────────
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn parse_quality_toml_round_trips_fallback_values() {
+        let input = r#"
+[rows.coverage]
+warn_pp_delta = -1.0
+fail_pp_delta = -5.0
+"#;
+        let cfg = parse_quality_toml(input).expect("parse");
+        assert_eq!(cfg.rows.coverage.warn_pp_delta, -1.0);
+        assert_eq!(cfg.rows.coverage.fail_pp_delta, -5.0);
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn parse_quality_toml_rejects_unknown_field() {
+        let input = r#"
+[rows.coverage]
+warn_pp_delta = -1.0
+fail_pp_delta = -5.0
+fail_pp_dleta = -7.0
+"#;
+        let err = parse_quality_toml(input).unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "got: {err}");
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn parse_quality_toml_rejects_string_for_numeric_field() {
+        let input = r#"
+[rows.coverage]
+warn_pp_delta = "tight"
+fail_pp_delta = -5.0
+"#;
+        assert!(parse_quality_toml(input).is_err());
+    }
+}

--- a/crates/scorecard/src/threshold.rs
+++ b/crates/scorecard/src/threshold.rs
@@ -243,9 +243,11 @@ mod tests {
 
     #[test]
     fn synthetic_red_below_fail_threshold_resolves_red() {
-        // The synthetic Red unit test required by impl-plan §DG —
-        // documents the Red branch behavior in the absence of an
-        // absolute-coverage row variant (V4+ territory).
+        // Documents the Red branch behavior with a synthetic delta that
+        // falls below `fail_pp_delta`. The coverage-delta row is the
+        // only row variant that exercises the Red branch today, so a
+        // unit test here is the canonical assertion until other row
+        // variants land their own resolvers.
         assert_eq!(
             resolve_coverage_delta(-7.5, &fallback_coverage()),
             Status::Red
@@ -302,8 +304,9 @@ mod tests {
 
     #[test]
     fn tightened_warn_flips_status_at_smaller_drop() {
-        // Operator tightens warn from -1.0 to -0.5; a drop of -0.8
-        // now resolves Yellow where it was Green under fallback.
+        // A drop of -0.8 lands Green against the fallback warn (-1.0)
+        // and Yellow against a tightened warn (-0.5) — the round-trip
+        // contract operators rely on when they tune `quality.toml`.
         let configured = CoverageThresholds {
             warn_pp_delta: -0.5,
             fail_pp_delta: -5.0,

--- a/crates/scorecard/tests/bdd.rs
+++ b/crates/scorecard/tests/bdd.rs
@@ -31,9 +31,16 @@ async fn main() {
                 && rule.is_none_or(|r| !is_exempt(&r.tags))
                 && !is_exempt(&scenario.tags)
         })
-        .filter_run_and_exit("tests/features", |feature, _, sc| {
-            let dominated_by_wip =
-                feature.tags.iter().any(|t| t == "wip") || sc.tags.iter().any(|t| t == "wip");
+        .filter_run_and_exit("tests/features", |feature, rule, sc| {
+            // `@wip` is honoured at all three Gherkin nesting levels —
+            // feature, rule, scenario — so a `Rule: @wip` tag silently
+            // skips its scenarios the same way `Feature: @wip` and
+            // `Scenario: @wip` do. The `fail_on_skipped_with` predicate
+            // above uses the same rule-tag logic for the skip-fail
+            // exemption, so the two checks stay in lockstep.
+            let dominated_by_wip = feature.tags.iter().any(|t| t == "wip")
+                || rule.is_some_and(|r| r.tags.iter().any(|t| t == "wip"))
+                || sc.tags.iter().any(|t| t == "wip");
             !dominated_by_wip
         })
         .await;

--- a/crates/scorecard/tests/bdd.rs
+++ b/crates/scorecard/tests/bdd.rs
@@ -1,0 +1,40 @@
+//! Cucumber-rs runner for `tests/features/scorecard_display.feature`.
+//!
+//! The runner wires the [`ThresholdWorld`] state machine in
+//! `tests/bdd_world/` to the Gherkin scenarios under `tests/features/`.
+//! Step-defs live in `tests/bdd_world/threshold_steps.rs` so `bdd-lint`
+//! (which globs `crates/*/tests/bdd_world/**/*.rs`) discovers them.
+//!
+//! Producer-only assertion surface: step-defs build [`Scorecard`] values
+//! through `aggregate::build_scorecard` and assert on JSON state. The
+//! renderer is asserted byte-for-byte by vitest snapshots in
+//! `.github/scripts/scorecard/__tests__/render.test.js`. See the
+//! Gherkin comment block above the fallback-marker scenario for the
+//! split rationale.
+
+use cucumber::World as _;
+
+#[path = "bdd_world/mod.rs"]
+mod bdd_world;
+
+const SKIP_EXEMPT_TAGS: &[&str] = &["wip", "allow.skipped", "future"];
+
+fn is_exempt(tags: &[String]) -> bool {
+    tags.iter().any(|t| SKIP_EXEMPT_TAGS.contains(&t.as_str()))
+}
+
+#[tokio::main]
+async fn main() {
+    bdd_world::ThresholdWorld::cucumber()
+        .fail_on_skipped_with(|feature, rule, scenario| {
+            !is_exempt(&feature.tags)
+                && rule.is_none_or(|r| !is_exempt(&r.tags))
+                && !is_exempt(&scenario.tags)
+        })
+        .filter_run_and_exit("tests/features", |feature, _, sc| {
+            let dominated_by_wip =
+                feature.tags.iter().any(|t| t == "wip") || sc.tags.iter().any(|t| t == "wip");
+            !dominated_by_wip
+        })
+        .await;
+}

--- a/crates/scorecard/tests/bdd_world/mod.rs
+++ b/crates/scorecard/tests/bdd_world/mod.rs
@@ -1,14 +1,15 @@
-//! `ThresholdWorld` — fixture state for the V3 threshold-engine BDD
-//! scenarios. Owned exclusively by `tests/bdd.rs`; the layout matches
-//! kikan/kikan-events so `bdd-lint`'s rust-glob
-//! (`crates/*/tests/bdd_world/**/*.rs`) discovers the step-defs.
+//! `ThresholdWorld` — fixture state for the threshold-engine BDD
+//! scenarios in `tests/features/scorecard_display.feature`. Owned
+//! exclusively by `tests/bdd.rs`; the layout matches kikan/kikan-events
+//! so `bdd-lint`'s rust-glob (`crates/*/tests/bdd_world/**/*.rs`)
+//! discovers the step-defs.
 
 use cucumber::World;
 use scorecard::{PrMeta, Scorecard, Status};
 
 pub mod threshold_steps;
 
-/// Scenario fixture for the V3 threshold-engine flow.
+/// Scenario fixture for the threshold-engine flow.
 ///
 /// Each scenario edits a temp `quality.toml`, runs the producer in
 /// process, and asserts on the resulting [`Scorecard`]. The fields are
@@ -42,9 +43,9 @@ impl ThresholdWorld {
         }
     }
 
-    /// Synthetic PR metadata. The scorecard's PR fields are not under
-    /// test in V3 — only the row + fallback flag are — so a fixed stub
-    /// is fine.
+    /// Synthetic PR metadata. The threshold-engine scenarios assert
+    /// only on the row + fallback flag of the produced scorecard, so a
+    /// fixed stub for `PrMeta` is sufficient.
     pub fn stub_pr_meta() -> PrMeta {
         PrMeta {
             pr_number: 768.into(),

--- a/crates/scorecard/tests/bdd_world/mod.rs
+++ b/crates/scorecard/tests/bdd_world/mod.rs
@@ -1,0 +1,56 @@
+//! `ThresholdWorld` — fixture state for the V3 threshold-engine BDD
+//! scenarios. Owned exclusively by `tests/bdd.rs`; the layout matches
+//! kikan/kikan-events so `bdd-lint`'s rust-glob
+//! (`crates/*/tests/bdd_world/**/*.rs`) discovers the step-defs.
+
+use cucumber::World;
+use scorecard::{PrMeta, Scorecard, Status};
+
+pub mod threshold_steps;
+
+/// Scenario fixture for the V3 threshold-engine flow.
+///
+/// Each scenario edits a temp `quality.toml`, runs the producer in
+/// process, and asserts on the resulting [`Scorecard`]. The fields are
+/// `Option`-typed so a step-def can fail loudly when an earlier step
+/// did not populate the slot it depends on.
+#[derive(Debug, World)]
+#[world(init = Self::new)]
+pub struct ThresholdWorld {
+    /// Working directory for the operator config — dropped at the end
+    /// of the scenario.
+    pub tmp: Option<tempfile::TempDir>,
+    /// Coverage delta in percentage points (the producer's
+    /// `--coverage-delta-pp` input). Set by Given/When steps.
+    pub coverage_delta_pp: Option<f64>,
+    /// Most recently produced scorecard. Set by the When step that
+    /// runs the producer; asserted on by Then steps.
+    pub scorecard: Option<Scorecard>,
+    /// Status of the row at index 0 (coverage) on the most recent
+    /// produced scorecard. Cached out of [`Self::scorecard`] for
+    /// terser Then steps.
+    pub coverage_row_status: Option<Status>,
+}
+
+impl ThresholdWorld {
+    fn new() -> Self {
+        Self {
+            tmp: None,
+            coverage_delta_pp: None,
+            scorecard: None,
+            coverage_row_status: None,
+        }
+    }
+
+    /// Synthetic PR metadata. The scorecard's PR fields are not under
+    /// test in V3 — only the row + fallback flag are — so a fixed stub
+    /// is fine.
+    pub fn stub_pr_meta() -> PrMeta {
+        PrMeta {
+            pr_number: 768.into(),
+            head_sha: "0000000000000000000000000000000000000000".into(),
+            base_sha: "1111111111111111111111111111111111111111".into(),
+            is_fork: false,
+        }
+    }
+}

--- a/crates/scorecard/tests/bdd_world/threshold_steps.rs
+++ b/crates/scorecard/tests/bdd_world/threshold_steps.rs
@@ -61,7 +61,7 @@ fn produce(world: &mut ThresholdWorld, delta_pp: f64) {
         // arm is required by rustc and signals to a future contributor
         // that adding a row variant means revisiting the BDD assertion
         // surface.
-        _ => panic!("unexpected Row variant in V3 producer output"),
+        _ => panic!("unexpected Row variant in producer output"),
     };
     world.coverage_delta_pp = Some(delta_pp);
     world.coverage_row_status = Some(row_status);
@@ -180,11 +180,12 @@ async fn then_regressed_shown_yellow(world: &mut ThresholdWorld) {
 
 #[then(expr = "any new gate failure is shown as red")]
 async fn then_new_failure_shown_red(_world: &mut ThresholdWorld) {
-    // V3 ships only the CoverageDelta row variant. We exercise the Red
-    // branch as a unit assertion against the same fallback config the
-    // producer is using; the "gate failure" wording in the .feature is
-    // forward-compatible with the absolute-coverage row variant that
-    // lands in V4 or later (council C5).
+    // The CoverageDelta row variant is the only row variant whose Red
+    // branch is exercised today; the "gate failure" wording in the
+    // .feature is intentionally row-variant-neutral so other variants
+    // can register themselves under the same Then step when their
+    // resolvers ship. The unit assertion below pins the Red branch on
+    // the same fallback config the producer is using.
     let cfg = ThresholdConfig::fallback();
     let coverage: &CoverageThresholds = &cfg.rows.coverage;
     assert_eq!(
@@ -196,10 +197,10 @@ async fn then_new_failure_shown_red(_world: &mut ThresholdWorld) {
 
 #[then(expr = "the ci-scorecard comment contains the HTML marker {string}")]
 async fn then_comment_contains_marker(_world: &mut ThresholdWorld, marker_literal: String) {
-    // Doc-drift gate (impl-plan §C13). The Gherkin literal is the
-    // canonical text on the renderer side; the Rust constant is the
-    // canonical text on the producer side. Asserting byte-equality
-    // here means a drift on either side fails this scenario first.
+    // Doc-drift gate. The Gherkin literal is the canonical text on
+    // the renderer side; the Rust constant is the canonical text on
+    // the producer side. Asserting byte-equality here means a drift on
+    // either side fails this scenario first.
     assert_eq!(
         marker_literal, FALLBACK_MARKER,
         "Gherkin marker literal must equal scorecard::threshold::FALLBACK_MARKER",
@@ -211,13 +212,35 @@ async fn then_comment_contains_marker(_world: &mut ThresholdWorld, marker_litera
     );
 }
 
+#[then(expr = "the comment opens with the italic preamble {string}")]
+async fn then_comment_opens_with_preamble(_world: &mut ThresholdWorld, preamble_literal: String) {
+    // Doc-drift gate (sibling of the marker assertion above). The
+    // Gherkin literal is the canonical text on the renderer side;
+    // `STARTER_PREAMBLE` is the canonical text on the producer side.
+    // A drift on either side fails this scenario before the rendered
+    // comment is ever inspected by a human.
+    assert_eq!(
+        preamble_literal, STARTER_PREAMBLE,
+        "Gherkin preamble literal must equal scorecard::threshold::STARTER_PREAMBLE",
+    );
+}
+
+#[then(expr = "the comment ends with the path-hint comment {string}")]
+async fn then_comment_ends_with_path_hint(_world: &mut ThresholdWorld, path_hint_literal: String) {
+    // Doc-drift gate for the third byte-stable string. Together with
+    // the FALLBACK_MARKER and STARTER_PREAMBLE assertions above this
+    // pins all three constants the renderer mirrors from the producer.
+    assert_eq!(
+        path_hint_literal, PATH_HINT_COMMENT,
+        "Gherkin path-hint literal must equal scorecard::threshold::PATH_HINT_COMMENT",
+    );
+}
+
 #[then(expr = "the comment displays a visible note that hardcoded fallback thresholds are in use")]
 async fn then_comment_displays_note(world: &mut ThresholdWorld) {
-    // Mirror of the above: the producer flags fallback so the renderer
-    // (asserted by vitest) prepends `STARTER_PREAMBLE` and trails with
-    // `PATH_HINT_COMMENT`. Touching the constants here keeps any
-    // unused-import drift from sneaking past compile.
-    let _ = (STARTER_PREAMBLE, PATH_HINT_COMMENT);
+    // The visible note is gated on the producer marking fallback. The
+    // text of the note (italic preamble + HTML marker + path-hint
+    // comment) is asserted byte-for-byte by the three Then steps above.
     let scorecard = world.scorecard.as_ref().expect("scorecard must be built");
     assert!(
         scorecard.fallback_thresholds_active,
@@ -226,8 +249,9 @@ async fn then_comment_displays_note(world: &mut ThresholdWorld) {
 }
 
 // ───────────────────────────────────────────────────────────────────
-// Pinning the helpers' types — keeps `cargo check` honest about the
-// public surface even when no scenario currently exercises a code path.
+// Type pin — keeps `cargo check` honest about the public surface so
+// that an upstream signature drift fails the BDD test target before
+// it can sneak past the lib-tests-only `cargo test -p scorecard`.
 // ───────────────────────────────────────────────────────────────────
 
 #[allow(dead_code)]

--- a/crates/scorecard/tests/bdd_world/threshold_steps.rs
+++ b/crates/scorecard/tests/bdd_world/threshold_steps.rs
@@ -149,10 +149,17 @@ async fn then_no_rust_modified(_world: &mut ThresholdWorld) {
 
 #[given(expr = "quality.toml is empty or absent")]
 async fn given_quality_toml_absent(world: &mut ThresholdWorld) {
-    // Allocate the tempdir but never write `quality.toml` in it —
-    // `resolve_threshold_source` will hit `io::ErrorKind::NotFound`
-    // and produce `ThresholdSource::Fallback`.
-    world.tmp = Some(tempfile::tempdir().expect("scenario tempdir must allocate"));
+    // Write a zero-byte `quality.toml` so the scenario exercises the
+    // empty-file branch of `resolve_threshold_source`, not just the
+    // absent-file (`io::ErrorKind::NotFound`) branch. The two unit
+    // tests in `aggregate::tests` cover absent + whitespace-only;
+    // pinning the empty-file path through the BDD scenario means a
+    // regression on that branch fails the acceptance test, not just
+    // the unit suite.
+    let tmp = tempfile::tempdir().expect("scenario tempdir must allocate");
+    std::fs::write(tmp.path().join("quality.toml"), b"")
+        .expect("must be able to write empty quality.toml inside the scenario tempdir");
+    world.tmp = Some(tmp);
 }
 
 #[when(expr = "CI completes")]

--- a/crates/scorecard/tests/bdd_world/threshold_steps.rs
+++ b/crates/scorecard/tests/bdd_world/threshold_steps.rs
@@ -1,0 +1,237 @@
+//! Step definitions for scenarios #5 (configured-threshold round-trip)
+//! and #6 (empty-toml fallback marker) in
+//! `tests/features/scorecard_display.feature`.
+//!
+//! ## Test split
+//!
+//! These step-defs assert on **producer behavior** — the JSON state of
+//! the [`Scorecard`] returned by `aggregate::build_scorecard`, including
+//! the `fallback_thresholds_active` flag and the per-row [`Status`].
+//! They never invoke the renderer.
+//!
+//! Renderer byte-equality on the rendered markdown
+//! (`STARTER_PREAMBLE` + `FALLBACK_MARKER` + `PATH_HINT_COMMENT`) is
+//! locked by vitest snapshots in
+//! `.github/scripts/scorecard/__tests__/render.test.js`.
+//!
+//! ## Doc-drift gate
+//!
+//! The Gherkin literal `"<!-- fallback-thresholds:hardcoded -->"` is
+//! checked byte-for-byte against
+//! [`scorecard::threshold::FALLBACK_MARKER`] inside the `Then` step.
+//! The same constant is mirrored on the renderer side and pinned by
+//! vitest, so a drift on either side fails this scenario first.
+
+use cucumber::{given, then, when};
+
+use scorecard::aggregate::{ThresholdSource, build_scorecard, resolve_threshold_source};
+use scorecard::threshold::{
+    self, CoverageThresholds, FALLBACK_MARKER, PATH_HINT_COMMENT, STARTER_PREAMBLE, ThresholdConfig,
+};
+use scorecard::{Row, Status};
+
+use super::ThresholdWorld;
+
+// ───────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────
+
+/// Produce a scorecard with `delta_pp` against the resolved thresholds
+/// from a `quality.toml` at `<tmp>/quality.toml`. Mirrors the path the
+/// `aggregate` binary would take in CI: `resolve_threshold_source` →
+/// `build_scorecard`.
+fn produce(world: &mut ThresholdWorld, delta_pp: f64) {
+    let tmp = world
+        .tmp
+        .as_ref()
+        .expect("tmp dir must be set by an earlier step");
+    let toml_path = tmp.path().join("quality.toml");
+
+    let source = resolve_threshold_source(&toml_path)
+        .expect("operator config must parse (or be absent → fallback)");
+    let cfg = source.config();
+    let fallback_active = source.fallback_active();
+
+    let pr = ThresholdWorld::stub_pr_meta();
+    let scorecard = build_scorecard(pr, delta_pp, &cfg, fallback_active);
+
+    let row_status = match scorecard.rows[0] {
+        Row::CoverageDelta { status, .. } => status,
+        // `Row` is `#[non_exhaustive]` (Layer-1 typestate); the wildcard
+        // arm is required by rustc and signals to a future contributor
+        // that adding a row variant means revisiting the BDD assertion
+        // surface.
+        _ => panic!("unexpected Row variant in V3 producer output"),
+    };
+    world.coverage_delta_pp = Some(delta_pp);
+    world.coverage_row_status = Some(row_status);
+    world.scorecard = Some(scorecard);
+}
+
+/// Build a tuned `quality.toml` with a single `[rows.coverage]` table
+/// where `warn_pp_delta = warn`. `fail_pp_delta` is held at the
+/// fallback's `-5.0` so the scenario isolates the warn-tightening
+/// effect.
+fn write_quality_toml_with_warn(world: &mut ThresholdWorld, warn: f64) {
+    let tmp = world
+        .tmp
+        .as_ref()
+        .expect("tmp dir must be set by an earlier step");
+    let body = format!(
+        "[rows.coverage]\nwarn_pp_delta = {warn}\nfail_pp_delta = -5.0\n",
+        warn = warn,
+    );
+    std::fs::write(tmp.path().join("quality.toml"), body)
+        .expect("must be able to write quality.toml inside the scenario tempdir");
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Scenario #5 — configured-threshold round-trip (Green → Yellow)
+// ───────────────────────────────────────────────────────────────────
+
+#[given(expr = "a row reports a coverage delta of {float} percentage points")]
+async fn given_row_reports_delta(world: &mut ThresholdWorld, delta_pp: f64) {
+    world.tmp = Some(tempfile::tempdir().expect("scenario tempdir must allocate"));
+    world.coverage_delta_pp = Some(delta_pp);
+}
+
+#[given(
+    expr = "the row is currently shown as green because the warn threshold is {float} percentage points"
+)]
+async fn given_row_currently_green(world: &mut ThresholdWorld, warn: f64) {
+    write_quality_toml_with_warn(world, warn);
+    let delta = world
+        .coverage_delta_pp
+        .expect("delta must have been set by the previous Given");
+    produce(world, delta);
+    assert_eq!(
+        world.coverage_row_status,
+        Some(Status::Green),
+        "scenario precondition: with warn={warn} the row must start Green at delta={delta}",
+    );
+}
+
+#[when(
+    expr = "the operator edits quality.toml to tighten the warn threshold to {float} percentage points"
+)]
+async fn when_operator_tightens_warn(world: &mut ThresholdWorld, new_warn: f64) {
+    write_quality_toml_with_warn(world, new_warn);
+}
+
+#[when(expr = "CI completes again on the same head commit with no other changes")]
+async fn when_ci_reruns(world: &mut ThresholdWorld) {
+    let delta = world
+        .coverage_delta_pp
+        .expect("delta must remain pinned across the two CI runs");
+    produce(world, delta);
+}
+
+#[then(expr = "the row is shown as yellow")]
+async fn then_row_shown_yellow(world: &mut ThresholdWorld) {
+    assert_eq!(
+        world.coverage_row_status,
+        Some(Status::Yellow),
+        "row status mismatch — tightened-warn run should flip Green → Yellow",
+    );
+}
+
+#[then(expr = "no Rust source files were modified between the two CI runs")]
+async fn then_no_rust_modified(_world: &mut ThresholdWorld) {
+    // Operator-config scenarios live entirely in the fixture tempdir;
+    // the step-def itself never touches `crates/scorecard/src/**`.
+    // This step exists for the spec to read cleanly — the contract is
+    // that threshold tuning round-trips through `quality.toml` only.
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Scenario #6 — empty-toml fallback marker
+// ───────────────────────────────────────────────────────────────────
+
+#[given(expr = "quality.toml is empty or absent")]
+async fn given_quality_toml_absent(world: &mut ThresholdWorld) {
+    // Allocate the tempdir but never write `quality.toml` in it —
+    // `resolve_threshold_source` will hit `io::ErrorKind::NotFound`
+    // and produce `ThresholdSource::Fallback`.
+    world.tmp = Some(tempfile::tempdir().expect("scenario tempdir must allocate"));
+}
+
+#[when(expr = "CI completes")]
+async fn when_ci_completes(world: &mut ThresholdWorld) {
+    // -2.0 pp picks up the fallback's `warn_pp_delta = -1.0` and stops
+    // short of `fail_pp_delta = -5.0`, so the row lands Yellow — the
+    // "regressed compared to the base branch" condition in the next
+    // Then step.
+    produce(world, -2.0);
+}
+
+#[then(expr = "any metric that regressed compared to the base branch is shown as yellow")]
+async fn then_regressed_shown_yellow(world: &mut ThresholdWorld) {
+    assert_eq!(
+        world.coverage_row_status,
+        Some(Status::Yellow),
+        "fallback warn_pp_delta = -1.0; delta of -2.0 pp must land Yellow",
+    );
+    let scorecard = world.scorecard.as_ref().expect("scorecard must be built");
+    assert!(
+        scorecard.fallback_thresholds_active,
+        "absent quality.toml must mark fallback_thresholds_active = true",
+    );
+}
+
+#[then(expr = "any new gate failure is shown as red")]
+async fn then_new_failure_shown_red(_world: &mut ThresholdWorld) {
+    // V3 ships only the CoverageDelta row variant. We exercise the Red
+    // branch as a unit assertion against the same fallback config the
+    // producer is using; the "gate failure" wording in the .feature is
+    // forward-compatible with the absolute-coverage row variant that
+    // lands in V4 or later (council C5).
+    let cfg = ThresholdConfig::fallback();
+    let coverage: &CoverageThresholds = &cfg.rows.coverage;
+    assert_eq!(
+        threshold::resolve_coverage_delta(-7.5, coverage),
+        Status::Red,
+        "fallback fail_pp_delta = -5.0; a delta of -7.5 pp must land Red",
+    );
+}
+
+#[then(expr = "the ci-scorecard comment contains the HTML marker {string}")]
+async fn then_comment_contains_marker(_world: &mut ThresholdWorld, marker_literal: String) {
+    // Doc-drift gate (impl-plan §C13). The Gherkin literal is the
+    // canonical text on the renderer side; the Rust constant is the
+    // canonical text on the producer side. Asserting byte-equality
+    // here means a drift on either side fails this scenario first.
+    assert_eq!(
+        marker_literal, FALLBACK_MARKER,
+        "Gherkin marker literal must equal scorecard::threshold::FALLBACK_MARKER",
+    );
+    let scorecard = _world.scorecard.as_ref().expect("scorecard must be built");
+    assert!(
+        scorecard.fallback_thresholds_active,
+        "fallback_thresholds_active must be true so the renderer emits the marker",
+    );
+}
+
+#[then(expr = "the comment displays a visible note that hardcoded fallback thresholds are in use")]
+async fn then_comment_displays_note(world: &mut ThresholdWorld) {
+    // Mirror of the above: the producer flags fallback so the renderer
+    // (asserted by vitest) prepends `STARTER_PREAMBLE` and trails with
+    // `PATH_HINT_COMMENT`. Touching the constants here keeps any
+    // unused-import drift from sneaking past compile.
+    let _ = (STARTER_PREAMBLE, PATH_HINT_COMMENT);
+    let scorecard = world.scorecard.as_ref().expect("scorecard must be built");
+    assert!(
+        scorecard.fallback_thresholds_active,
+        "the visible note is gated on fallback_thresholds_active = true",
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Pinning the helpers' types — keeps `cargo check` honest about the
+// public surface even when no scenario currently exercises a code path.
+// ───────────────────────────────────────────────────────────────────
+
+#[allow(dead_code)]
+fn _type_pins(source: ThresholdSource) -> Status {
+    let cfg = source.config();
+    threshold::resolve_coverage_delta(0.0, &cfg.rows.coverage)
+}

--- a/crates/scorecard/tests/features/scorecard_display.feature
+++ b/crates/scorecard/tests/features/scorecard_display.feature
@@ -162,6 +162,8 @@ Feature: Sticky PR scorecard display contract
       Then any metric that regressed compared to the base branch is shown as yellow
       And any new gate failure is shown as red
       And the ci-scorecard comment contains the HTML marker "<!-- fallback-thresholds:hardcoded -->"
+      And the comment opens with the italic preamble "_Using starter-wheels fallback thresholds. Tune them in [`quality.toml`](QUALITY.md#threshold-tuning)._"
+      And the comment ends with the path-hint comment "<!-- tune at .config/scorecard/quality.toml — see QUALITY.md#threshold-tuning -->"
       And the comment displays a visible note that hardcoded fallback thresholds are in use
 
   # --- Forward compatibility: older renderers tolerate newer producers ---

--- a/crates/scorecard/tests/features/scorecard_display.feature
+++ b/crates/scorecard/tests/features/scorecard_display.feature
@@ -1,5 +1,3 @@
-# tracked: mokumo#650 — scenarios get step-defined incrementally as later slices land their behaviors; @future blanket-defers the file from BDD staleness checks until then
-@future
 Feature: Sticky PR scorecard display contract
 
   Every pull request gets a single sticky comment that summarizes the quality
@@ -24,6 +22,7 @@ Feature: Sticky PR scorecard display contract
 
   Rule: The scorecard appears as exactly one sticky comment per PR
 
+    @future
     Scenario: A new PR receives one ci-scorecard comment after CI completes
       Given a developer opens a pull request
       And no ci-scorecard comment yet exists on the PR
@@ -31,6 +30,7 @@ Feature: Sticky PR scorecard display contract
       Then exactly one comment containing the HTML marker "<!-- ci-scorecard -->" appears on the PR
       And the comment is authored by the github-actions bot
 
+    @future
     Scenario: Subsequent pushes update the ci-scorecard comment in place
       Given a pull request with an existing ci-scorecard comment
       And the developer has pushed three subsequent commits
@@ -38,6 +38,7 @@ Feature: Sticky PR scorecard display contract
       Then the PR has exactly one comment containing the HTML marker "<!-- ci-scorecard -->"
       And the comment body contains the SHA of the third subsequent head commit
 
+    @future
     Scenario: Reopening a closed PR continues to update the same comment
       Given a pull request was closed with an existing ci-scorecard comment
       When the developer reopens the PR and pushes a new commit
@@ -45,6 +46,7 @@ Feature: Sticky PR scorecard display contract
       Then the PR still has exactly one comment containing the HTML marker "<!-- ci-scorecard -->"
       And the comment body contains the SHA of the new head commit
 
+    @future
     Scenario: Draft PRs receive the ci-scorecard comment identically to ready PRs
       Given a developer opens a pull request as draft
       When CI completes on the head commit
@@ -54,6 +56,7 @@ Feature: Sticky PR scorecard display contract
 
   Rule: The status banner and row icons accurately reflect the worst status across all gates
 
+    @future
     Scenario: A PR that passes every gate shows a green banner and 8 green rows
       Given a developer opens a pull request
       When CI completes and every quality gate passes
@@ -61,6 +64,7 @@ Feature: Sticky PR scorecard display contract
       And the 8-row summary table shows a green status icon on every row
       And no inline failure detail blocks are present
 
+    @future
     Scenario: A PR with a mix of green, yellow, and red rows surfaces the red as the banner status
       Given a pull request where one gate fails, two gates regress, and the rest pass
       When CI completes
@@ -73,6 +77,7 @@ Feature: Sticky PR scorecard display contract
 
   Rule: A malformed scorecard artifact must surface as a fail-closed comment, not be silently dropped
 
+    @future
     Scenario: A scorecard artifact that fails schema validation triggers fail-closed rendering
       Given the producer emits a scorecard artifact that does not match the committed schema
       When the renderer runs against that artifact
@@ -87,6 +92,7 @@ Feature: Sticky PR scorecard display contract
 
   Rule: The committed schema and TypeScript types must match the Rust source of truth
 
+    @future
     Scenario: Modifying the scorecard's Rust schema without regenerating committed artifacts fails CI
       Given a developer modifies the scorecard's Rust schema definition
       And the developer did not regenerate the committed schema and types artifacts
@@ -94,6 +100,7 @@ Feature: Sticky PR scorecard display contract
       Then the drift-check job fails
       And the failure message names the regeneration command the developer must run
 
+    @future
     Scenario: Modifying the scorecard's Rust schema and regenerating both committed artifacts passes CI
       Given a developer modifies the scorecard's Rust schema definition
       And the developer regenerated both the committed schema artifact and the committed types artifact
@@ -104,6 +111,7 @@ Feature: Sticky PR scorecard display contract
 
   Rule: A row with status Red must show an inline human-readable failure detail (three layers of enforcement)
 
+    @future
     Scenario: A Red row displays its failure detail inline below the summary row
       Given the producer emits a row with status Red
       And the row's failure_detail_md is "coverage dropped 4.2% on crate kikan"
@@ -111,12 +119,14 @@ Feature: Sticky PR scorecard display contract
       Then the row appears in the summary table with a red status icon
       And the line "coverage dropped 4.2% on crate kikan" appears inline directly below the row
 
+    @future
     Scenario: The committed schema rejects a Red row that omits failure_detail_md (Layer 2)
       Given a candidate scorecard artifact contains a row with status Red and no failure_detail_md
       When the renderer validates the artifact against the committed schema
       Then validation fails citing the failure_detail_md requirement on Red rows
       And the renderer posts a fail-closed comment naming the violation
 
+    @future
     Scenario: The Rust typestate API forbids constructing a Red row without failure_detail_md at compile time (Layer 1)
       Given the scorecard crate's typestate Row API
       When code attempts to construct a Row with status Red and no failure_detail_md
@@ -135,6 +145,17 @@ Feature: Sticky PR scorecard display contract
       Then the row is shown as yellow
       And no Rust source files were modified between the two CI runs
 
+    # Test-split (V3 covers Yellow + marker via two layers):
+    # - Producer behavior (`fallback_thresholds_active=true` + Yellow status) is
+    #   asserted by step-defs in `tests/features/steps/threshold_steps.rs`.
+    # - Renderer byte-equality (FALLBACK_MARKER + STARTER_PREAMBLE +
+    #   PATH_HINT_COMMENT) is asserted by vitest snapshot tests in
+    #   `.github/scripts/scorecard/__tests__/render.test.js`.
+    # - Red branch (any new gate failure → red) is unit-tested in
+    #   `crates/scorecard/src/threshold.rs::tests` via synthetic
+    #   `resolve_coverage_delta(-7.5, &fallback().rows.coverage) == Status::Red`
+    #   (council C5 — V3 has only the CoverageDelta row variant; absolute-
+    #   coverage row variant lands V4 or later).
     Scenario: An empty quality.toml falls back to hardcoded thresholds with a visible marker
       Given quality.toml is empty or absent
       When CI completes
@@ -147,6 +168,7 @@ Feature: Sticky PR scorecard display contract
 
   Rule: The renderer tolerates unknown row variants from future producer versions
 
+    @future
     Scenario: A future producer emits a row variant the current renderer does not recognize
       Given the renderer recognizes the v0 row variants
       And the producer emits a scorecard at schema_version 1 containing one row of an unrecognized variant
@@ -156,6 +178,7 @@ Feature: Sticky PR scorecard display contract
       And the workflow run does not fail
       And the workflow logs name the unrecognized row variant
 
+    @future
     Scenario: A scorecard artifact at a higher schema_version is rendered with a degradation notice
       Given the renderer is built against schema_version 1
       And the producer emits a scorecard at schema_version 2
@@ -168,6 +191,7 @@ Feature: Sticky PR scorecard display contract
 
   Rule: Every failing gate is reachable from the ci-scorecard comment in one click
 
+    @future
     Scenario: The top failing gates are linked as Check Runs from the comment
       Given a pull request with five failing gates
       When the ci-scorecard comment is rendered
@@ -175,6 +199,7 @@ Feature: Sticky PR scorecard display contract
       And every Check Run link in the comment body is an absolute https:// URL pointing at github.com/{owner}/{repo}/runs/{check_run_id}
       And the comment also contains an "all checks" link to the full Check Runs list for the head commit
 
+    @future
     Scenario: Fork-PR Check Run links resolve against the fork's head commit
       Given a pull request opened from a fork
       When CI completes and the ci-scorecard comment is posted

--- a/crates/scorecard/tests/trybuild/green_works.rs
+++ b/crates/scorecard/tests/trybuild/green_works.rs
@@ -10,5 +10,5 @@ fn main() {
         anchor: "coverage".into(),
     };
 
-    let _row = Row::coverage_delta_green(common, "+0.3 pp".to_string());
+    let _row = Row::coverage_delta_green(common, 0.3, "+0.3 pp".to_string());
 }

--- a/crates/scorecard/tests/trybuild/red_struct_literal_must_fail.rs
+++ b/crates/scorecard/tests/trybuild/red_struct_literal_must_fail.rs
@@ -21,6 +21,7 @@ fn main() {
     let _row = Row::CoverageDelta {
         common,
         status: Status::Red,
+        delta_pp: -4.2,
         delta_text: "-4.2 pp".to_string(),
         failure_detail_md: None,
     };

--- a/crates/scorecard/tests/trybuild/red_struct_literal_must_fail.stderr
+++ b/crates/scorecard/tests/trybuild/red_struct_literal_must_fail.stderr
@@ -5,7 +5,8 @@ error[E0639]: cannot create non-exhaustive variant using struct expression
    |  ________________^
 22 | |         common,
 23 | |         status: Status::Red,
-24 | |         delta_text: "-4.2 pp".to_string(),
-25 | |         failure_detail_md: None,
-26 | |     };
+24 | |         delta_pp: -4.2,
+25 | |         delta_text: "-4.2 pp".to_string(),
+26 | |         failure_detail_md: None,
+27 | |     };
    | |_____^

--- a/crates/scorecard/tests/trybuild/red_with_none_must_fail.rs
+++ b/crates/scorecard/tests/trybuild/red_with_none_must_fail.rs
@@ -14,7 +14,7 @@ fn main() {
         anchor: "coverage".into(),
     };
 
-    // Third argument is `Option<String>::None`; the constructor takes
+    // Fourth argument is `Option<String>::None`; the constructor takes
     // `String`. rustc must reject with E0308 (mismatched types).
-    let _row = Row::coverage_delta_red(common, "-4.2 pp".to_string(), None);
+    let _row = Row::coverage_delta_red(common, -4.2, "-4.2 pp".to_string(), None);
 }

--- a/crates/scorecard/tests/trybuild/red_with_none_must_fail.stderr
+++ b/crates/scorecard/tests/trybuild/red_with_none_must_fail.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> tests/trybuild/red_with_none_must_fail.rs:19:71
+  --> tests/trybuild/red_with_none_must_fail.rs:19:77
    |
-19 |     let _row = Row::coverage_delta_red(common, "-4.2 pp".to_string(), None);
-   |                -----------------------                                ^^^^ expected `String`, found `Option<_>`
+19 |     let _row = Row::coverage_delta_red(common, -4.2, "-4.2 pp".to_string(), None);
+   |                -----------------------                                      ^^^^ expected `String`, found `Option<_>`
    |                |
    |                arguments to this function are incorrect
    |

--- a/crates/scorecard/tests/trybuild/red_without_detail_must_fail.rs
+++ b/crates/scorecard/tests/trybuild/red_without_detail_must_fail.rs
@@ -13,5 +13,5 @@ fn main() {
 
     // Missing the required `failure_detail_md: String` argument — Layer 1
     // typestate makes this a compile-time error, not a runtime check.
-    let _row = Row::coverage_delta_red(common, "-4.2 pp".to_string());
+    let _row = Row::coverage_delta_red(common, -4.2, "-4.2 pp".to_string());
 }

--- a/crates/scorecard/tests/trybuild/red_without_detail_must_fail.stderr
+++ b/crates/scorecard/tests/trybuild/red_without_detail_must_fail.stderr
@@ -1,8 +1,8 @@
-error[E0061]: this function takes 3 arguments but 2 arguments were supplied
+error[E0061]: this function takes 4 arguments but 3 arguments were supplied
   --> tests/trybuild/red_without_detail_must_fail.rs:16:16
    |
-16 |     let _row = Row::coverage_delta_red(common, "-4.2 pp".to_string());
-   |                ^^^^^^^^^^^^^^^^^^^^^^^------------------------------- argument #3 of type `String` is missing
+16 |     let _row = Row::coverage_delta_red(common, -4.2, "-4.2 pp".to_string());
+   |                ^^^^^^^^^^^^^^^^^^^^^^^------------------------------------- argument #4 of type `String` is missing
    |
 note: associated function defined here
   --> src/lib.rs
@@ -11,5 +11,5 @@ note: associated function defined here
    |            ^^^^^^^^^^^^^^^^^^
 help: provide the argument
    |
-16 |     let _row = Row::coverage_delta_red(common, "-4.2 pp".to_string(), /* String */);
-   |                                                                     ++++++++++++++
+16 |     let _row = Row::coverage_delta_red(common, -4.2, "-4.2 pp".to_string(), /* String */);
+   |                                                                           ++++++++++++++

--- a/crates/scorecard/tests/trybuild/red_works.rs
+++ b/crates/scorecard/tests/trybuild/red_works.rs
@@ -15,6 +15,7 @@ fn main() {
 
     let _row = Row::coverage_delta_red(
         common,
+        -4.2,
         "-4.2 pp".to_string(),
         "coverage dropped 4.2% on crate kikan".to_string(),
     );

--- a/crates/scorecard/tests/trybuild/yellow_works.rs
+++ b/crates/scorecard/tests/trybuild/yellow_works.rs
@@ -10,5 +10,5 @@ fn main() {
         anchor: "coverage".into(),
     };
 
-    let _row = Row::coverage_delta_yellow(common, "-0.6 pp".to_string());
+    let _row = Row::coverage_delta_yellow(common, -0.6, "-0.6 pp".to_string());
 }

--- a/tools/regen-types.sh
+++ b/tools/regen-types.sh
@@ -1,26 +1,33 @@
 #!/usr/bin/env bash
-# Regenerate the scorecard JSON Schema and the renderer's `types.d.ts`.
+# Regenerate the scorecard JSON Schemas and the renderer's `types.d.ts`.
 #
-# Two sequential steps:
-#   1. `cargo run -p scorecard --bin emit-schema` writes the canonical
-#      `.config/scorecard/schema.json` from the Rust types via schemars.
-#      The committed schema is the renderer's wire contract.
-#   2. `pnpm regen-types` (in `.github/scripts/scorecard/`) projects that
-#      schema into `.github/scripts/scorecard/types.d.ts` so the plain-JS
-#      renderer can JSDoc-reference the same shapes the producer emits.
-#      The `json-schema-to-typescript` version is pinned in that
-#      package's `package.json` — the single source of truth.
+# Three sequential steps:
+#   1. `cargo run -p scorecard --bin emit-schema` writes BOTH committed
+#      schemas from the Rust types via schemars:
+#        - `.config/scorecard/schema.json` — wire contract for the
+#          renderer.
+#        - `.config/scorecard/quality.config.schema.json` — operator
+#          contract for `quality.toml` (validated by ajv on the
+#          `scorecard-drift` CI gate).
+#      Default `--target both` means the binary needs no flags here.
+#   2. `pnpm regen-types` (in `.github/scripts/scorecard/`) projects the
+#      wire schema into `.github/scripts/scorecard/types.d.ts` so the
+#      plain-JS renderer can JSDoc-reference the same shapes the
+#      producer emits. The `json-schema-to-typescript` version is
+#      pinned in that package's `package.json` — the single source of
+#      truth.
 #
-# CI runs the same two commands (`scorecard-drift` job in `quality.yml`)
-# and fails on any uncommitted diff, so contributors who change the Rust
-# scorecard types must regen + commit both files. See the §Renderer types
-# section in `crates/scorecard/README.md`.
+# CI runs the same commands (`scorecard-drift` job in `quality.yml`)
+# and fails on any uncommitted diff, so contributors who change the
+# Rust scorecard types must regen + commit all three files. See the
+# §Renderer types section in `crates/scorecard/README.md`.
 #
 # Usage:
 #   tools/regen-types.sh
 set -euo pipefail
 
-SCHEMA_OUT=".config/scorecard/schema.json"
+WIRE_SCHEMA_OUT=".config/scorecard/schema.json"
+QUALITY_SCHEMA_OUT=".config/scorecard/quality.config.schema.json"
 TYPES_OUT=".github/scripts/scorecard/types.d.ts"
 
 # Resolve to repo root regardless of where the user invoked the script.
@@ -28,8 +35,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
 
-echo "Regenerating ${SCHEMA_OUT} from Rust source..."
-cargo run --quiet -p scorecard --bin emit-schema -- --out "${SCHEMA_OUT}"
+echo "Regenerating wire + operator schemas from Rust source..."
+cargo run --quiet -p scorecard --bin emit-schema
 
 echo "Installing renderer dependencies (frozen lockfile)..."
 pnpm install --filter @mokumo/scorecard-renderer... --frozen-lockfile
@@ -38,5 +45,6 @@ echo "Regenerating ${TYPES_OUT}..."
 pnpm --filter @mokumo/scorecard-renderer regen-types
 
 echo "Wrote:"
-echo "  ${SCHEMA_OUT}"
+echo "  ${WIRE_SCHEMA_OUT}"
+echo "  ${QUALITY_SCHEMA_OUT}"
 echo "  ${TYPES_OUT}"


### PR DESCRIPTION
## Summary

Sticky scorecard V3 (mokumo#768): introduces a producer-side threshold engine + an operator-tunable `quality.toml` surface for per-row warn/fail thresholds, with a hardcoded starter-wheels fallback when the operator config is absent or empty.

Six sequenced commits on this branch correspond to slices V1–V6b in the impl plan; a final review-pass commit addresses findings from the multi-agent review.

- **V1** — `crates/scorecard/src/threshold.rs` introduces the threshold types + `resolve_coverage_delta`. `Row::CoverageDelta` gains `delta_pp`; `Scorecard` gains `fallback_thresholds_active`. `aggregate` learns `--coverage-delta-pp`.
- **V2** — `parse_quality_toml` (cli-feature-gated) + `resolve_threshold_source` add the configured-thresholds branch. Producer aborts loudly on a malformed `quality.toml`; absent or empty file falls back. `.config/scorecard/quality.toml` ships as the operator-tunable surface.
- **V3** — `emit-schema` learns `--target scorecard|quality|both`; the operator schema `.config/scorecard/quality.config.schema.json` is generated from `ThresholdConfig` derives. `scorecard-drift` CI extends to `git diff --exit-code` both schemas + runs `tomllib → ajv-cli` over the committed `quality.toml`. `strip_nonstandard_number_formats` post-process keeps the operator schema ajv-strict.
- **V4** — Renderer mirrors the byte-stable strings `STARTER_PREAMBLE`, `FALLBACK_MARKER`, `PATH_HINT_COMMENT` from `crates/scorecard/src/threshold.rs`; emits them only when `fallback_thresholds_active` is true. New `bin/render-cli.js` is a stdin→stdout wrapper around `renderScorecardMarkdown`. Vitest pins all three signals byte-for-byte and asserts the renderer dependency hygiene (no TOML parser).
- **V5** — Cucumber-rs scenarios #5 + #6 of `scorecard_display.feature` are wired live; the other 16 stay `@future`. Step-defs assert producer behavior (artifact JSON state + `fallback_thresholds_active`). The doc-drift gate inside the `Then` steps `assert_eq` the Gherkin literals against all three Rust constants.
- **V6b** — `QUALITY.md#threshold-tuning` documents the operator surface in plain prose; `CHANGELOG.md` adds a user-facing line; `.github/workflows/v3-red-smoke.yml` is a one-shot label-gated smoke that posts a rendered Red-row scorecard as visual proof. The smoke workflow file is deleted as the **last commit** before merge so `main` never carries it.

The companion ADR amendment lives in the ops vault (`~/Github/ops/decisions/mokumo/adr-scorecard-crate-shape.md`, separate commit) and lands before this PR merges.

## Review-pass changes (final commit)

Multi-agent review surfaced 2 critical, 3 high, and 2 medium findings. All addressed:

- **C1** — `scorecard-aggregate` CI step was missing the V3-required `--coverage-delta-pp` flag; fixed with a `0.0` placeholder pending upstream coverage-delta computation.
- **C2** — Empty `quality.toml` now falls back (was loud-failing). Doc + .feature scenario title both promised this; behavior now matches.
- **H1** — `STARTER_PREAMBLE` and `PATH_HINT_COMMENT` are now byte-pinned cross-language (Gherkin literals + `assert_eq`), not just `FALLBACK_MARKER`.
- **H2** — `v3-red-smoke.yml` points `--quality-toml` at a non-existent path so the smoke comment exercises the fallback signals it claims to demonstrate.
- **H3** — Empirically verified `ajv-cli@5.0.0` catches `additionalProperties` violations at root, `[rows]`, and `[rows.coverage]` nesting levels. Locked in by a regression test on the operator schema shape.
- **M1** — Forward-dating sweep per CLAUDE.md item 18: stripped "V1/V2/V3", "council CN", "impl-plan §X" references from in-source comments.
- **M2** — `--coverage-delta-pp NaN` was silently resolving Green; now rejected at the CLI boundary by a finite-only value-parser.

## Acceptance gates

- [x] 102 lib + 1 schema_drift + 1 trybuild tests pass on `cargo test -p scorecard --features cli`.
- [x] 2 of 18 BDD scenarios pass (#5 + #6); 16 stay `@future` and skip cleanly.
- [x] `cargo check -p scorecard --no-default-features` succeeds (lib stays mokumo-deps-zero; `parse_quality_toml` cli-feature-gated).
- [x] `cargo clippy -p scorecard --features bdd --tests` clean.
- [x] 35 vitest tests pass; `tsc --noEmit` clean.
- [x] `bdd-lint` exits 0 (no dead specs introduced).
- [x] `cargo fmt --check -p scorecard` clean.
- [x] `cargo run -p scorecard --bin emit-schema` round-trips `.config/scorecard/schema.json` + `.config/scorecard/quality.config.schema.json` byte-identically.
- [x] All three byte-stable fallback strings pinned cross-language at scenario time.

Closes #768.

## Test plan

- [ ] `cargo test -p scorecard --features bdd` — full Rust suite + cucumber-rs scenarios.
- [ ] `pnpm vitest run` from `.github/scripts/scorecard/` — renderer + render-cli.
- [ ] `pnpm tsc --noEmit -p tsconfig.json` from `.github/scripts/scorecard/` — JSDoc/types lock.
- [ ] CI `scorecard-drift` job — schema + types regen drift gate.
- [ ] CI `scorecard-aggregate` job — producer smoke against the live PR.
- [ ] Apply `v3-red-smoke` label → confirm the Red-smoke comment appears with fallback signals visible in the rendered markdown.
- [ ] Final commit before merge: `git rm .github/workflows/v3-red-smoke.yml` (one-shot workflow deletion).

## Notes

`scorecard_display.feature` had its file-level `@future` tag stripped; 16 scenarios are now per-scenario `@future`. The `.feature` file is the executable spec — the deferred scenarios remain there as forward-shape documentation until their step-defs land in V4+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a threshold engine enabling operators to configure quality rules via `quality.toml` with warn/fail deltas for coverage scoring
  * Added fallback thresholds with distinct UI signaling when config is absent
  * Implemented coverage-delta status resolution with clear red/yellow/green verdicts

* **Bug Fixes**
  * Changed malformed config behavior to fail loudly with non-zero exit instead of silently falling back

* **Documentation**
  * Added threshold tuning guide describing configuration and fallback behavior
  * Updated schema regeneration documentation

* **Tests**
  * Added BDD integration test suite for scorecard display scenarios
  * Expanded unit test coverage for delta formatting and threshold resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->