### PR TITLE
docs: #742 #743 #744 #745 — Group A Wave 1 onboarding docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,11 @@
 
 ## Synchronized-Docs
 
-Files with `<!-- AUTO-GEN:name -->` / `<!-- /AUTO-GEN:name -->` markers have sections owned by the `docs-gen` binary (`tools/docs-gen`). Never edit between these markers by hand — the generator overwrites them on the next run.
+Two mechanisms keep code and prose in sync. Both live here so a contributor with one change in hand can find the other one they owe.
+
+### A. AUTO-GEN marker registry
+
+Files with `<!-- AUTO-GEN:name -->` / `<!-- /AUTO-GEN:name -->` markers have sections owned by the `docs-gen` binary (`tools/docs-gen`). **Never edit between these markers by hand** — the generator overwrites them on the next run.
 
 After changing any source listed below, regenerate and verify before pushing:
 
@@ -32,3 +36,14 @@ The registry of every owned section lives in `tools/docs-gen/src/registry.rs`. A
 | `AUTO-GEN:msrv` | `Cargo.toml` (`workspace.package.rust-version`) | `README.md` |
 
 CI enforces this via the `docs-drift` job: every PR regenerates all AUTO-GEN sections and fails if any target file differs from HEAD.
+
+### B. Paired-files rules
+
+When a class of code changes, a matching prose doc must change in the same PR. These rules are enforced socially today (PR review + checklist); CI enforcement is tracked in [issue #776](https://github.com/breezy-bays-labs/mokumo/issues/776).
+
+| When this changes… | …update this in the same PR | Why |
+|---|---|---|
+| Trust-boundary code: auth handlers, control / data plane split, container mount config, `DeploymentMode` posture | [`SECURITY.md`](SECURITY.md) | The threat-model document and the boundary code share one truth. A code change that shifts a boundary without a doc update silently moves the trust contract. |
+| New `pub` domain entity, repository trait, service, or wire-type under `crates/mokumo-*/` | [`LANGUAGE.md`](LANGUAGE.md) (vertical glossary) | The vertical glossary is the entry point for new contributors looking up shop-domain vocabulary. A new term that lacks an entry sends the reader to read the source. |
+| New `pub` platform entity, repository trait, service, or wire-type under `crates/kikan/`, `crates/kikan-events/`, `crates/kikan-mail/`, `crates/kikan-scheduler/`, `crates/kikan-socket/`, `crates/kikan-spa-sveltekit/`, `crates/kikan-tauri/`, `crates/kikan-cli/`, `crates/kikan-types/` | [`crates/kikan/LANGUAGE.md`](crates/kikan/LANGUAGE.md) (platform glossary) | Same rationale, kikan-side. The kikan glossary is the file that travels with the crate post-extraction; keeping it in sync at every PR avoids a one-shot reconciliation later. |
+| Architectural change touching the planes, the multi-tenant DB layout, the deployment posture, or the doc-set itself | [`CONTEXT.md`](CONTEXT.md) and (when structural) [`ARCHITECTURE.md`](ARCHITECTURE.md) | `CONTEXT.md` is the doc map; if a new doc lands or an existing one moves, the map must reflect it. `ARCHITECTURE.md` is the structural source of truth; section §11 also tracks ADRs by Y-statement. |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,70 @@
+# Mokumo Context
+
+> Orientation hub for new agents and human contributors. Tells you which document answers which question. **This file does not try to teach you the architecture** — that's [`ARCHITECTURE.md`](ARCHITECTURE.md)'s job, and it does it better than a summary would. This file's job is "I have a question, where do I look?"
+>
+> If you're trying to absorb the system end-to-end, read [`ARCHITECTURE.md`](ARCHITECTURE.md) cover-to-cover. If you're trying to find a specific answer fast, use the map below.
+
+---
+
+## What this repo ships
+
+Two products from one Cargo + pnpm workspace:
+
+- **Kikan** — a self-hosted Rust application platform. Engine, tenancy, migrations, backup, auth, control plane. Headless-first. Knows nothing about decoration shops.
+- **Mokumo** — a decorator garment management application. Quote → Artwork Approval → Production → Shipping → Invoice. The first vertical built on Kikan.
+
+The architectural why and how are in [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+---
+
+## Where to look for X
+
+| If you want to know… | Read… |
+|---|---|
+| **What the parts are and how they connect** (crates, dependency DAG, control / data plane, deployment topology, Graft trait, database layout, upgrade safety, invariants I1–I5, ADR index) | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
+| **What a term means** — `Engine`, `Graft`, `Profile`, `DeploymentMode`, `ActivityWriter` … | [`crates/kikan/LANGUAGE.md`](crates/kikan/LANGUAGE.md) (platform glossary) |
+| **What a term means** — `Customer`, `Quote`, `Decoration Method`, `Garment`, `SetupMode` … | [`LANGUAGE.md`](LANGUAGE.md) (vertical glossary) |
+| **Where vertical language meets platform language** (Profile, Active DB, Migration, User, Activity Log, Recovery Artifact, Setup Token) | The "Boundary terms" section at the bottom of either `LANGUAGE.md` |
+| **How to set up the toolchain, run tests, ship a PR** | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| **Day-to-day commands, conventions, gotchas** | [`CLAUDE.md`](CLAUDE.md) |
+| **Per-crate conventions** | The crate's `AGENTS.md` (e.g. [`crates/kikan/AGENTS.md`](crates/kikan/AGENTS.md), [`crates/mokumo-shop/AGENTS.md`](crates/mokumo-shop/AGENTS.md)) |
+| **How to report a vulnerability, what the threat model is, what's out of scope** | [`SECURITY.md`](SECURITY.md) |
+| **Why a decision was made** | The relevant ADR in `ops/decisions/mokumo/` (private). [`ARCHITECTURE.md` §11](ARCHITECTURE.md#11-decision-index) carries the load-bearing Y-statement summaries when the link is dead. |
+| **How synchronized docs and AUTO-GEN sections work** | [`AGENTS.md` §Synchronized-Docs](AGENTS.md#synchronized-docs) |
+
+---
+
+## First-time onboarding path
+
+For an agent or human starting cold, in order:
+
+1. **[`ARCHITECTURE.md`](ARCHITECTURE.md)** — read end-to-end. ~30 minutes. This is the real model of the system.
+2. **[`crates/kikan/LANGUAGE.md`](crates/kikan/LANGUAGE.md)** and **[`LANGUAGE.md`](LANGUAGE.md)** — skim. You'll come back to look up specific terms; the goal of the first read is just to know what's in each.
+3. **[`CLAUDE.md`](CLAUDE.md)** (or [`CONTRIBUTING.md`](CONTRIBUTING.md) for humans) — read the commands and conventions you'll use day-to-day.
+
+Skip on a first read: per-crate `AGENTS.md` files (read them when you touch the crate); ADR text (the Y-statements in `ARCHITECTURE.md` §11 are usually enough); ops standards (private repo; the public docs cite the load-bearing ones inline).
+
+---
+
+## How the docs stay honest
+
+Docs go stale when code changes and prose doesn't. Three mechanisms keep this set in sync:
+
+- **`<!-- AUTO-GEN:* -->` markers** — sections of a doc owned by `tools/docs-gen` and overwritten on every run. The `docs-drift` CI gate fails if the regenerated content differs from HEAD. The marker registry is in [`AGENTS.md` §Synchronized-Docs](AGENTS.md#synchronized-docs).
+- **Paired-files rules** — when a class of code changes, a specific doc must change in the same PR. Recorded in the same Synchronized-Docs section. CI enforcement of this rule is tracked in [issue #776](https://github.com/breezy-bays-labs/mokumo/issues/776).
+- **Per-doc reality checks** — each `LANGUAGE.md` ends with a "When this glossary is wrong" note. ARCHITECTURE.md ends with a "How to update this document" note. The convention: the code wins, the doc gets fixed in the same PR, every time.
+
+If you see a doc disagreeing with the code: the code wins. Fix the doc — in the same PR if you have one open, or open a new one.
+
+---
+
+## When in doubt
+
+- **Architecture question** → [`ARCHITECTURE.md`](ARCHITECTURE.md)
+- **What does this term mean?** → [`crates/kikan/LANGUAGE.md`](crates/kikan/LANGUAGE.md) or [`LANGUAGE.md`](LANGUAGE.md)
+- **Day-to-day commands** → [`CLAUDE.md`](CLAUDE.md)
+- **Per-crate conventions** → that crate's `AGENTS.md`
+- **Security concern** → [`SECURITY.md`](SECURITY.md)
+- **Why a decision was made** → ADRs in `ops/decisions/mokumo/` (private; Y-statements in [`ARCHITECTURE.md` §11](ARCHITECTURE.md#11-decision-index))
+
+If none of those answers your question, the answer probably belongs in one of the documents above. Open a discussion or DM the maintainer; we'd rather extend the doc than have you guess.

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -1,0 +1,240 @@
+# Mokumo Vertical Language
+
+> Glossary of vertical-domain vocabulary used inside `crates/mokumo-shop/`, `apps/web/` (the SvelteKit frontend), and the `apps/mokumo-*` binaries. This is the language a decorator-shop owner — and the engineer building for them — uses. Platform vocabulary (Engine, Graft, Profile, Tenancy, Migration runner, …) lives in [`crates/kikan/LANGUAGE.md`](crates/kikan/LANGUAGE.md), not here.
+>
+> Pair with [`ARCHITECTURE.md`](ARCHITECTURE.md) for structural detail and [`CONTEXT.md`](CONTEXT.md) for navigation across the doc set.
+
+## How to read this glossary
+
+- Terms are grouped by surface area (setup, customer, shop, order lifecycle, …) and alphabetical within each group.
+- Each entry names the canonical Rust symbol, wire-type, or frontend route (when there is one) and its location.
+- **Planned terms** that map to a frontend route stub but no backend implementation yet are marked **(planned)**. They appear in the glossary so the doc evolves in lockstep with the lifecycle build-out (M1 onward) rather than racing to catch up.
+- Boundary terms — vocabulary the vertical glossary shares with the platform — get their own [Boundary terms](#boundary-terms) section at the end with explicit cross-references.
+
+> **Provenance.** This file does **not** travel with `crates/kikan/` post-beta extraction. It belongs to Mokumo. The kikan platform glossary at [`crates/kikan/LANGUAGE.md`](crates/kikan/LANGUAGE.md) is the file that travels.
+
+---
+
+## 1. Setup and profile
+
+### Demo
+
+A profile created with `SetupMode::Demo`. Pre-populated with sample data so a shop owner can explore the UI before committing to a Production profile. Reset destructively via the `Demo Reset` flow.
+
+### MokumoApp
+
+`mokumo_shop::graft::MokumoApp` — the Mokumo `Graft` impl. Carries `MokumoAppState`, declares `db_filename = "mokumo.db"`, and implements the kikan `Graft` contract for vertical migrations, recovery directory, and data-plane routes.
+
+### MokumoAppState / MokumoState / MokumoShopState
+
+`mokumo_shop::state::*` — runtime state carried through the data-plane router. Holds repository handles, the activity writer, and shop-domain services.
+
+### Production
+
+A profile created with `SetupMode::Production`. Real shop data; never reset destructively. Backups are mandatory before migration; recovery requires a recovery artifact in the configured `recovery_dir`.
+
+### Setup
+
+The first-run wizard. Triggered when `kikan::detect_boot_state` returns "pristine" and `Graft::requires_setup_wizard(profile_kind)` returns `true`. Creates the initial admin user and the first profile.
+
+### SetupMode
+
+`kikan_types::SetupMode` — Mokumo's `ProfileKind`. Variants: `Demo`, `Production`. The wire-type lives in `kikan-types` because both the engine and the SPA name it. See [Boundary terms](#boundary-terms).
+
+---
+
+## 2. Customer
+
+### Customer
+
+`mokumo_shop::customer::Customer` — a person or organization the shop sells to. Carries `name`, contact fields, an optional `tag` taxonomy, and `created_at` / `updated_at`. Soft-deletable via `deleted_at`.
+
+### CustomerId
+
+`mokumo_shop::customer::CustomerId(Uuid)` — newtype wrapping a UUID. Bare `Uuid` or `String` IDs never appear in handler signatures; the newtype is the contract.
+
+### CustomerRepository / SqliteCustomerRepository
+
+`mokumo_shop::customer::{CustomerRepository, SqliteCustomerRepository}` — repo trait + SeaORM impl. The SQLite impl writes activity-log rows in the same transaction as the mutation (per the `ActivityWriter` contract).
+
+### CustomerService
+
+`mokumo_shop::customer::CustomerService<R>` — domain service over a `CustomerRepository`. Where validation / dedup / search logic lives.
+
+### CustomerResponse
+
+`mokumo_shop::types::CustomerResponse` — wire shape returned by customer endpoints.
+
+### CreateCustomer / UpdateCustomer
+
+Wire shapes for create / update requests.
+
+---
+
+## 3. Shop
+
+### Shop
+
+`mokumo_shop::shop::Shop` — the tenant's own brand identity inside a profile: name, address, tax ID, and contact information. One `Shop` row per profile.
+
+### Shop Logo
+
+The shop's logo image. Validated by `LogoValidator` (format, size, dimensions). Stored on disk under the profile's data directory; pointers in `meta.db` are backed up alongside the SQLite file.
+
+### LogoFormat / LogoError
+
+`mokumo_shop::shop::{LogoFormat, LogoError}` — supported formats (`PNG`, `JPEG`, `SVG`, …) and the validation-error union.
+
+### LogoValidator / ValidatedLogo
+
+`mokumo_shop::shop::{LogoValidator, ValidatedLogo}` — validator + validated newtype. Production code never accepts a raw `Bytes` blob; it accepts a `ValidatedLogo`.
+
+### ShopLogoService / ShopLogoRepository
+
+`mokumo_shop::shop::{ShopLogoService, ShopLogoRepository}` — service + repo trait for the logo artifact pipeline (write / fetch / replace / delete).
+
+---
+
+## 4. Sequence
+
+### FormattedSequence
+
+`mokumo_shop::sequence::FormattedSequence` — display-shaped sequence number after applying the configured prefix, padding, and increment rules.
+
+### SequenceGenerator / SqliteSequenceGenerator
+
+`mokumo_shop::sequence::{SequenceGenerator, SqliteSequenceGenerator}` — atomically-incrementing generator for shop-wide series (Order #, Invoice #, …). The SQLite impl uses an `INSERT … ON CONFLICT DO UPDATE … RETURNING` upsert against `number_sequences`, so allocation is single-statement and contention-safe.
+
+---
+
+## 5. Order lifecycle
+
+The garment lifecycle: **Quote → Artwork Approval → Production → Shipping → Invoice**. The frontend route shells exist under `apps/web/src/routes/(app)/{orders,quotes,artwork,production,shipping,invoices}`; the backend domain types are introduced milestone-by-milestone. Where a term is **(planned)**, the frontend stub exists but the Rust domain type does not yet.
+
+### Order **(planned)**
+
+The top-level container for a customer's work. Holds the lifecycle state, the line items, the customer, the financials, and a sequence number. Lands in M1.
+
+### Quote **(planned)**
+
+A pre-production pricing artifact. Once accepted, becomes the source-of-truth for the Order's pricing. Lands in M1 Wave 1 (Quote Foundation + Simple Merch — issue #173).
+
+### Artwork Approval **(planned)**
+
+The approval gate between Quote acceptance and Production. The customer reviews mockups; once approved, the order proceeds to Production. Frontend route stub at `apps/web/src/routes/(app)/artwork`; backend lands in M1 / M2.
+
+### Production **(planned)**
+
+The manufacturing stage. A garment moves through Production while it is being decorated. Frontend route stub at `apps/web/src/routes/(app)/production`; backend lands in M1 / M2.
+
+### Job **(planned)**
+
+A unit of production work — typically one decoration pass on one garment line. An Order may have multiple Jobs (front-print + back-print + tag-print). Lands with Production in M1 / M2.
+
+### Kanban **(planned)**
+
+The board view of work-in-progress Jobs and Orders. Frontend uses card-per-Order columns keyed on lifecycle state. Lands with Production.
+
+### Shipping **(planned)**
+
+The fulfillment stage. Tracks carriers, tracking numbers, ship-by-date, and partial shipments. Frontend route stub at `apps/web/src/routes/(app)/shipping`.
+
+### Invoice **(planned)**
+
+The billing artifact. Generated from the accepted Quote at Order completion or at scheduled milestones. Frontend route stub at `apps/web/src/routes/(app)/invoices`.
+
+---
+
+## 6. Decoration model
+
+How decoration techniques (screen print, embroidery, DTF, DTG, sublimation, …) compose into the shop. The full mechanism lands in Wave 8 per [`ARCHITECTURE.md` §9](ARCHITECTURE.md#9-extension-model-placeholder-until-wave-8). Vocabulary is captured here so the doc lines up when the code arrives.
+
+### Decoration Method **(planned)**
+
+The technique applied to a Garment — `ScreenPrint`, `Embroidery`, `DTF`, `DTG`, `Sublimation`, `HeatTransfer`, `DirectToGarment`. Each method is its own extension crate at `crates/extensions/{method}/` and is registered against `mokumo-shop`'s `ExtensionRegistry`.
+
+### Extension **(planned)**
+
+A crate at `crates/extensions/{technique}/` that contributes domain types, side tables (never extends shop base tables), and per-method pricing rules to `mokumo-shop`. Extensions register at `BootConfig` construction time and are activated per-profile via `meta.db.profile_active_extensions`.
+
+### Garment **(planned)**
+
+The physical apparel item being decorated — t-shirt, hoodie, hat, polo. The substrate of the work. Frontend route stub at `apps/web/src/routes/(app)/garments`. The backend Garment domain type lands in M1.
+
+### Line / LineKind **(planned)**
+
+A single line item on a Quote / Order / Invoice. The kind determines which extension owns the line's pricing — `LineKind::ScreenPrint` dispatches to the screen-printing extension. Per the Backstage-style typed dispatch decision documented in `adr-mokumo-extensions`.
+
+### Methodology **(planned)**
+
+How decoration is applied (screen print, embroidery, DTF, …). Independent axis from substrate — an extension declares which (substrate × methodology) combinations it supports.
+
+### Substrate **(planned)**
+
+What is being decorated — apparel (garments), hard goods (mugs, tumblers), banners. Independent axis from methodology.
+
+---
+
+## 7. Activity actions
+
+The Mokumo-vertical-emitted variants of `kikan_types::ActivityAction`. Adapters insert these inside the same transaction as the mutation they record.
+
+| Action | Triggered by |
+|---|---|
+| `CustomerCreated` | `SqliteCustomerRepository::create` |
+| `CustomerUpdated` | `SqliteCustomerRepository::update` |
+| `CustomerDeleted` | `SqliteCustomerRepository::soft_delete` |
+| `ShopLogoSet` | `SqliteShopLogoRepository::write` |
+| `ShopLogoCleared` | `SqliteShopLogoRepository::delete` |
+
+Platform-shaped actions (login, profile-switch, backup, restore, recovery) live in [`crates/kikan/LANGUAGE.md` §5](crates/kikan/LANGUAGE.md#5-activity-and-audit).
+
+---
+
+## 8. Demo Reset
+
+### Demo Reset
+
+A destructive reset of a `Demo` profile back to the seeded sample-data state. Uses kikan's `SidecarRecovery` mechanism: the engine swaps the live `mokumo.db` for a fresh seeded sidecar atomically. Never available on `Production` profiles. The control-plane endpoint is gated by `Graft::requires_setup_wizard` and the profile's kind.
+
+### RecoveryCleanupError
+
+`mokumo_shop::demo_reset::RecoveryCleanupError` — error union for sweeping stale recovery artifacts during a reset.
+
+---
+
+## 9. CLI entry points
+
+### kikan-cli
+
+The admin CLI binary, dispatched as a subcommand of `mokumo-server`. Talks to the running server over a Unix domain socket at mode 0600. Reachable only from the same host (physical access is the trust boundary). Subcommands cover profile lifecycle, backup / restore, diagnostics, and user administration.
+
+### mokumo-server
+
+The headless Linux/musl-compatible binary. Composes `kikan` + `kikan-socket` + `kikan-cli` + `kikan-spa-sveltekit` + `kikan-types` + `mokumo-shop`. Zero transitive Tauri dependency (invariant I3).
+
+### mokumo-desktop
+
+The Tauri desktop binary. Composes `kikan` + `kikan-tauri` + `kikan-spa-sveltekit` + `mokumo-shop` + `kikan-types`. Native window, tray, single-instance, auto-updater.
+
+---
+
+## Boundary terms
+
+Vocabulary that the vertical glossary shares with [`crates/kikan/LANGUAGE.md`](crates/kikan/LANGUAGE.md) — the seam where vertical language meets platform language.
+
+| Term | Vertical side | Platform side |
+|---|---|---|
+| **Profile / ProfileKind** | Mokumo's `ProfileKind` is `kikan_types::SetupMode` (`Demo`, `Production`). The wire-type lives in `kikan-types` because the SPA names it. See §1 above. | Kikan owns the `Profile` row, repository, lifecycle, and tenancy resolution. See [`crates/kikan/LANGUAGE.md` §2](crates/kikan/LANGUAGE.md#2-tenancy-and-profiles). |
+| **Active DB** | `MokumoApp::db_filename` returns `"mokumo.db"`. The vertical chooses the filename. | Kikan owns init, pragmas, pool, migration runner, and backup. See [`crates/kikan/LANGUAGE.md` §2](crates/kikan/LANGUAGE.md#2-tenancy-and-profiles). |
+| **Migration** | Mokumo's per-profile migrations live under `crates/mokumo-shop/src/migrations/` and are contributed via `MokumoApp::migrations`. They name vertical tables (`customers`, `shop`, `number_sequences`, `activity_log`, …). | Kikan owns the `Migration` trait, the per-profile DAG runner, transactional application, and `MigrationTarget` routing. See [`crates/kikan/LANGUAGE.md` §6](crates/kikan/LANGUAGE.md#6-migrations-backups-restore). |
+| **User** | Mokumo's auth handlers (login / forgot-password / recover / reset / regenerate-recovery-codes) sit in `crates/mokumo-shop/src/auth/`. They route through the kikan `Backend` and never touch the user model. | Kikan owns `User`, `UserId`, `Backend`, `UserService`, password hashing, and login rate-limiting. See [`crates/kikan/LANGUAGE.md` §4](crates/kikan/LANGUAGE.md#4-auth-sessions-and-recovery). |
+| **Activity Log** | Mokumo emits log rows from adapter-layer mutations (see §7 above). Action variants for vertical mutations live in `kikan_types::ActivityAction` so the SPA can name them too. | Kikan owns the table shape, the `ActivityWriter` trait, and the SQLite impls. See [`crates/kikan/LANGUAGE.md` §5](crates/kikan/LANGUAGE.md#5-activity-and-audit). |
+| **Recovery Artifact** | `MokumoApp::recovery_dir(profile_id)` chooses the directory; `mokumo_shop::auth::recovery_artifact` defines the file format. | Kikan owns the watcher, the validation mechanism, and `RecoveryArtifactLocation`. See [`crates/kikan/LANGUAGE.md` §4](crates/kikan/LANGUAGE.md#4-auth-sessions-and-recovery). |
+| **Setup Token** | `MokumoApp::requires_setup_wizard(profile_kind)` returns `true` for `Demo` and `Production`. | Kikan owns the `SetupTokenSource` flow and the bootstrap. See [`crates/kikan/LANGUAGE.md` §4](crates/kikan/LANGUAGE.md#4-auth-sessions-and-recovery). |
+
+---
+
+## When this glossary is wrong
+
+If a term in this file disagrees with the code: the code wins, this file is stale. Open a PR that updates the glossary in the same diff as the code change. The Synchronized-Docs rule in [`AGENTS.md`](AGENTS.md#synchronized-docs) calls this out as a paired-files invariant — a `pub` symbol added under `crates/mokumo-*` should arrive with its glossary entry, not "in a follow-up."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -136,6 +136,20 @@ For self-hosters running Mokumo on a server they own:
 
 ---
 
+## Related ADRs
+
+The decisions behind the trust boundaries and threat-model choices above live in `ops/decisions/mokumo/` (private repo). The full Y-statement summaries for the architectural ADRs are in [`ARCHITECTURE.md` §11](ARCHITECTURE.md#11-decision-index); the security-shaped ADRs below are the ones load-bearing for the contents of this document.
+
+| ADR | What it pins |
+|---|---|
+| `adr-control-plane-data-plane-split` | Admin handlers stay reachable only over loopback (Tauri webview) or the Unix domain socket at mode 0600 (CLI). LAN clients never reach the control plane. Physical filesystem / shell access is the trust boundary for admin operations. |
+| `adr-auth-security-under-cp-dp` | Session and recovery-flow handling under the control-plane / data-plane split: argon2id password hashing, login rate-limiting (per-user always; per-IP in `Internet` / `ReverseProxy`), opaque `RecoverySessionId` so rejected sessions can't enumerate emails, TOCTOU-safe atomic remove+reinsert in the recovery PIN registry, and a uniform 400 response across recovery rejection modes. |
+| `adr-container-security-hardening` (with the 2026-04-29 amendment) | Container-runtime posture for cmux / Docker hosts: dev-container `RUSTUP_TOOLCHAIN` / `RUSTC_WRAPPER` overrides, `cargo-deny` invocation envelope, `/workspace` mount as the worktree (no nested git worktrees inside the container), and the operational guidance behind the [Operational hardening checklist](#operational-hardening-checklist) above. |
+
+The decisions behind invariants I1–I5 (workspace boundary purity, headless Tauri-free build, one-way DAG) live in `adr-workspace-split-kikan` and are summarized in [`ARCHITECTURE.md` §8 Quality invariants](ARCHITECTURE.md#8-quality-invariants).
+
+---
+
 ## Security standards we follow
 
 - **OWASP ASVS L1** (target) — application security verification standard, level 1, for self-hosted commercial software.

--- a/crates/kikan/LANGUAGE.md
+++ b/crates/kikan/LANGUAGE.md
@@ -1,0 +1,472 @@
+# Kikan Platform Language
+
+> Glossary of platform vocabulary used inside `crates/kikan/` and its sibling adapter / SubGraft crates. **This file travels with `crates/kikan/` post-beta extraction (Mokumo M16)** — it should remain accurate for any future kikan consumer, not just Mokumo. Vertical-domain language (customer, garment, quote, …) lives in [`/LANGUAGE.md`](../../LANGUAGE.md), not here.
+>
+> Pair with [`ARCHITECTURE.md`](../../ARCHITECTURE.md) for structural detail and [`/CONTEXT.md`](../../CONTEXT.md) for navigation across the doc set.
+
+## How to read this glossary
+
+- Terms are grouped by surface area (composition seam, tenancy, control / data plane, …) and alphabetical within each group.
+- Each entry names the canonical Rust symbol or wire-type (when there is one) and its module path.
+- Boundary terms — vocabulary the kikan glossary shares with the consuming vertical — get their own [Boundary terms](#boundary-terms) section at the end with explicit cross-references to the vertical glossary.
+
+---
+
+## 1. Composition seam
+
+How the engine and the application meet at compile time.
+
+### Application
+
+The vertical that grafts onto the engine — Mokumo today, a future second consumer post-beta. The Application supplies the `Graft` impl. Kikan never names a specific Application by identifier (invariant I1).
+
+### BootConfig
+
+`kikan::BootConfig` — engine boot-time configuration. Carries the `Graft`, registered `SubGraft` instances, and `DataPlaneConfig`. Constructed by the binary; consumed by `Engine::boot`.
+
+### Engine
+
+`kikan::Engine<G: Graft>` — the platform abstraction. Composes platform tables, vertical tables, SubGraft contributions, the data-plane router, the control-plane handlers, and the activity log into one runtime. `Engine::boot` runs the per-profile migration DAG, opens pools, validates the boot state, and returns a ready engine.
+
+### EngineContext
+
+`kikan::EngineContext` — handle returned from `Engine::boot`. Exposes the active `PlatformState`, the composed `axum::Router`, and shutdown hooks. The binary owns it for the process lifetime.
+
+### Graft
+
+`kikan::Graft` — the application's contract with the engine. Trait with associated types for app-chosen state (`AppState`) and tenant-kind enum (`ProfileKind`), plus methods for the per-profile DB filename, recovery directory, vertical migrations, and data-plane routes. Dependency inversion: kikan depends on the abstraction; the application supplies the concrete values.
+
+### PlatformState
+
+`kikan::PlatformState` — runtime state held by the engine: pools, mDNS status, sessions store, control-plane state. Accessible through Axum extractors.
+
+### SelfGraft
+
+`kikan::SelfGraft` — kikan's own contribution to the per-profile migration DAG. Distinct from `Graft` in that it carries only platform-owned tables (`users`, `activity_log`, `profile_active_extensions`, `schema_version`).
+
+### SubGraft
+
+`kikan::SubGraft` — opt-in platform satellite. Each is its own crate (`kikan-events`, `kikan-mail`, `kikan-scheduler`) and contributes some mix of migrations, runtime state, and routes. Apps register the ones they need at `BootConfig` construction time. Builder-time activation, not Cargo-feature activation, so the same binary can run different SubGraft sets at runtime.
+
+---
+
+## 2. Tenancy and profiles
+
+Multi-tenant SQLite: one platform DB plus N per-profile DBs.
+
+### Active DB
+
+The per-profile database currently bound to a request — `mokumo.db` for Mokumo, whatever the consuming vertical's `Graft::db_filename()` returns for a future consumer. The engine resolves it through `Tenancy` and serves it via the `ProfileDb` extractor. Distinct from `meta.db`, which is platform-owned and shared across profiles.
+
+### Active Profile
+
+`kikan::profile_db::ActiveProfile` — the profile currently bound to the request. Set by tenancy resolution before handlers run.
+
+### Profile
+
+`kikan::meta::Profile` — a tenant unit. Each profile has its own per-profile DB, its own backup chain, and its own migration history. Stored in `meta.db.profiles` with a `slug`, a display name, a `kind` (the application's `ProfileKind`, stringified), timestamps, and an archive flag.
+
+### ProfileDb
+
+`kikan::ProfileDb` — Axum extractor that yields the SeaORM connection bound to the active profile's DB. Handlers operating on per-profile data take `ProfileDb` as an argument; switching profiles is a single connection-routing change.
+
+### ProfileDirName
+
+`kikan::tenancy::ProfileDirName` — newtype wrapping the on-disk directory name for a profile. Derived deterministically from the slug; never user-supplied freeform text.
+
+### ProfileId
+
+`kikan::ProfileId<K>` — typed identifier carrying the application's `ProfileKind` `K` so downstream code can pattern-match on tenant kind without a stringly-typed lookup.
+
+### ProfileKind
+
+The application-defined enum of tenant kinds. Mokumo's is `kikan_types::SetupMode` (`Demo`, `Production`); a different application would supply a different enum. Kikan stores it via the `Display` + `FromStr` bounds on the associated type and never names a variant in production code (invariant I1/strict).
+
+### ProfileRepo
+
+`kikan::meta::ProfileRepo` — repository trait for `meta.db.profiles`. `SeaOrmProfileRepo` is the production impl.
+
+### Slug
+
+`kikan::Slug` — short, URL-safe profile identifier. Validated against `RESERVED_SLUGS` and `MAX_SLUG_LEN`.
+
+### Tenancy
+
+`kikan::Tenancy` — service that resolves an inbound request to its active profile. Reads the `Host:` header (LAN), `X-Forwarded-Host` (reverse proxy), or session state, against the configured host-allow-list.
+
+---
+
+## 3. Control plane and data plane
+
+Two logical surfaces, one Axum router. See [`ARCHITECTURE.md` §4](../../ARCHITECTURE.md#4-control-plane-vs-data-plane).
+
+### Control Plane
+
+Admin operations: profile lifecycle, migrate / dry-run, backup / restore, diagnostics, audit, recovery. Implemented as plain `async fn` returning `Result<T, ControlPlaneError>` in `kikan::control_plane::*`. Reachable only over loopback (Tauri webview) or a Unix domain socket at mode 0600 (CLI). LAN clients are blocked by the host-allow-list middleware.
+
+### ControlPlaneError
+
+`kikan::ControlPlaneError` — narrow handler-level error type. Variants are mapped to `(ErrorCode, http_status)` pairs by the data-plane HTTP adapter and rendered directly by the UDS adapter; both transports yield the same wire shape, pinned by `control_plane_error_variants.feature`.
+
+### ControlPlaneState
+
+`kikan::ControlPlaneState` — admin-state container passed into control-plane handlers. Holds repo handles, the activity writer, and the auth backend.
+
+### Data Plane
+
+Business surface: customers, quotes, invoices, kanban, products, inventory, sessions, auth. Reachable from all client surfaces per the active `DeploymentMode`. Vertical routes contributed via `Graft::data_plane_routes`; platform routes (auth, health, users) contributed by kikan.
+
+### DataPlaneConfig
+
+`kikan::DataPlaneConfig` — runtime middleware configuration. Carries `DeploymentMode`, host patterns, rate-limit windows, and CSRF posture. The middleware stack reads from it; nothing else has to.
+
+### DeploymentMode
+
+`kikan::DeploymentMode` — enum: `Lan`, `Internet`, `ReverseProxy`. Selects cookie flags, CSRF gating, per-IP rate limiting, mDNS, and host-allow-list shape at boot. A fourth `TailscaleMesh` mode is post-M00 work. See [`ARCHITECTURE.md` §3](../../ARCHITECTURE.md#3-deployment-topology) for the matrix.
+
+### HostPattern
+
+`kikan::HostPattern` — entry in the host-allow-list. A pattern is either a literal host or a controlled wildcard; `loopback` and `{shop}.local` are common entries.
+
+### SpaMount
+
+`kikan::data_plane::spa::SpaMount` — handle returned when an SPA source is mounted into the data-plane router. Determines cache behavior and the JSON-404 catch-all on `/api/**`.
+
+### SpaSource
+
+`kikan::data_plane::spa::SpaSource` — adapter trait for SPA delivery. `kikan-spa-sveltekit` provides the SvelteKit impls; the binary picks one (embedded or on-disk) and injects via `MokumoApp::with_spa_source`. Kept out of `kikan` itself so the engine builds without `apps/web/build/` (invariant I5).
+
+---
+
+## 4. Auth, sessions, and recovery
+
+### AuthenticatedUser
+
+`kikan::auth::AuthenticatedUser<K>` — Axum extractor for a logged-in user. Generic over the application's `ProfileKind` `K`.
+
+### Backend
+
+`kikan::auth::Backend<K>` — `axum-login` backend. Verifies credentials, loads users, owns rate-limit interaction with login attempts.
+
+### Credentials
+
+`kikan::auth::Credentials` — login input. Email + password.
+
+### PinId
+
+`kikan::PinId` — short, opaque identifier for a recovery PIN drop. Validated by `PinIdError`.
+
+### Recovery Artifact
+
+A file the operator writes into the application's `Graft::recovery_dir(profile_id)` to authorize a recovery operation. Kikan owns the watching + validation mechanism; the application owns the directory location.
+
+### RecoveryArtifactLocation
+
+`kikan::RecoveryArtifactLocation` — typed pointer to where on disk the artifact is expected.
+
+### RecoveryError
+
+`kikan::RecoveryError` — error union returned from recovery operations. Maps to a uniform 400 across all rejection modes per the recovery-token security pattern (TOCTOU-safe atomic remove+reinsert in `DashMap`).
+
+### RecoverySessionId
+
+The opaque identifier issued at the start of a recovery flow. It is the storage key, *not* the user's email — so an attacker cannot enumerate emails from rejected sessions.
+
+### Sessions
+
+`kikan::Sessions` — `tower-sessions` SQLite store wrapped in an `Arc`. Owns ephemeral session state (`session.db`); login / logout never touches the platform or vertical DBs.
+
+### SetupTokenSource
+
+`kikan::SetupTokenSource` — input variants for the first-run bootstrap token (PIN file, env var, etc.).
+
+### User / UserId / RoleId
+
+`kikan::auth::{User, UserId, RoleId}` — platform user model. Lives in `meta.db.users`, never per-profile. A user can be granted access to multiple profiles within one platform install.
+
+### UserRepository / SeaOrmUserRepo
+
+`kikan::auth::{UserRepository, SeaOrmUserRepo}` — repository trait + production impl. Composite operations (set-role-and-log, reset-password-and-log) run inside transactions so the activity-log row is atomic with the mutation.
+
+### UserService
+
+`kikan::auth::UserService<R>` — domain service over a `UserRepository`. Where role / permission logic lives.
+
+---
+
+## 5. Activity and audit
+
+### Activity Log
+
+The kikan-owned audit table. Mokumo and any future vertical write to it through the same writer trait; queries through the same repository. Lives in each per-profile DB (not `meta.db`).
+
+### ActivityAction
+
+`kikan_types::ActivityAction` — wire enum naming the kind of action recorded (`UserCreated`, `LoginSucceeded`, `BackupStarted`, …). Lives in `kikan-types` because both kikan and the SPA name it.
+
+### ActivityLogEntry
+
+`kikan::ActivityLogEntry` — row shape. Carries `actor_id` (a transport-native string tag, **not** an FK to users — `'system'` for system-initiated actions), `action`, `resource_kind`, `resource_id`, `metadata`, and a timestamp.
+
+### ActivityLogRepository
+
+`kikan::activity::ActivityLogRepository` — read-side trait over the activity log.
+
+### ActivityWriter
+
+`kikan::ActivityWriter` — adapter-side trait that adapter repos call to insert log rows *inside the same transaction* as the mutation they record. This makes logging part of the mutation contract — atomicity is guaranteed by the adapter, not the service layer.
+
+### SqliteActivityWriter / SqliteActivityLogRepo
+
+`kikan::SqliteActivityWriter` and `kikan::activity::SqliteActivityLogRepo` — SQLite implementations.
+
+---
+
+## 6. Migrations, backups, restore
+
+### Backup
+
+A `VACUUM INTO`-snapshot of `meta.db` and the active per-profile DB written *before* every migration batch. Filename pattern: `backups/{db}.bak-vX.Y.Z-{timestamp}.db`. See [`ARCHITECTURE.md` §7](../../ARCHITECTURE.md#7-upgrade-safety-model).
+
+### BackupResult / BackupError
+
+`kikan::backup::{BackupResult, BackupError}` — outcome and error union from `create_backup`.
+
+### Boot State
+
+`kikan::BootState` — detected state at boot: pristine, healthy, partially-migrated, sidecar-recovery-needed. Drives setup wizard routing on first run.
+
+### BootStateDetectionError
+
+Error returned when boot-state detection itself fails (corrupted `meta.db`, unreadable directory).
+
+### Bundle / BundleManifest / BundleManifestEntry
+
+`kikan::meta::{create_bundle, restore_bundle, BundleManifest, BundleManifestEntry}` — multi-DB backup bundle for full-install snapshots. Used by the diagnostics / support bundle and full-restore paths.
+
+### DbInBundle
+
+`kikan::DbInBundle<'a>` — pointer to a single DB file inside a bundle.
+
+### GraftId
+
+`kikan::GraftId` — opaque ownership tag on a migration. Lets the runner build a per-profile DAG that mixes platform migrations (`SelfGraft`), vertical migrations (`Graft::migrations`), and SubGraft migrations.
+
+### Migration
+
+`kikan::Migration` — trait every migration implements. Must return `Some(true)` from `use_transaction()` (atomic SQLite migrations). The runner acquires every connection in the pool simultaneously to make `FK=ON` apply uniformly.
+
+### MigrationConn
+
+`kikan::migrations::MigrationConn` — wrapper over a `DatabaseTransaction` that exposes the SeaORM `SchemaManager` to migrations.
+
+### MigrationRef
+
+`kikan::MigrationRef` — DAG node: `{id, target, after}` plus the migration itself.
+
+### MigrationTarget
+
+`kikan::MigrationTarget` — enum: `Meta` (the platform DB) vs `Profile` (per-profile DB). The runner routes each migration to its target.
+
+### Restore / RestoreResult / RestoreError
+
+`kikan::backup::{restore_from_backup, RestoreResult, RestoreError}` — the reverse operation. Validates the source through `validate_candidate` before writing.
+
+### RestoreTarget
+
+`kikan::RestoreTarget` — destination of a restore operation (a specific profile, or the meta DB).
+
+### SidecarRecovery / SidecarRecoveryDiagnostic
+
+`kikan::{SidecarRecovery, SidecarRecoveryDiagnostic}` — sidecar swap mechanism for demo-reset and restore flows; runs outside SQLite's locking protocol, so requires single-Engine-per-data-directory.
+
+### UpgradeOutcome / UpgradeError
+
+`kikan::meta::upgrade::{UpgradeOutcome, UpgradeError}` — boot-time upgrade result.
+
+---
+
+## 7. Eventing
+
+`kikan-events` — SubGraft.
+
+### BroadcastEventBus
+
+`kikan_events::BroadcastEventBus` — Tokio broadcast wrapper. Default `EventBus` implementation.
+
+### Event
+
+`kikan_events::Event` — marker trait (`Clone + Send + Sync + 'static`).
+
+### EventBus
+
+`kikan_events::bus::EventBus` — pub/sub abstraction. Apps depend on the trait, not a specific impl.
+
+### EventBusError
+
+Error returned by publish operations.
+
+### EventBusSubGraft
+
+`kikan_events::EventBusSubGraft` — registration handle. Apps add it via `BootConfig::with_subgraft`.
+
+### FanoutChannel
+
+`kikan_events::FanoutChannel<T>` — generic fan-out channel used internally by the bus.
+
+### HealthEvent / LifecycleEvent / MigrationEvent / ProfileEvent
+
+Domain event types published by kikan: HealthResolver state transitions, lifecycle callbacks, migration progress, and profile create / archive / switch events.
+
+---
+
+## 8. Mail
+
+`kikan-mail` — SubGraft.
+
+### CapturingMailer
+
+Test-only `Mailer` impl that captures messages into an in-memory vec. Used by integration tests.
+
+### EmailAddress
+
+`kikan_mail::EmailAddress` — newtype over a validated address. Constructed via `EmailAddress::parse`.
+
+### LettreMailer
+
+Production SMTP mailer over `lettre`.
+
+### MailError
+
+Error union for mail operations.
+
+### Mailer
+
+The trait every mailer implements. `send(message: OutgoingMail) -> Result<(), MailError>`.
+
+### MailerSubGraft
+
+Registration handle.
+
+### OutgoingMail
+
+`kikan_mail::OutgoingMail` — wire shape for a message to send (from / to / subject / body / template hints).
+
+### SmtpConfig
+
+`kikan_mail::SmtpConfig` — SMTP server configuration.
+
+---
+
+## 9. Scheduler
+
+`kikan-scheduler` — SubGraft.
+
+### ApalisScheduler
+
+Production `Scheduler` impl over the `apalis` crate.
+
+### ImmediateScheduler
+
+Synchronous in-process scheduler. Runs jobs on submission. Useful for tests and for shop owners who don't need a background worker.
+
+### JobId
+
+Opaque identifier for an enqueued job.
+
+### JobPayload
+
+Trait every job payload implements (`Serialize + Deserialize + Send + Sync + 'static`).
+
+### PendingJob
+
+`kikan_scheduler::PendingJob` — wire shape for an enqueued-but-not-yet-run job.
+
+### Scheduler
+
+The trait. `schedule(job)`, `cancel(id)`, `pending_jobs()`.
+
+### SchedulerError
+
+Error union.
+
+### SchedulerSubGraft
+
+Registration handle.
+
+---
+
+## 10. SPA delivery
+
+`kikan-spa-sveltekit` — adapter crate. Two `SpaSource` impls:
+
+### CompositeSpaSource
+
+`kikan::data_plane::spa::CompositeSpaSource` — composite that overlays multiple sources (e.g. a tenant-specific override on top of the default SPA build).
+
+### SvelteKitSpa
+
+`kikan_spa_sveltekit::SvelteKitSpa<A: RustEmbed>` — embedded-SPA source for single-binary delivery. The binary supplies a `RustEmbed` of `apps/web/build/`.
+
+### SvelteKitSpaDir
+
+`kikan_spa_sveltekit::SvelteKitSpaDir { dir }` — on-disk source for `mokumo-server --spa-dir <PATH>`. Boot-validates `<PATH>/index.html` then mounts.
+
+---
+
+## 11. Diagnostics, server info, and version
+
+### AppDiagnostics
+
+`kikan_types::AppDiagnostics` — top-level diagnostics envelope (system + database + runtime + os).
+
+### KikanVersionResponse
+
+`kikan_types::KikanVersionResponse` — wire shape for `GET /api/platform/v1/kikan-version`.
+
+### MdnsStatus / SharedMdnsStatus
+
+`kikan::{MdnsStatus, SharedMdnsStatus}` — mDNS advertise state (off, advertising, error).
+
+### ServerInfoResponse
+
+Wire shape for the public server-info endpoint (no auth required).
+
+---
+
+## 12. Errors
+
+### AppError
+
+`kikan::AppError` — wide HTTP transport error. Renders `(ErrorCode, http_status, ErrorBody)` to the client. Distinct from `ControlPlaneError` (narrow, handler-level); `From<ControlPlaneError> for AppError` bridges them on the HTTP path.
+
+### DomainError
+
+`kikan::DomainError` — generic over a domain-specific error. Wraps a domain error in an HTTP-transport-shaped result without leaking the domain enum to the wire.
+
+### ErrorBody / ErrorCode
+
+`kikan_types::{ErrorBody, ErrorCode}` — wire shape: `{"code": "...", "message": "...", "details": null}`. Hurl smoke tests assert on `$.code`; Hurl assertions on `$.error` will silently pass on a missing field, so the convention is `$.code`.
+
+---
+
+## Boundary terms
+
+Vocabulary that the kikan glossary shares with [`/LANGUAGE.md`](../../LANGUAGE.md) — the seam where platform language meets vertical language. Each entry below names the kikan-side concept and points at the vertical-side counterpart.
+
+| Term | Kikan side | Vertical side |
+|---|---|---|
+| **Profile** | The tenant unit. Kikan owns `Profile`, `ProfileId`, `ProfileRepo`, the meta-DB row shape, the lifecycle (create / archive / switch). See §2 above. | The vertical names its profiles via `ProfileKind`. Mokumo's is `SetupMode` with variants `Demo` / `Production`. See [`/LANGUAGE.md` § Setup and profile](../../LANGUAGE.md). |
+| **ProfileKind** | An associated type on `Graft`. Kikan stores it through `Display` / `FromStr` and pattern-matches on it via `Graft` hooks (`all_profile_kinds`, `default_profile_kind`, `requires_setup_wizard`, `auth_profile_kind`). | The vertical defines the concrete enum. See [`/LANGUAGE.md` § Setup and profile](../../LANGUAGE.md). |
+| **Active DB** | Per-profile DB whose filename comes from `Graft::db_filename()`. Kikan owns init, pragmas, pool, migration runner, backup. See §2 above. | The vertical chooses the filename. Mokumo returns `"mokumo.db"`. See [`/LANGUAGE.md` § Setup and profile](../../LANGUAGE.md). |
+| **Migration** | Kikan owns the `Migration` trait, the per-profile migration DAG runner, transactional application, and `MigrationTarget` routing. See §6 above. | The vertical contributes its migrations through `Graft::migrations()`. SubGrafts contribute their own. See [`/LANGUAGE.md` § Migration](../../LANGUAGE.md). |
+| **User** | Platform user model in `meta.db.users`. Kikan owns `User`, `UserId`, `Backend`, `UserService`, `UserRepository`, password hashing, and login rate-limiting. See §4 above. | The vertical's auth handlers route through the kikan `Backend`. Mokumo extends auth UX (recovery, reset, sidecar PIN) but never the user model. See [`/LANGUAGE.md` § Auth](../../LANGUAGE.md). |
+| **Activity Log** | Kikan owns the table shape, `ActivityWriter`, `ActivityLogRepository`, and the SQLite impls. See §5 above. | The vertical emits log rows from adapter-layer mutations *inside the same transaction* as the mutation. Action variants live in `kikan_types::ActivityAction`. See [`/LANGUAGE.md` § Activity](../../LANGUAGE.md). |
+| **Recovery Artifact** | Kikan owns the watching mechanism, validation, and `RecoveryArtifactLocation` typing. See §4 above. | The vertical chooses the directory via `Graft::recovery_dir(profile_id)` and the artifact format. See [`/LANGUAGE.md` § Auth](../../LANGUAGE.md). |
+| **Setup Token** | Kikan owns `SetupTokenSource` and the bootstrap flow. | The vertical decides whether its profiles need a setup wizard via `Graft::requires_setup_wizard(profile_kind)`. See [`/LANGUAGE.md` § Setup](../../LANGUAGE.md). |
+
+---
+
+## When this glossary is wrong
+
+If a term in this file disagrees with the code: the code wins, this file is stale. Open a PR that updates the glossary in the same diff as the code change. The Synchronized-Docs rule in [`AGENTS.md`](../../AGENTS.md#synchronized-docs) calls this out as a paired-files invariant — a `pub` symbol added under `crates/kikan-*` should arrive with its glossary entry, not "in a follow-up."


### PR DESCRIPTION
## Summary

Lands the four Group A Wave 1 onboarding docs in one PR — they cross-reference each other, so shipping them together avoids dangling links and gives reviewers one coherent surface to assess.

- **`crates/kikan/LANGUAGE.md` (#744)** — kikan platform glossary, grouped by surface area (composition seam, tenancy, control/data plane, auth, activity, migrations, events, mail, scheduler, SPA delivery, diagnostics, errors). Carries the *"this file travels with `crates/kikan/` post-beta extraction (M16)"* note.
- **`LANGUAGE.md` (#743)** — Mokumo vertical glossary at repo root. Honest about implemented terms (customer, shop, sequence, demo-reset, setup) vs. frontend-route stubs marked **(planned)** (order, quote, artwork, garment, production, job, kanban, shipping, invoice). Decoration model vocabulary captured ahead of the Wave 8 build-out.
- **`CONTEXT.md` (#745)** — orientation hub: a *"where do I look for X"* map, not duplication of `ARCHITECTURE.md`. Names the synchronized-docs mechanisms by which the doc set stays honest.
- **`SECURITY.md` (#742)** — incremental delta only; the file was already substantial. Adds a *Related ADRs* table pinning `adr-control-plane-data-plane-split`, `adr-auth-security-under-cp-dp`, and `adr-container-security-hardening` (with the 2026-04-29 amendment) to the contents of the doc.

Plus the housekeeping:

- **`AGENTS.md` §Synchronized-Docs** split into two tables — *AUTO-GEN marker registry* (existing AUTO-GEN:msrv row, unchanged) and *Paired-files rules* (4 new rows). Different mechanisms, different shape.

### Boundary-terms cross-references (Archer's directive)

Both `LANGUAGE.md` files end with a *Boundary terms* table that pairs vertical and platform sides for the seven seam terms — Profile, ProfileKind, Active DB, Migration, User, Activity Log, Recovery Artifact, Setup Token. Each entry links to the matching section in the paired glossary.

### Path placement

`LANGUAGE.md` and `CONTEXT.md` ship at repo root, matching `SECURITY.md` / `ARCHITECTURE.md` / `CONTRIBUTING.md` / `README.md`. The kikan-side glossary lives at `crates/kikan/LANGUAGE.md` per the issue.

### AUTO-GEN markers — none in this PR

No producer exists today for the candidate sources (no releases for SECURITY supported-versions; no AST extractor for LANGUAGE term tables; no obvious source for CONTEXT). *"Where applicable"* satisfied honestly; auto-population is tracked under #777 and future producer-dependent work.

## Test plan

- [x] `bash scripts/check-i1-domain-purity.sh` — passes; glossary docs are outside `crates/kikan/src/` so the boundary check is unaffected
- [x] `cargo run --quiet -p docs-gen` — no-op; no AUTO-GEN markers added
- [x] `git diff --exit-code README.md` — clean
- [x] All cross-document anchor links resolve (verified manually against existing headings)
- [x] `LANGUAGE.md` "planned" terms reflect actual frontend route stubs at `apps/web/src/routes/(app)/{orders,quotes,artwork,garments,production,shipping,invoices}`

## Notes for reviewers

- Each doc is independently readable — if you want to redline one, you can do it without touching the others.
- The boundary table is the load-bearing piece per Archer; the rest is conventional glossary prose.
- I deliberately avoided pulling in the AUTO-GEN mechanism for these docs; that's tracked separately under #777 (badge expansion) and would benefit from a real producer (release tags / AST walker) before adding regions.

Closes #742
Closes #743
Closes #744
Closes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new contributor onboarding hub mapping common questions to documentation resources
  * Created domain glossaries for platform and vertical-specific terminology with cross-references and boundary-term mappings
  * Established documentation synchronization workflow with structured markers and rules for maintaining code-prose alignment
  * Enhanced security documentation with links to related architecture decisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->