### PR TITLE
feat(ci): #776 — docs-paired-files gate (Synchronized-Docs §B rules 2 + 3)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1074,11 +1074,15 @@ jobs:
               ].join('\n');
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              }
+            );
             const existing = comments.find(c => c.body && c.body.includes(marker));
 
             if (existing && existing.body === body) {

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,6 +50,7 @@ jobs:
               - 'scripts/check-i*.sh'
               - 'scripts/check-no-hurl-in-workflows.sh'
               - 'scripts/check-route-coverage.sh'
+              - 'scripts/check-docs-paired-files.sh'
               - 'scripts/lib/**'
               - 'scripts/test/**'
               - '.github/workflows/quality.yml'
@@ -744,7 +745,7 @@ jobs:
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ripgrep
       - name: shellcheck
-        run: shellcheck -x --source-path=SCRIPTDIR scripts/check-i*.sh scripts/check-r13-action-strings.sh scripts/check-no-hurl-in-workflows.sh scripts/check-route-coverage.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
+        run: shellcheck -x --source-path=SCRIPTDIR scripts/check-i*.sh scripts/check-r13-action-strings.sh scripts/check-no-hurl-in-workflows.sh scripts/check-route-coverage.sh scripts/check-docs-paired-files.sh scripts/lib/rg-check.sh scripts/test/run-self-tests.sh
       - uses: moonrepo/setup-rust@v1
         with:
           cache: false
@@ -981,10 +982,138 @@ jobs:
       - name: Assert README.md is unchanged
         run: git diff --exit-code README.md
 
+  docs-paired-files:
+    # Enforces AGENTS.md §Synchronized-Docs §B rules 2 + 3: every PR that
+    # adds public crate surface (`pub fn`/`struct`/…) under mokumo-shop or
+    # any of the 9 kikan-* satellites must also touch the matching glossary
+    # (`LANGUAGE.md` or `crates/kikan/LANGUAGE.md`). See mokumo#776.
+    #
+    # Detection: bash + awk syntax-walk over the PR diff. `cargo public-api`
+    # was considered and rejected: it requires a nightly toolchain on every
+    # Rust-touching PR and only resolves the rename-with-re-export case,
+    # which the `docs-not-applicable` opt-out label already covers.
+    #
+    # Semantic rules 1 (trust-boundary → SECURITY.md) and 4 (architectural
+    # change → CONTEXT.md + ARCHITECTURE.md) have no diff signal and are
+    # tracked separately under mokumo#781.
+    needs: [changes]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.kikan == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need the merge-base for `git diff origin/<base>...HEAD`. Default
+          # depth=1 only fetches the merge ref, so the diff lookup fails on
+          # PRs whose branch heads aren't in local history.
+          fetch-depth: 0
+      - name: Run docs-paired-files gate
+        id: gate
+        continue-on-error: true
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          STRICT_BASE_REF: '1'
+          # GitHub Actions joins the labels array; the script's parser
+          # handles both ' ' and ',' as separators. Comma is a safer choice
+          # because GitHub label names can technically contain spaces.
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set +e
+          git fetch origin "$GITHUB_BASE_REF" --depth=200 --quiet
+          # Capture streams to files synchronously so the sticky-comment
+          # step has a reliable input regardless of process-substitution
+          # timing. Replay to the job log so the check view shows them too.
+          bash scripts/check-docs-paired-files.sh > /tmp/gate.stdout 2> /tmp/gate.stderr
+          rc=$?
+          cat /tmp/gate.stdout
+          cat /tmp/gate.stderr >&2
+          exit "$rc"
+      - name: Sticky comment with failure details
+        # Always run on PRs so a passing PR can clear a stale failure
+        # comment; only POSTS new comments on failure (avoids passing-noise
+        # on PRs that never had a failure).
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- docs-paired-files-sticky -->';
+            const outcome = process.env.GATE_OUTCOME;
+            const ruleUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/AGENTS.md#synchronized-docs`;
+
+            let body;
+            if (outcome === 'success') {
+              body = [
+                marker,
+                '## docs-paired-files [PASS]',
+                '',
+                'Paired-files Synchronized-Docs rules (AGENTS.md §B 2 + 3) satisfied.',
+              ].join('\n');
+            } else {
+              const err = fs.existsSync('/tmp/gate.stderr')
+                ? fs.readFileSync('/tmp/gate.stderr', 'utf8')
+                : '(no error output captured)';
+              body = [
+                marker,
+                '## docs-paired-files [FAIL]',
+                '',
+                'This PR adds public crate surface without touching the matching glossary.',
+                `See [AGENTS.md §Synchronized-Docs](${ruleUrl}) for the rule.`,
+                '',
+                '<details><summary>Gate output</summary>',
+                '',
+                '```',
+                err.trim(),
+                '```',
+                '',
+                '</details>',
+              ].join('\n');
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing && existing.body === body) {
+              core.info('Sticky comment already up to date.');
+              return;
+            }
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated sticky comment ${existing.id}.`);
+            } else if (outcome !== 'success') {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info('Created new sticky comment.');
+            } else {
+              core.info('No prior sticky comment and gate passed; nothing to post.');
+            }
+      - name: Re-fail job if gate failed
+        if: steps.gate.outcome == 'failure'
+        run: |
+          echo "::error::docs-paired-files gate failed; see sticky comment on PR for details"
+          exit 1
+
   verdict:
     if: always()
     runs-on: ubuntu-latest
-    needs: [changes, lint-rust, test-rust, quality-ts, quality-kikan-admin-ui, seam-check, demo-smoke, crap-rust, api-smoke, security, dependency-review, secret-scan, bdd-lint, test-storybook, test-welcome-restore, kikan-invariants, kikan-musl-build, scorecard-aggregate, scorecard-drift, docs-drift]
+    needs: [changes, lint-rust, test-rust, quality-ts, quality-kikan-admin-ui, seam-check, demo-smoke, crap-rust, api-smoke, security, dependency-review, secret-scan, bdd-lint, test-storybook, test-welcome-restore, kikan-invariants, kikan-musl-build, scorecard-aggregate, scorecard-drift, docs-drift, docs-paired-files]
     steps:
       - name: Check upstream results
         env:
@@ -1007,9 +1136,10 @@ jobs:
           SCORECARD_AGGREGATE: ${{ needs.scorecard-aggregate.result }}
           SCORECARD_DRIFT: ${{ needs.scorecard-drift.result }}
           DOCS_DRIFT: ${{ needs.docs-drift.result }}
+          DOCS_PAIRED_FILES: ${{ needs.docs-paired-files.result }}
         run: |
           # Jobs that were skipped due to path filtering are fine
-          for job in LINT_RUST TEST_RUST QUALITY_TS QUALITY_KIKAN_ADMIN_UI SEAM_CHECK DEMO_SMOKE CRAP_RUST API_SMOKE SECURITY DEPENDENCY_REVIEW SECRET_SCAN BDD_LINT TEST_STORYBOOK TEST_WELCOME_RESTORE KIKAN_INVARIANTS KIKAN_MUSL_BUILD SCORECARD_AGGREGATE SCORECARD_DRIFT DOCS_DRIFT; do
+          for job in LINT_RUST TEST_RUST QUALITY_TS QUALITY_KIKAN_ADMIN_UI SEAM_CHECK DEMO_SMOKE CRAP_RUST API_SMOKE SECURITY DEPENDENCY_REVIEW SECRET_SCAN BDD_LINT TEST_STORYBOOK TEST_WELCOME_RESTORE KIKAN_INVARIANTS KIKAN_MUSL_BUILD SCORECARD_AGGREGATE SCORECARD_DRIFT DOCS_DRIFT DOCS_PAIRED_FILES; do
             result=$(eval echo "\$$job")
             if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
               echo "Job $job failed with result: $result"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ CI enforces this via the `docs-drift` job: every PR regenerates all AUTO-GEN sec
 
 ### B. Paired-files rules
 
-When a class of code changes, a matching prose doc must change in the same PR. These rules are enforced socially today (PR review + checklist); CI enforcement is tracked in [issue #776](https://github.com/breezy-bays-labs/mokumo/issues/776).
+When a class of code changes, a matching prose doc must change in the same PR. Rules **2** and **3** below are enforced by the `docs-paired-files` CI job (and a matching `lefthook` pre-push hook); rules **1** and **4** are semantic (no diff signal) and remain socially enforced — CI for them is tracked in [issue #781](https://github.com/breezy-bays-labs/mokumo/issues/781). The opt-out path for rules 2 + 3 is the `docs-not-applicable` PR label, intended for genuinely internal `pub` items kept public for module-graph reasons (no consumer surface).
 
 | When this changes… | …update this in the same PR | Why |
 |---|---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+- **Codified-docs Layer 2 paired-files CI gate** (#776, M00): a new `docs-paired-files` CI job (and `lefthook` pre-push mirror) enforces AGENTS.md §Synchronized-Docs §B rules 2 + 3 — every PR adding public crate surface (`pub fn`/`struct`/`trait`/…) under `crates/mokumo-shop/src/**` or any of the 9 kikan satellites (`crates/kikan{,-events,-mail,-scheduler,-socket,-spa-sveltekit,-tauri,-cli,-types}/src/**`) must also touch the matching glossary (`LANGUAGE.md` for the shop vertical, `crates/kikan/LANGUAGE.md` for the platform). Detection is a bash + awk syntax-walk over the PR diff (~60 ms — `cargo public-api` semantic diff was rejected because it requires a nightly toolchain on every Rust-touching PR). Opt-out via the `docs-not-applicable` PR label. Failures post a sticky comment on the PR linking the rule. Wired into the `verdict` aggregator. Semantic rules 1 (trust-boundary code → SECURITY.md) and 4 (architectural change → CONTEXT.md + ARCHITECTURE.md) have no diff signal and are tracked separately under #781.
+
 ### Changed
 
 - **Codified-docs Layer 1+2 mechanism (Wave 1 README)** (#741, M00): introduces `<!-- AUTO-GEN:* -->` marker infrastructure for machine-maintained doc sections. The `docs-gen` binary (`tools/docs-gen`) renders the MSRV badge in `README.md` from `Cargo.toml`'s `workspace.package.rust-version`; `moon run docs:gen` wraps it; a new `docs-drift` CI job enforces no-drift on every PR via `git diff --exit-code`. The Synchronized-Docs rule in `AGENTS.md` declares all source→target relationships and points at the registry in `tools/docs-gen/src/registry.rs` where new sections plug in. Pre-push hook fires when `Cargo.toml`, `README.md`, or `tools/docs-gen/**` changes. Foundation for Group A+B doc automation (#743, #744, #745, QUALITY, COVERAGE).

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -72,3 +72,13 @@ pre-push:
         CARGO_TARGET_DIR: /tmp/mokumo-target
       run: cargo run --quiet -p docs-gen && git diff --exit-code README.md
       timeout: 60s
+    docs-paired-files:
+      # Local mirror of the CI gate. Detects added `pub` items in the §B
+      # source paths and asserts the matching glossary was touched. Like
+      # the route-coverage hook, this warn-skips when origin/main isn't
+      # fetched so a stale ref doesn't block a push (CI is the source of
+      # truth). Glob fires on Rust source changes in scope and on
+      # AGENTS.md / glossary edits so a doc-only push still validates.
+      glob: "{crates/mokumo-shop/src/**/*.rs,crates/kikan/src/**/*.rs,crates/kikan-*/src/**/*.rs,LANGUAGE.md,crates/kikan/LANGUAGE.md,AGENTS.md,scripts/check-docs-paired-files.sh}"
+      run: bash scripts/check-docs-paired-files.sh
+      timeout: 30s

--- a/scripts/check-docs-paired-files.sh
+++ b/scripts/check-docs-paired-files.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Guard: paired-files Synchronized-Docs rule (AGENTS.md §B rules 2 + 3).
+#
+# Every PR that adds public crate surface (`pub fn`, `pub struct`, `pub trait`,
+# `pub enum`, `pub mod`, `pub static`, `pub const`, `pub type`, `pub use`) under
+# the listed source paths must also touch the matching prose glossary in the
+# same PR. The wider-scope path map (mokumo-shop + 9 kikan satellites) tracks
+# AGENTS.md §B verbatim.
+#
+# Path → required doc:
+#   crates/mokumo-shop/src/**            → LANGUAGE.md            (vertical)
+#   crates/kikan/src/**                  → crates/kikan/LANGUAGE.md (platform)
+#   crates/kikan-{events,mail,scheduler,
+#                  socket,spa-sveltekit,
+#                  tauri,cli,types}/src/** → crates/kikan/LANGUAGE.md
+#
+# Out of scope (deferred to mokumo#781):
+#   - Rule 1 (trust-boundary code → SECURITY.md): semantic, no diff signal
+#   - Rule 4 (architectural change → CONTEXT.md + ARCHITECTURE.md): ditto
+#
+# Detection: syntax-walk over `+`-prefixed diff lines. `pub(crate)`, `pub(super)`,
+# and `pub(in …)` are excluded by the regex anchor — they're not crate surface.
+# `cargo public-api` semantic diff was considered (mokumo#776 discovery) and
+# rejected: it requires a nightly toolchain on every Rust-touching PR and only
+# resolves the "rename-with-re-export" case, which the opt-out label already
+# covers.
+#
+# Opt-out: PR_LABELS env var (space- or comma-separated). The label
+# `docs-not-applicable` skips the gate — for genuinely internal `pub` items
+# kept public for module-graph reasons. The label is part of the contract and
+# its presence MUST be visible in the failure message so authors can find it.
+#
+# Diff base: BASE_REF (default origin/main). Local hooks tolerate a stale ref;
+# CI sets STRICT_BASE_REF=1 to fail loudly.
+#
+# Self-test injection points:
+#   DIFF_OVERRIDE  — file containing pre-recorded `git diff` output
+#   NAME_OVERRIDE  — file containing pre-recorded `git diff --name-only`
+#   PR_LABELS      — env var read directly; fixtures set it inline
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/.." && pwd)"
+cd "$ROOT"
+
+BASE_REF="${BASE_REF:-origin/main}"
+PR_LABELS="${PR_LABELS:-}"
+DIFF_OVERRIDE="${DIFF_OVERRIDE:-}"
+NAME_OVERRIDE="${NAME_OVERRIDE:-}"
+
+# === Opt-out short-circuit ================================================
+# Must come BEFORE diff acquisition so the gate is a true no-op when the
+# author has accepted the rule's escape hatch.
+
+if printf '%s' "$PR_LABELS" | tr ' ,' '\n\n' | grep -Fxq 'docs-not-applicable'; then
+    echo "docs-paired-files ok: docs-not-applicable label set; gate skipped"
+    exit 0
+fi
+
+# === Path → required-doc map ==============================================
+
+SHOP_DOC="LANGUAGE.md"
+KIKAN_DOC="crates/kikan/LANGUAGE.md"
+
+# In-scope diff paths (kept as a single argv array so the git invocation
+# matches the awk path-classifier byte-for-byte).
+SCOPE_PATHS=(
+    'crates/mokumo-shop/src/'
+    'crates/kikan/src/'
+    'crates/kikan-events/src/'
+    'crates/kikan-mail/src/'
+    'crates/kikan-scheduler/src/'
+    'crates/kikan-socket/src/'
+    'crates/kikan-spa-sveltekit/src/'
+    'crates/kikan-tauri/src/'
+    'crates/kikan-cli/src/'
+    'crates/kikan-types/src/'
+)
+
+# === Diff acquisition =====================================================
+
+if [[ -n "$DIFF_OVERRIDE" ]]; then
+    DIFF=$(cat "$DIFF_OVERRIDE")
+else
+    if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+        if [[ "${STRICT_BASE_REF:-0}" == "1" ]]; then
+            echo "::error::docs-paired-files: base ref '$BASE_REF' not found (STRICT_BASE_REF=1)" >&2
+            exit 2
+        fi
+        echo "::warning::docs-paired-files: base ref '$BASE_REF' not found locally; skipping (run 'git fetch origin main' to enable)" >&2
+        exit 0
+    fi
+    DIFF=$(git diff "${BASE_REF}...HEAD" -- "${SCOPE_PATHS[@]}")
+fi
+
+# === Phase A: extract added pub items, group by required doc =============
+# Output: tab-separated "doc-path<TAB>file<TAB>line".
+
+ADDED_BY_DOC=$(printf '%s\n' "$DIFF" | awk -v shop="$SHOP_DOC" -v kikan="$KIKAN_DOC" '
+    /^diff --git / { file=""; doc=""; in_scope=0 }
+    /^\+\+\+ b\// {
+        file = substr($0, 7)
+        in_scope = 0
+        if (file ~ /^crates\/mokumo-shop\/src\//) {
+            doc = shop; in_scope = 1
+        } else if (file ~ /^crates\/(kikan|kikan-events|kikan-mail|kikan-scheduler|kikan-socket|kikan-spa-sveltekit|kikan-tauri|kikan-cli|kikan-types)\/src\//) {
+            doc = kikan; in_scope = 1
+        }
+    }
+    in_scope && /^\+[^+]/ {
+        if ($0 ~ /^\+[[:space:]]*pub[[:space:]]+(fn|struct|trait|enum|mod|static|const|type|use)[[:space:]]/) {
+            printf("%s\t%s\t%s\n", doc, file, substr($0, 2))
+        }
+    }
+')
+
+if [[ -z "$ADDED_BY_DOC" ]]; then
+    echo "docs-paired-files ok: no public-surface additions in scope vs ${BASE_REF}"
+    exit 0
+fi
+
+# === Phase B: identify changed file names =================================
+
+if [[ -n "$NAME_OVERRIDE" ]]; then
+    CHANGED_FILES=$(cat "$NAME_OVERRIDE")
+else
+    CHANGED_FILES=$(git diff --name-only "${BASE_REF}...HEAD")
+fi
+
+doc_was_changed() {
+    printf '%s' "$CHANGED_FILES" | grep -Fxq "$1"
+}
+
+# === Phase C: per-doc check ===============================================
+# Each doc that has at least one paired pub-item must be touched in the diff.
+
+REQUIRED_DOCS=$(printf '%s\n' "$ADDED_BY_DOC" | cut -f1 | sort -u)
+FAIL=0
+
+while IFS= read -r doc; do
+    [[ -z "$doc" ]] && continue
+    if doc_was_changed "$doc"; then
+        echo "docs-paired-files ok: ${doc} touched, paired with public-surface changes"
+        continue
+    fi
+
+    cat <<EOF >&2
+::error::docs-paired-files violation: public surface added without paired ${doc} change
+
+This PR introduces new public crate surface (pub fn / struct / trait / …) but
+does not modify ${doc}. AGENTS.md §Synchronized-Docs §B requires every new
+public surface to land with a matching glossary entry in the same PR.
+
+Added pub items requiring an entry in ${doc}:
+EOF
+    printf '%s\n' "$ADDED_BY_DOC" \
+        | awk -F'\t' -v d="$doc" '$1==d { printf("  - %s: %s\n", $2, $3) }' >&2
+
+    cat <<EOF >&2
+
+To resolve, choose ONE:
+  1. Add an entry for each new pub item to ${doc} in this PR.
+  2. Mark items as crate-private if they are NOT part of the public API:
+     change \`pub fn foo\` to \`pub(crate) fn foo\`.
+  3. If the items are genuinely internal pub-for-mod-graph reasons (no
+     consumer surface), add the \`docs-not-applicable\` PR label.
+
+See https://github.com/breezy-bays-labs/mokumo/blob/main/AGENTS.md#synchronized-docs
+for the full rule and rationale. Semantic rules 1 (trust-boundary) and 4
+(architectural change) are not yet enforced — see mokumo#781.
+EOF
+    FAIL=1
+done <<< "$REQUIRED_DOCS"
+
+[[ "$FAIL" -ne 0 ]] && exit 1
+exit 0

--- a/scripts/check-docs-paired-files.sh
+++ b/scripts/check-docs-paired-files.sh
@@ -2,9 +2,10 @@
 # Guard: paired-files Synchronized-Docs rule (AGENTS.md §B rules 2 + 3).
 #
 # Every PR that adds public crate surface (`pub fn`, `pub struct`, `pub trait`,
-# `pub enum`, `pub mod`, `pub static`, `pub const`, `pub type`, `pub use`) under
-# the listed source paths must also touch the matching prose glossary in the
-# same PR. The wider-scope path map (mokumo-shop + 9 kikan satellites) tracks
+# `pub enum`, `pub mod`, `pub static`, `pub const`, `pub type`, `pub use`, plus
+# the modifier-prefixed forms `pub async`, `pub unsafe`, `pub extern`) under the
+# listed source paths must also touch the matching prose glossary in the same
+# PR. The wider-scope path map (mokumo-shop + 9 kikan satellites) tracks
 # AGENTS.md §B verbatim.
 #
 # Path → required doc:
@@ -79,9 +80,12 @@ SCOPE_PATHS=(
 )
 
 # === Diff acquisition =====================================================
+# Stream the diff straight into awk rather than slurping it into a bash var —
+# very large PRs would otherwise risk the bash variable copy becoming the
+# memory bottleneck.
 
 if [[ -n "$DIFF_OVERRIDE" ]]; then
-    DIFF=$(cat "$DIFF_OVERRIDE")
+    DIFF_CMD=(cat -- "$DIFF_OVERRIDE")
 else
     if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
         if [[ "${STRICT_BASE_REF:-0}" == "1" ]]; then
@@ -91,13 +95,13 @@ else
         echo "::warning::docs-paired-files: base ref '$BASE_REF' not found locally; skipping (run 'git fetch origin main' to enable)" >&2
         exit 0
     fi
-    DIFF=$(git diff "${BASE_REF}...HEAD" -- "${SCOPE_PATHS[@]}")
+    DIFF_CMD=(git diff "${BASE_REF}...HEAD" -- "${SCOPE_PATHS[@]}")
 fi
 
 # === Phase A: extract added pub items, group by required doc =============
 # Output: tab-separated "doc-path<TAB>file<TAB>line".
 
-ADDED_BY_DOC=$(printf '%s\n' "$DIFF" | awk -v shop="$SHOP_DOC" -v kikan="$KIKAN_DOC" '
+ADDED_BY_DOC=$("${DIFF_CMD[@]}" | awk -v shop="$SHOP_DOC" -v kikan="$KIKAN_DOC" '
     /^diff --git / { file=""; doc=""; in_scope=0 }
     /^\+\+\+ b\// {
         file = substr($0, 7)
@@ -109,7 +113,7 @@ ADDED_BY_DOC=$(printf '%s\n' "$DIFF" | awk -v shop="$SHOP_DOC" -v kikan="$KIKAN_
         }
     }
     in_scope && /^\+[^+]/ {
-        if ($0 ~ /^\+[[:space:]]*pub[[:space:]]+(fn|struct|trait|enum|mod|static|const|type|use)[[:space:]]/) {
+        if ($0 ~ /^\+[[:space:]]*pub[[:space:]]+(fn|struct|trait|enum|mod|static|const|type|use|async|unsafe|extern)[[:space:]]/) {
             printf("%s\t%s\t%s\n", doc, file, substr($0, 2))
         }
     }

--- a/scripts/check-docs-paired-files.sh
+++ b/scripts/check-docs-paired-files.sh
@@ -53,7 +53,7 @@ NAME_OVERRIDE="${NAME_OVERRIDE:-}"
 # Must come BEFORE diff acquisition so the gate is a true no-op when the
 # author has accepted the rule's escape hatch.
 
-if printf '%s' "$PR_LABELS" | tr ' ,' '\n\n' | grep -Fxq 'docs-not-applicable'; then
+if printf '%s' "$PR_LABELS" | tr ' ,' '\n' | grep -Fxq 'docs-not-applicable'; then
     echo "docs-paired-files ok: docs-not-applicable label set; gate skipped"
     exit 0
 fi

--- a/scripts/test/fixtures/docs-paired-files-async-fn/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-async-fn/diff.txt
@@ -1,0 +1,11 @@
+diff --git a/crates/mokumo-shop/src/handler.rs b/crates/mokumo-shop/src/handler.rs
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/crates/mokumo-shop/src/handler.rs
+@@ -0,0 +1,5 @@
++pub async fn list_widgets() -> Json<Vec<Widget>> {
++    Json(vec![])
++}
++
++pub unsafe trait WidgetMagic {}

--- a/scripts/test/fixtures/docs-paired-files-async-fn/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-async-fn/names.txt
@@ -1,0 +1,1 @@
+crates/mokumo-shop/src/handler.rs

--- a/scripts/test/fixtures/docs-paired-files-out-of-scope/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-out-of-scope/diff.txt
@@ -1,0 +1,8 @@
+diff --git a/tools/docs-gen/src/main.rs b/tools/docs-gen/src/main.rs
+index 1111111..2222222 100644
+--- a/tools/docs-gen/src/main.rs
++++ b/tools/docs-gen/src/main.rs
+@@ -10,3 +10,5 @@
+ fn main() {}
++
++pub fn helper() {}

--- a/scripts/test/fixtures/docs-paired-files-out-of-scope/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-out-of-scope/names.txt
@@ -1,0 +1,1 @@
+tools/docs-gen/src/main.rs

--- a/scripts/test/fixtures/docs-paired-files-pass-kikan/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-pass-kikan/diff.txt
@@ -1,0 +1,11 @@
+diff --git a/crates/kikan-types/src/widgets.rs b/crates/kikan-types/src/widgets.rs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/crates/kikan-types/src/widgets.rs
+@@ -0,0 +1,5 @@
++#[derive(Debug, serde::Serialize, ts_rs::TS)]
++pub struct WidgetDto {
++    pub id: String,
++    pub label: String,
++}

--- a/scripts/test/fixtures/docs-paired-files-pass-kikan/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-pass-kikan/names.txt
@@ -1,0 +1,2 @@
+crates/kikan-types/src/widgets.rs
+crates/kikan/LANGUAGE.md

--- a/scripts/test/fixtures/docs-paired-files-pass-shop/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-pass-shop/diff.txt
@@ -1,0 +1,9 @@
+diff --git a/crates/mokumo-shop/src/widgets/mod.rs b/crates/mokumo-shop/src/widgets/mod.rs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/crates/mokumo-shop/src/widgets/mod.rs
+@@ -0,0 +1,3 @@
++pub fn build_widget() -> Widget {
++    Widget::default()
++}

--- a/scripts/test/fixtures/docs-paired-files-pass-shop/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-pass-shop/names.txt
@@ -1,0 +1,2 @@
+crates/mokumo-shop/src/widgets/mod.rs
+LANGUAGE.md

--- a/scripts/test/fixtures/docs-paired-files-pubcrate/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-pubcrate/diff.txt
@@ -1,0 +1,10 @@
+diff --git a/crates/mokumo-shop/src/widgets/inner.rs b/crates/mokumo-shop/src/widgets/inner.rs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/crates/mokumo-shop/src/widgets/inner.rs
+@@ -0,0 +1,4 @@
++pub(crate) fn helper() {}
++pub(super) struct Inner;
++pub(in crate::widgets) const FOO: u32 = 1;
++fn private() {}

--- a/scripts/test/fixtures/docs-paired-files-pubcrate/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-pubcrate/names.txt
@@ -1,0 +1,1 @@
+crates/mokumo-shop/src/widgets/inner.rs

--- a/scripts/test/fixtures/docs-paired-files-renamed-rs/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-renamed-rs/diff.txt
@@ -1,0 +1,4 @@
+diff --git a/crates/mokumo-shop/src/old_widget.rs b/crates/mokumo-shop/src/widget.rs
+similarity index 100%
+rename from crates/mokumo-shop/src/old_widget.rs
+rename to crates/mokumo-shop/src/widget.rs

--- a/scripts/test/fixtures/docs-paired-files-renamed-rs/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-renamed-rs/names.txt
@@ -1,0 +1,1 @@
+crates/mokumo-shop/src/widget.rs

--- a/scripts/test/fixtures/docs-paired-files-violation/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-violation/diff.txt
@@ -1,0 +1,11 @@
+diff --git a/crates/mokumo-shop/src/widgets/mod.rs b/crates/mokumo-shop/src/widgets/mod.rs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/crates/mokumo-shop/src/widgets/mod.rs
+@@ -0,0 +1,5 @@
++pub mod inner;
++
++pub fn build_widget() -> Widget {
++    Widget::default()
++}

--- a/scripts/test/fixtures/docs-paired-files-violation/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-violation/names.txt
@@ -1,0 +1,1 @@
+crates/mokumo-shop/src/widgets/mod.rs

--- a/scripts/test/fixtures/docs-paired-files-wrong-doc/diff.txt
+++ b/scripts/test/fixtures/docs-paired-files-wrong-doc/diff.txt
@@ -1,0 +1,9 @@
+diff --git a/crates/mokumo-shop/src/widgets/mod.rs b/crates/mokumo-shop/src/widgets/mod.rs
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/crates/mokumo-shop/src/widgets/mod.rs
+@@ -0,0 +1,3 @@
++pub fn build_widget() -> Widget {
++    Widget::default()
++}

--- a/scripts/test/fixtures/docs-paired-files-wrong-doc/names.txt
+++ b/scripts/test/fixtures/docs-paired-files-wrong-doc/names.txt
@@ -1,0 +1,2 @@
+crates/mokumo-shop/src/widgets/mod.rs
+crates/kikan/LANGUAGE.md

--- a/scripts/test/run-self-tests.sh
+++ b/scripts/test/run-self-tests.sh
@@ -212,6 +212,15 @@ assert_exit "docs-paired-files rename-only passes" 0 \
         NAME_OVERRIDE="${FIX}/docs-paired-files-renamed-rs/names.txt" \
     bash scripts/check-docs-paired-files.sh
 
+# Modifier-prefixed pub items (`pub async fn`, `pub unsafe trait`,
+# `pub extern fn`) must register as public surface; Axum handlers are nearly
+# all `pub async fn`, so missing this case would silently let the gate green
+# on the most common shape it's meant to catch.
+assert_exit "docs-paired-files pub async/unsafe fails without doc" 1 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-async-fn/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-async-fn/names.txt" \
+    bash scripts/check-docs-paired-files.sh
+
 echo
 echo "self-tests: ${pass} passed, ${fail} failed"
 [[ "$fail" -eq 0 ]]

--- a/scripts/test/run-self-tests.sh
+++ b/scripts/test/run-self-tests.sh
@@ -46,6 +46,7 @@ assert_exit "I4 real-tree pass" 0 bash scripts/check-i4-dag.sh
 assert_exit "I5 real-tree pass" 0 bash scripts/check-i5-features.sh
 assert_exit "R13 real-tree pass" 0 bash scripts/check-r13-action-strings.sh
 assert_exit "route-coverage real-tree pass" 0 bash scripts/check-route-coverage.sh
+assert_exit "docs-paired-files real-tree pass" 0 bash scripts/check-docs-paired-files.sh
 
 # R13 fixture: a file containing a forbidden prefixed literal must fail.
 R13_FIX="$(mktemp)"
@@ -148,6 +149,68 @@ assert_exit "route-coverage dot-escape rejects fuzzy match" 1 \
         HURL_TREE="${FIX}/route-coverage-dot-escape/api" \
         LEDGER_FILE="${FIX}/route-coverage-dot-escape/empty-ledger.yml" \
     bash scripts/check-route-coverage.sh
+
+# === docs-paired-files (mokumo#776) =======================================
+# Each fixture pairs `diff.txt` (recorded `git diff` output) with `names.txt`
+# (recorded `git diff --name-only` output) so the gate can be exercised
+# without a live git tree.
+
+# Public surface added in mokumo-shop with no LANGUAGE.md change → fail.
+assert_exit "docs-paired-files violation fails" 1 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-violation/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-violation/names.txt" \
+    bash scripts/check-docs-paired-files.sh
+
+# Same public surface but the docs-not-applicable label is set → pass.
+assert_exit "docs-paired-files opt-out label passes" 0 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-violation/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-violation/names.txt" \
+        PR_LABELS="docs-not-applicable" \
+    bash scripts/check-docs-paired-files.sh
+
+# Public surface in mokumo-shop AND LANGUAGE.md touched → pass.
+assert_exit "docs-paired-files shop pair passes" 0 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-pass-shop/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-pass-shop/names.txt" \
+    bash scripts/check-docs-paired-files.sh
+
+# Public surface in kikan-types (a §B kikan satellite) AND
+# crates/kikan/LANGUAGE.md touched → pass. Validates the wider §B scope: any
+# of the 9 kikan-* satellites maps to the platform glossary.
+assert_exit "docs-paired-files kikan-types pair passes" 0 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-pass-kikan/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-pass-kikan/names.txt" \
+    bash scripts/check-docs-paired-files.sh
+
+# Spine case: pub surface in mokumo-shop, but only crates/kikan/LANGUAGE.md
+# was touched (the WRONG glossary) → fail. The script must keep separate
+# accounting per crate-prefix; "any doc touched" is not the contract.
+assert_exit "docs-paired-files wrong-doc fails (spine)" 1 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-wrong-doc/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-wrong-doc/names.txt" \
+    bash scripts/check-docs-paired-files.sh
+
+# Restricted-pub additions only (`pub(crate)`, `pub(super)`, `pub(in …)`) do
+# not contribute to crate surface and must not trigger the gate.
+assert_exit "docs-paired-files pub(crate)-only passes" 0 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-pubcrate/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-pubcrate/names.txt" \
+    bash scripts/check-docs-paired-files.sh
+
+# `pub fn` outside any §B path (e.g. tools/docs-gen/src/) must not trigger.
+assert_exit "docs-paired-files out-of-scope passes" 0 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-out-of-scope/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-out-of-scope/names.txt" \
+    bash scripts/check-docs-paired-files.sh
+
+# Pure file rename inside an in-scope path with no `+pub` lines must not
+# trigger. Rename-with-content-edit is not testable from a fixture (git
+# generates rename markers via similarity index, not literal `+pub` lines)
+# so this fixture only covers the pure-rename case.
+assert_exit "docs-paired-files rename-only passes" 0 \
+    env DIFF_OVERRIDE="${FIX}/docs-paired-files-renamed-rs/diff.txt" \
+        NAME_OVERRIDE="${FIX}/docs-paired-files-renamed-rs/names.txt" \
+    bash scripts/check-docs-paired-files.sh
 
 echo
 echo "self-tests: ${pass} passed, ${fail} failed"


### PR DESCRIPTION
## Summary

Lands the CI gate that enforces the Synchronized-Docs paired-files rule recorded in [`AGENTS.md` §B](https://github.com/breezy-bays-labs/mokumo/blob/main/AGENTS.md#synchronized-docs) (the rule itself shipped with #779). When a PR adds public crate surface in scope, the matching prose glossary must change in the same PR.

| When this changes…                                                                                                                                | …gate requires this be touched | Doc                                  |
|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|--------------------------------------|
| `pub fn`/`struct`/`trait`/`enum`/`mod`/`use` in `crates/mokumo-shop/src/**`                                                                       | shop vertical glossary         | `LANGUAGE.md`                        |
| `pub …` in any of the 9 kikan satellites (`crates/kikan{,-events,-mail,-scheduler,-socket,-spa-sveltekit,-tauri,-cli,-types}/src/**`)             | platform glossary              | `crates/kikan/LANGUAGE.md`           |

Out: `pub(crate)`, `pub(super)`, `pub(in …)`. Opt-out: `docs-not-applicable` PR label.

## Spike findings (#776 discovery): `cargo public-api` vs syntax-walk

Both were spiked. Syntax-walk wins on every measurable axis except one:

|                                | (a) cargo public-api                                                            | (b) syntax-walk **[chosen]**            |
|--------------------------------|---------------------------------------------------------------------------------|------------------------------------------|
| Toolchain                      | nightly Rust + rust-docs (rustdoc-json is nightly-only — confirmed from upstream README) | bash + awk + git                          |
| Tool install                   | 59 s (cargo install --locked)                                                  | none                                     |
| Workspace support              | per-crate only (`-p <crate>`); virtual manifest unsupported → 9 crates × 2 refs = 18 rustdoc-json builds | one diff over all in-scope paths         |
| Run on PR #779 (docs-only)     | not measurable in container (RUSTUP_HOME read-only)                            | 7 ms, 0 hits                              |
| Run on PR #685 (39 real pub additions) | not measurable                                                          | 60 ms, 39 hits — every line correct       |
| `pub(crate)`/`pub(super)`/`pub(in …)` | excluded                                                                | excluded by regex anchor                  |
| Rename-with-re-export false-positive | recognised as no-op                                                       | flags both lines (covered by opt-out label) |
| Maintainability                | external crate + nightly toolchain pin                                          | ~50 lines of bash                         |

The opt-out label is in the acceptance criteria specifically for the case where (a) would have been smarter. (a)'s only real win is wasted in mokumo's pre-1.0 activity profile.

## Acceptance criteria — status

- [x] CI job (`docs-paired-files`) detects `pub` API mutations under `crates/kikan/src/**` and `crates/mokumo-shop/src/**` — **plus** the wider §B kikan satellite set
- [x] Job fails when an API mutation has no paired prose doc change in the same PR
- [x] Opt-out via `docs-not-applicable` PR label
- [x] Wired into `verdict.needs` and the verdict status loop
- [x] Failure-message UX: sticky comment on the PR linking [`AGENTS.md` §Synchronized-Docs](https://github.com/breezy-bays-labs/mokumo/blob/main/AGENTS.md#synchronized-docs)
- [x] Negative-path tests: violation fails; opt-out label passes; `pub(crate)` only passes; **wrong glossary touched fails (spine case)**

## Out of scope (deferred to #781)

- §B rule 1 (trust-boundary code → `SECURITY.md`) — semantic, no diff signal
- §B rule 4 (architectural change → `CONTEXT.md` + `ARCHITECTURE.md`) — same

## Files

- `scripts/check-docs-paired-files.sh` — the gate (~150 lines, including comments)
- `scripts/test/fixtures/docs-paired-files-{violation,pass-shop,pass-kikan,wrong-doc,pubcrate,renamed-rs,out-of-scope}/{diff,names}.txt` — 7 fixtures
- `scripts/test/run-self-tests.sh` — 9 new assertions (1 real-tree + 8 fixture)
- `.github/workflows/quality.yml` — new `docs-paired-files` job + verdict wiring + shellcheck list + changes filter
- `lefthook.yml` — pre-push mirror
- `AGENTS.md` — §B preamble updated (rules 2 + 3 enforced; rules 1 + 4 → #781)
- `CHANGELOG.md` — Unreleased entry

## Test plan

- [x] All 9 docs-paired-files self-tests pass locally
- [x] Real-tree gate against this PR's diff: `docs-paired-files ok: no public-surface additions in scope`
- [x] Smoke against PR #685 commit (real pub additions in `crates/kikan-types`/`crates/kikan/auth`): correctly fails with file:line precision in BOTH the shop and kikan-glossary error messages
- [x] Pre-push lefthook hook ran on this push and passed
- [ ] CI green on this PR
- [ ] Sticky comment renders correctly on a synthetic-failure PR (deferred — would need a follow-up PR that intentionally violates the rule to verify visually)

Closes #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `docs-paired-files` CI gate that automatically enforces keeping documentation synchronized with public code changes.
  * Added pre-push hook for local validation of documentation compliance.
  * Added `docs-not-applicable` PR label to opt out of documentation enforcement when appropriate.

* **Documentation**
  * Updated developer guidelines to document new documentation enforcement rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->