### PR TITLE
feat(ci): adopt dry-scorecard (Tier 1, standalone sticky comment)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -625,6 +625,85 @@ jobs:
           path: tmp/crap-scorecard-row.json
           if-no-files-found: ignore
 
+  dry-scorecard:
+    # dry-scorecard
+    # Adopted from breezy-bays-labs/dry-rs/.github/workflows/examples/dry-scorecard.yml
+    # pinned at SHA 94ca5328c8228e280dfa2b63c36d45d76df4a6af (V1 merge of dry-rs#58).
+    # NEW pattern: dry-rs's composite action stays reporter-agnostic (no comment-mode
+    # input). This job owns the sticky-comment emission directly via marocchino.
+    # See dry-rs#60 for adoption rationale; dry-rs#18 for the ergonomics epic.
+    #
+    # Simpler than crap-scorecard: pure source analysis via syn, no coverage capture,
+    # no baseline (dry-rs v0.1 has no delta-block). The composite action self-builds
+    # dry4rs from the pinned ref and brings its own Swatinem cache — no outer
+    # cargo/moonrepo/rust-cache setup needed.
+    needs: [changes]
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run dry-rs scorecard
+        id: dry
+        uses: breezy-bays-labs/dry-rs/.github/actions/scorecard@94ca5328c8228e280dfa2b63c36d45d76df4a6af
+        with:
+          paths: crates/
+          extensions: 'rs'
+          threshold: '0.85'
+          fail-on-findings: 'false'
+
+      - name: Render dry-scorecard sticky-comment message
+        # The dry-rs composite action exposes report-path (JSON envelope on
+        # disk) and findings-count (truthful-gate count) but NO markdown
+        # output — the action writes its formatted summary to
+        # $GITHUB_STEP_SUMMARY, not to a step output. So this job templates
+        # the marocchino comment body from the JSON envelope itself.
+        #
+        # The envelope shape (locked at v0.1 per dry-rs's
+        # adr-nested-json-envelope.md): .result.passed (bool),
+        # .result.matches (array), .result.summary.total_forms,
+        # .result.summary.by_tier (BTreeMap auto_refactor/review_first/advisory).
+        # We surface the truthful gate (result.*), not the shapeable
+        # display (view.*).
+        env:
+          REPORT_PATH: ${{ steps.dry.outputs.report-path }}
+          FINDINGS_COUNT: ${{ steps.dry.outputs.findings-count }}
+        run: |
+          set -euo pipefail
+          mkdir -p tmp
+          passed=$(jq -r '.result.passed' "$REPORT_PATH")
+          total_forms=$(jq -r '.result.summary.total_forms' "$REPORT_PATH")
+          auto=$(jq -r '.result.summary.by_tier.auto_refactor // 0' "$REPORT_PATH")
+          review=$(jq -r '.result.summary.by_tier.review_first // 0' "$REPORT_PATH")
+          advisory=$(jq -r '.result.summary.by_tier.advisory // 0' "$REPORT_PATH")
+          {
+            echo "## dry-scorecard"
+            echo ""
+            if [ "$passed" = "true" ]; then
+              echo ":white_check_mark: **No duplication above threshold (0.85).**"
+            else
+              echo ":mag: **${FINDINGS_COUNT} duplication match(es) at or above threshold (0.85).**"
+            fi
+            echo ""
+            echo "| metric | value |"
+            echo "| --- | --- |"
+            echo "| forms surveyed | \`${total_forms}\` |"
+            echo "| auto_refactor (>= 0.95) | \`${auto}\` |"
+            echo "| review_first (>= 0.85) | \`${review}\` |"
+            echo "| advisory | \`${advisory}\` |"
+            echo ""
+            echo "<sub>dry-rs scorecard @ \`94ca5328c8228e280dfa2b63c36d45d76df4a6af\` (dry-rs#58 merge). Paths: \`crates/\`. See Actions step summary for the full text report.</sub>"
+          } > tmp/dry-scorecard-comment.md
+
+      - name: Post dry-scorecard sticky comment
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405  # v2.9.4
+        with:
+          header: dry-scorecard
+          path: tmp/dry-scorecard-comment.md
+
   api-smoke:
     needs: [changes]
     if: github.event_name == 'pull_request' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.smoke == 'true')

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -628,7 +628,9 @@ jobs:
   dry-scorecard:
     # dry-scorecard
     # Adopted from breezy-bays-labs/dry-rs/.github/workflows/examples/dry-scorecard.yml
-    # pinned at SHA 94ca5328c8228e280dfa2b63c36d45d76df4a6af (V1 merge of dry-rs#58).
+    # pinned at SHA fc602844677a8b0ae200af877bece574f71f7c90 (V1 hotfix merge of
+    # dry-rs#64; supersedes 94ca5328 which had a description-block template-eval
+    # bug + a Swatinem double-nested workspace path).
     # NEW pattern: dry-rs's composite action stays reporter-agnostic (no comment-mode
     # input). This job owns the sticky-comment emission directly via marocchino.
     # See dry-rs#60 for adoption rationale; dry-rs#18 for the ergonomics epic.
@@ -648,7 +650,7 @@ jobs:
 
       - name: Run dry-rs scorecard
         id: dry
-        uses: breezy-bays-labs/dry-rs/.github/actions/scorecard@94ca5328c8228e280dfa2b63c36d45d76df4a6af
+        uses: breezy-bays-labs/dry-rs/.github/actions/scorecard@fc602844677a8b0ae200af877bece574f71f7c90
         with:
           paths: crates/
           extensions: 'rs'
@@ -695,7 +697,7 @@ jobs:
             echo "| review_first (>= 0.85) | \`${review}\` |"
             echo "| advisory | \`${advisory}\` |"
             echo ""
-            echo "<sub>dry-rs scorecard @ \`94ca5328c8228e280dfa2b63c36d45d76df4a6af\` (dry-rs#58 merge). Paths: \`crates/\`. See Actions step summary for the full text report.</sub>"
+            echo "<sub>dry-rs scorecard @ \`fc602844677a8b0ae200af877bece574f71f7c90\` (dry-rs#64 hotfix merge). Paths: \`crates/\`. See Actions step summary for the full text report.</sub>"
           } > tmp/dry-scorecard-comment.md
 
       - name: Post dry-scorecard sticky comment

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -655,7 +655,11 @@ jobs:
         uses: breezy-bays-labs/dry-rs/.github/actions/scorecard@1fe2a6dbbb33a9debb0d8e9a8cfeca1d063e5bce
         with:
           paths: crates/
-          extensions: 'rs'
+          # extensions: 'rs' removed — dry-rs action.yml@1fe2a6db splices an
+          # `--extensions <ext>` flag the dry4rs CLI doesn't accept (action
+          # wiring bug tracked at dry-rs#66, hotfix in PR #67). The action
+          # already defaults to the syn normalizer's `rs` allowlist when this
+          # input is empty, so the v0.1 dry4rs adapter behavior is unchanged.
           threshold: '0.85'
           fail-on-findings: 'false'
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -628,9 +628,11 @@ jobs:
   dry-scorecard:
     # dry-scorecard
     # Adopted from breezy-bays-labs/dry-rs/.github/workflows/examples/dry-scorecard.yml
-    # pinned at SHA fc602844677a8b0ae200af877bece574f71f7c90 (V1 hotfix merge of
-    # dry-rs#64; supersedes 94ca5328 which had a description-block template-eval
-    # bug + a Swatinem double-nested workspace path).
+    # pinned at SHA 1fe2a6dbbb33a9debb0d8e9a8cfeca1d063e5bce (V1 hotfix-sweep
+    # merge of dry-rs#65; restructures the action to drop the misresolving
+    # `github.action_repository` checkout step and uses $GITHUB_ACTION_PATH
+    # navigation instead. Supersedes fc602844 (description fix only, missing
+    # Swatinem) and 94ca5328 (description-block template-eval bug).
     # NEW pattern: dry-rs's composite action stays reporter-agnostic (no comment-mode
     # input). This job owns the sticky-comment emission directly via marocchino.
     # See dry-rs#60 for adoption rationale; dry-rs#18 for the ergonomics epic.
@@ -650,7 +652,7 @@ jobs:
 
       - name: Run dry-rs scorecard
         id: dry
-        uses: breezy-bays-labs/dry-rs/.github/actions/scorecard@fc602844677a8b0ae200af877bece574f71f7c90
+        uses: breezy-bays-labs/dry-rs/.github/actions/scorecard@1fe2a6dbbb33a9debb0d8e9a8cfeca1d063e5bce
         with:
           paths: crates/
           extensions: 'rs'
@@ -697,7 +699,7 @@ jobs:
             echo "| review_first (>= 0.85) | \`${review}\` |"
             echo "| advisory | \`${advisory}\` |"
             echo ""
-            echo "<sub>dry-rs scorecard @ \`fc602844677a8b0ae200af877bece574f71f7c90\` (dry-rs#64 hotfix merge). Paths: \`crates/\`. See Actions step summary for the full text report.</sub>"
+            echo "<sub>dry-rs scorecard @ \`1fe2a6dbbb33a9debb0d8e9a8cfeca1d063e5bce\` (dry-rs#65 hotfix-sweep merge). Paths: \`crates/\`. See Actions step summary for the full text report.</sub>"
           } > tmp/dry-scorecard-comment.md
 
       - name: Post dry-scorecard sticky comment


### PR DESCRIPTION
## Summary

Adopts the [dry-rs scorecard composite action](https://github.com/breezy-bays-labs/dry-rs/tree/main/.github/actions/scorecard) at V1 merge SHA `94ca5328c8228e280dfa2b63c36d45d76df4a6af` into mokumo's `quality.yml`. Adds a new `dry-scorecard:` job that:

- Runs `dry4rs` on `crates/` at threshold `0.85` (advisory floor), `fail-on-findings: false` (informational only)
- Templates a sticky-comment markdown block from the v0.1 JSON wire envelope (`.result.passed`, `.result.summary.total_forms`, `.result.summary.by_tier`)
- Posts the comment via `marocchino/sticky-pull-request-comment@v2.9.4` under the **distinct** header `dry-scorecard` (no collision with `crap-scorecard`)

This is **Tier 1 only** — standalone sticky-comment adoption per [`spike-mokumo-adoption.md`](https://github.com/breezy-bays-labs/dry-rs/blob/main/ops/...). Tier 2 (scorecard-aggregate ingestion) is tracked separately at [dry-rs#39](https://github.com/breezy-bays-labs/dry-rs/issues/39) and is NOT in scope here.

## NEW pattern (worth flagging for reviewers)

mokumo's existing `crap-scorecard:` job passes `comment-mode: 'sticky'` as an INPUT to the `crap4rs` composite action, which internally invokes marocchino. **dry-rs's composite action is intentionally reporter-agnostic** — it has no `comment-mode` input and does not invoke marocchino itself (the action stays usable in non-PR contexts like main-branch dogfood). This means **this new mokumo job emits the sticky comment via a separate marocchino step** inside the job block. The source-comment header on the new job documents this honestly.

## Scope

ONE file extended additively:

- `.github/workflows/quality.yml` — new `dry-scorecard:` job inserted between `crap-scorecard:` and `api-smoke:` (`+79 -0`). `crap-scorecard:` is byte-for-byte unchanged.

No `tools.toml` pin needed — the composite action self-builds dry4rs from the pinned ref. `scripts/check-tools-pins.sh` passes unchanged.

## Test plan

- [x] `actionlint .github/workflows/quality.yml` clean locally
- [x] `scripts/check-tools-pins.sh` passes (3 governed tools consistent)
- [x] `git diff --stat origin/main` shows only `+79 -0` to `quality.yml`
- [x] No other files touched (no `crap-scorecard:` regression)
- [ ] CI green on this PR (new `dry-scorecard:` job runs; crap-scorecard unchanged)
- [ ] The new sticky comment renders on this PR with the dry-rs duplication summary

## Closes

Closes breezy-bays-labs/dry-rs#60
Refs breezy-bays-labs/dry-rs#18 (parent epic — CI ergonomics for dry-rs consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)