### PR TITLE
quality(coverage): #808/#655 — runner+scope groundwork for route-presence axis

### DIFF
--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -188,18 +188,35 @@ tasks:
     # in `coverage::CoverageMapping::getInstantiationGroups`). Adding a
     # new handler-bearing crate means appending its `-p` flag here.
     #
-    # `--lib` was removed (mokumo#808). Handlers are reachable only from
-    # the cucumber-rs BDD integration suites under
-    # `crates/mokumo-shop/tests/api_bdd*` and `crates/kikan/tests/`; with
-    # `--lib` they were invisible to the producer (10 handlers showed as
-    # unresolved). Including integration tests captures their branch
-    # coverage at the cost of a larger surface for the LLVM merge step —
-    # if the SIGSEGV recurs, the rollback is one-line (re-add `--lib`).
+    # `--lib` was removed (mokumo#808 phase 1) — Phase 1 CI proved no LLVM
+    # SIGSEGV recurs on `nightly-2026-05-01` against the wider integration
+    # surface; rollback path remains one-line if a future nightly regresses.
+    #
+    # **Runner:** `cargo llvm-cov test`, NOT `cargo llvm-cov nextest`
+    # (mokumo#808 phase 2). `cargo nextest` silently skips test binaries
+    # declared `harness = false` — those are the cucumber-rs BDD runners
+    # (`bdd`, `platform_bdd`, `api_bdd` in `Cargo.toml`'s `[[test]]`
+    # entries). Phase 1's drop of `--lib` brought libtest-harnessed
+    # integration tests into the coverage map (test count 620 → 890) but
+    # the 10 unresolved-handler producer findings stayed at 10 because
+    # those handlers (auth login/logout/me, ws_handler, debug_*,
+    # regenerate_recovery_codes) are exercised only by the BDD scenarios.
+    # `cargo test` invokes `harness = false` binaries via their custom
+    # `fn main()` and llvm-cov instruments them the same as harnessed
+    # tests; `--features bdd` matches the conditional compile gate the
+    # `shop:test-bdd*` tasks already use.
+    #
+    # **This run is the experiment** for mokumo#808 / mokumo#655 / #807:
+    # the producer's per-handler branch coverage distribution decides
+    # whether #583's branch dimension is informative or superseded by
+    # #655's route-presence axis. See the "Discovery" bullet on #655 and
+    # the analysis comment on PR #809.
     script: |
       set -euo pipefail
       RUSTUP_TOOLCHAIN="$(scripts/nightly-coverage-channel.sh)" \
-        cargo llvm-cov nextest --branch \
+        cargo llvm-cov test --branch \
           -p kikan -p kikan-cli -p kikan-spa-sveltekit -p mokumo-shop \
+          --features kikan/bdd,mokumo-shop/bdd \
           --json --output-path coverage-branches.json
     deps:
     - web:build

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -196,21 +196,23 @@ tasks:
     # (mokumo#808 phase 2). `cargo nextest` silently skips test binaries
     # declared `harness = false` — those are the cucumber-rs BDD runners
     # (`bdd`, `platform_bdd`, `api_bdd` in `Cargo.toml`'s `[[test]]`
-    # entries). Phase 1's drop of `--lib` brought libtest-harnessed
-    # integration tests into the coverage map (test count 620 → 890) but
-    # the 10 unresolved-handler producer findings stayed at 10 because
-    # those handlers (auth login/logout/me, ws_handler, debug_*,
-    # regenerate_recovery_codes) are exercised only by the BDD scenarios.
-    # `cargo test` invokes `harness = false` binaries via their custom
-    # `fn main()` and llvm-cov instruments them the same as harnessed
-    # tests; `--features bdd` matches the conditional compile gate the
-    # `shop:test-bdd*` tasks already use.
+    # entries). The 10 unresolved-handler producer findings (auth
+    # login/logout/me, ws_handler, debug_*, regenerate_recovery_codes)
+    # were exercised only by BDD scenarios — invisible to nextest, visible
+    # to `cargo test` which invokes `harness = false` binaries via their
+    # custom `fn main()`. `--features kikan/bdd,mokumo-shop/bdd` matches
+    # the conditional compile gate both crates' BDD test entries declare;
+    # the explicit per-package syntax is required when `-p` selects
+    # multiple crates that each declare a `bdd` feature.
     #
-    # **This run is the experiment** for mokumo#808 / mokumo#655 / #807:
-    # the producer's per-handler branch coverage distribution decides
-    # whether #583's branch dimension is informative or superseded by
-    # #655's route-presence axis. See the "Discovery" bullet on #655 and
-    # the analysis comment on PR #809.
+    # **Why this runner choice outlasts #583:** Per the experiment on
+    # PR #809, mokumo#583's per-handler branch dimension was found to be
+    # uninformative on this codebase (71% of handlers are branchless thin
+    # shells; the gate emits a vacuous 100% on those). The route-presence
+    # axis in mokumo#655 supersedes it. The runner change above remains
+    # load-bearing for #655 because its tracing-middleware approach also
+    # needs BDD scenarios to actually execute — and that requires the
+    # `cargo test` runner to invoke the `harness = false` binaries.
     script: |
       set -euo pipefail
       RUSTUP_TOOLCHAIN="$(scripts/nightly-coverage-channel.sh)" \

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -213,6 +213,9 @@ tasks:
     # load-bearing for #655 because its tracing-middleware approach also
     # needs BDD scenarios to actually execute — and that requires the
     # `cargo test` runner to invoke the `harness = false` binaries.
+    #
+    # tracked: mokumo#655 — branch-by-handler gate kept non-blocking;
+    # route-presence axis supersedes for quality gating
     script: |
       set -euo pipefail
       RUSTUP_TOOLCHAIN="$(scripts/nightly-coverage-channel.sh)" \

--- a/crates/mokumo-shop/moon.yml
+++ b/crates/mokumo-shop/moon.yml
@@ -187,10 +187,18 @@ tasks:
     # nightly LLVM with the wider workspace surface (an upstream LLVM bug
     # in `coverage::CoverageMapping::getInstantiationGroups`). Adding a
     # new handler-bearing crate means appending its `-p` flag here.
+    #
+    # `--lib` was removed (mokumo#808). Handlers are reachable only from
+    # the cucumber-rs BDD integration suites under
+    # `crates/mokumo-shop/tests/api_bdd*` and `crates/kikan/tests/`; with
+    # `--lib` they were invisible to the producer (10 handlers showed as
+    # unresolved). Including integration tests captures their branch
+    # coverage at the cost of a larger surface for the LLVM merge step —
+    # if the SIGSEGV recurs, the rollback is one-line (re-add `--lib`).
     script: |
       set -euo pipefail
       RUSTUP_TOOLCHAIN="$(scripts/nightly-coverage-channel.sh)" \
-        cargo llvm-cov nextest --lib --branch \
+        cargo llvm-cov nextest --branch \
           -p kikan -p kikan-cli -p kikan-spa-sveltekit -p mokumo-shop \
           --json --output-path coverage-branches.json
     deps:


### PR DESCRIPTION
Groundwork for mokumo#655. References mokumo#808.

## What this PR is

Two infrastructure changes to `crates/mokumo-shop/moon.yml`'s `coverage-branches` task:

1. **Phase 1 (`0c89a58`)** — drop `--lib`. Brings libtest-harnessed integration tests into the coverage instrumentation. CI proved no LLVM SIGSEGV recurs on `nightly-2026-05-01` against the wider integration surface. Test count 620 → 890.
2. **Phase 2 (`707b16a`)** — swap `cargo llvm-cov nextest` for `cargo llvm-cov test --features kikan/bdd,mokumo-shop/bdd`. `cargo nextest` silently skips `harness = false` binaries; the cucumber-rs BDD runners (`bdd`, `platform_bdd`, `api_bdd`) are exactly that. `cargo test` invokes their custom `fn main()` so BDD scenarios actually execute under coverage.
3. **Comment update (`ad1b814`)** — record the post-experiment framing in the moon.yml comment block.

Both changes are load-bearing for mokumo#655's route-presence-with-axes producer. #655 captures handler hits via tracing middleware during scenario runs — that requires the scenarios to run, which requires the runner change.

## Why this isn't #808's original plan (Phase 3)

The experiment that ran on this PR (full analysis: [comment thread](https://github.com/breezy-bays-labs/mokumo/pull/809#issuecomment-4384444328)) showed mokumo#583's per-handler branch axis is uninformative on this codebase:

- 71% of Mokumo handlers are branchless (`branches_total == 0`) — the gate emits a vacuous 100% on those, no measurement of test quality possible.
- 29% have actual branches, mean 34 / median 25, with the bottom tail correlating with **failing BDD scenarios** rather than missing tests.

That makes the original #808 plan (remove handler exclusions from `crap4rs.toml`, promote `coverage-handlers` from soft- to hard-gate) the wrong move — the gate has too much structural noise. #655's route-presence axis is the right replacement and this PR sets up its runner.

## Out of scope (filed elsewhere or staying for follow-up)

- **Removing `BranchByHandler` from mokumo#807** — coordinating with the host session who's editing #807 to soften that axis to "source TBD."
- **Closing or repurposing #808** — leaving open; will likely close as superseded by #655 once that lands.
- **Producer macro-resolution bug** — 3 handlers (`auth::handlers::setup`, `demo_reset`, `profile_switch`) had their `filename` resolve to `tracing-0.1.44/src/macros.rs` instead of their source. Cosmetic until/unless #583's producer stays load-bearing. File as follow-up if so.
- **Producer name-resolution gap on generic handlers** — 6 of 10 unresolved are generic-over-K platform auth handlers; matcher needs to strip type params. Same conditionality as above.
- **Failing BDD scenarios on `restore_handler` / `profile_switch` / `demo_reset`** — real test failures visible in this PR's CI log, separate from the coverage producer. Worth a triage pass.

## Coordination with #655

- Reuse the existing route walker at `tools/docs-gen/src/coverage/route_walker.rs` — it already extracts `(method, path, handler_rust_path)` from `Router::route(...)` / `.nest(...)` chains.
- The runner change in this PR is the foundation; #655's middleware-capture approach should sidestep the symbol-matching issues that hit the branch producer (generics + macro expansion).
- Low rebase conflict — only `crates/mokumo-shop/moon.yml` touched.

## Test plan

- [x] Phase 1 CI green — no LLVM SIGSEGV on wider integration surface
- [x] Phase 2 CI green — BDD binaries execute under coverage; producer artifact captures branch data on previously-invisible handlers
- [x] Distribution analysis posted as comment with verdict
- [x] Comment block updated to post-experiment framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage configuration to enhance testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->