### PR TITLE
test(scorecard): #839 — BDD coverage for aggregate::read_crap_row_json (lcov-pending allowlist)

### DIFF
--- a/.config/pub-api-spec-audit/allowlist.txt
+++ b/.config/pub-api-spec-audit/allowlist.txt
@@ -18,3 +18,5 @@
 # has been baselined per-crate at `.config/pub-api-spec-audit/<crate>.txt`.
 # Add entries here only for items you don't want frozen-as-baseline (e.g.
 # items expected to gain coverage in an in-flight tracking issue).
+
+scorecard::aggregate::read_crap_row_json  # tracked: mokumo#838 — lcov-pending; .feature scenario landed at crates/scorecard/tests/features/crap_row_ingestion.feature, awaiting ADR §D5 BDD lcov capture wire-up

--- a/crates/scorecard/tests/bdd_world/crap_row_steps.rs
+++ b/crates/scorecard/tests/bdd_world/crap_row_steps.rs
@@ -1,0 +1,195 @@
+//! Step definitions for the CrapDelta row ingestion scenarios in
+//! `tests/features/crap_row_ingestion.feature`.
+//!
+//! These steps assert producer-side behavior at the ingestion boundary
+//! — `scorecard::aggregate::read_crap_row_json` reads an artifact
+//! emitted by `crap4rs --format scorecard-row` and either yields a
+//! parsed [`Row::CrapDelta`] or fails loud at the boundary. The Layer 1
+//! typestate ctors (which Red branch goes through) and the Layer 2
+//! schema validator (which the full envelope goes through) are
+//! exercised by Rust integration tests in
+//! `tests/layer2_e2e.rs::crap_row_json_*`; the BDD scenarios pin the
+//! ingestion-flag contract (Model P: producer mints status; aggregator
+//! trusts via the `RowCommon::tool` serde default).
+
+use std::io::Write as _;
+
+use cucumber::{given, then, when};
+use scorecard::Row;
+use scorecard::aggregate::read_crap_row_json;
+use serde_json::json;
+
+use super::ThresholdWorld;
+
+// ───────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────
+
+/// Write `body` to `<tmp>/crap-row.json` and stash the path on the
+/// world. The tempdir lives on `ThresholdWorld::tmp` so it's dropped
+/// at the end of the scenario.
+fn write_crap_row_artifact(world: &mut ThresholdWorld, body: &[u8]) {
+    let tmp = world
+        .tmp
+        .get_or_insert_with(|| tempfile::tempdir().expect("scenario tempdir must allocate"));
+    let path = tmp.path().join("crap-row.json");
+    let mut f = std::fs::File::create(&path).expect("must be able to create crap-row.json");
+    f.write_all(body)
+        .expect("must be able to write the crap-row.json body");
+    world.crap_row_path = Some(path);
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Givens — write the artifact
+// ───────────────────────────────────────────────────────────────────
+
+#[given(
+    expr = "a --crap-row-json artifact whose wire JSON omits the tool field and reports a Green CrapDelta of {string} with threshold {int}"
+)]
+async fn given_well_formed_crap_row_artifact(
+    world: &mut ThresholdWorld,
+    delta_text: String,
+    threshold: u32,
+) {
+    // Wire format per Model P (crap4rs `docs/scorecard-row-contract.md`):
+    // `tool` field deliberately omitted so the aggregator's
+    // `RowCommon::tool` serde default stamps "crap4rs".
+    let body = json!({
+        "type": "CrapDelta",
+        "id": "crap_delta",
+        "label": "CRAP Δ",
+        "anchor": "crap-delta",
+        "status": "Green",
+        "threshold": threshold,
+        "delta_count": 0,
+        "delta_text": delta_text,
+    });
+    write_crap_row_artifact(world, body.to_string().as_bytes());
+}
+
+#[given(expr = "an empty --crap-row-json artifact")]
+async fn given_empty_crap_row_artifact(world: &mut ThresholdWorld) {
+    // The composite action emits an empty `outputs.row-json` when the
+    // installed crap4rs lacks `--format scorecard-row` support
+    // (graceful binstall-regression probe). Empty input must NOT
+    // crash the aggregator — it falls through to the producer-pending
+    // stub so a transient regression cannot block the merge queue.
+    write_crap_row_artifact(world, b"");
+}
+
+#[given(
+    expr = "a --crap-row-json artifact whose wire JSON contains a MutationSurvivors row instead of a CrapDelta row"
+)]
+async fn given_wrong_variant_crap_row_artifact(world: &mut ThresholdWorld) {
+    // The flag is variant-specific. A non-CrapDelta row at this slot
+    // means the upstream wired the wrong artifact; surface that loudly
+    // instead of silently mis-stamping.
+    let body = json!({
+        "type": "MutationSurvivors",
+        "id": "mutation_survivors",
+        "label": "Mutation survivors",
+        "anchor": "mutation-survivors",
+        "status": "Green",
+        "survivor_count": 0,
+        "top_survivors": [],
+        "delta_text": "0 survivors",
+    });
+    write_crap_row_artifact(world, body.to_string().as_bytes());
+}
+
+// ───────────────────────────────────────────────────────────────────
+// When — invoke the ingestion fn
+// ───────────────────────────────────────────────────────────────────
+
+#[when(expr = "the aggregator reads the --crap-row-json artifact")]
+async fn when_aggregator_reads_artifact(world: &mut ThresholdWorld) {
+    let path = world
+        .crap_row_path
+        .clone()
+        .expect("a Given step must have written the --crap-row-json artifact");
+    world.crap_row_result = Some(read_crap_row_json(Some(path.as_path())));
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Thens — assert on the parsed Row / Ok(None) / Err shape
+// ───────────────────────────────────────────────────────────────────
+
+fn parsed_crap_delta(world: &ThresholdWorld) -> &Row {
+    let result = world
+        .crap_row_result
+        .as_ref()
+        .expect("a When step must have invoked read_crap_row_json");
+    let row_opt = result
+        .as_ref()
+        .expect("expected Ok(_) from read_crap_row_json on a well-formed artifact");
+    row_opt
+        .as_ref()
+        .expect("expected Some(Row) — the artifact body was non-empty")
+}
+
+#[then(expr = "the parsed CrapDelta row carries tool {string}")]
+async fn then_parsed_row_carries_tool(world: &mut ThresholdWorld, expected_tool: String) {
+    let Row::CrapDelta { common, .. } = parsed_crap_delta(world) else {
+        panic!("expected Row::CrapDelta variant");
+    };
+    assert_eq!(
+        common.tool, expected_tool,
+        "the RowCommon::tool serde default must stamp `{expected_tool}` when the wire format omits the field",
+    );
+}
+
+#[then(expr = "the parsed CrapDelta row carries status Green")]
+async fn then_parsed_row_status_green(world: &mut ThresholdWorld) {
+    let Row::CrapDelta { status, .. } = parsed_crap_delta(world) else {
+        panic!("expected Row::CrapDelta variant");
+    };
+    assert_eq!(*status, scorecard::Status::Green);
+}
+
+#[then(expr = "the parsed CrapDelta row carries threshold {int}")]
+async fn then_parsed_row_threshold(world: &mut ThresholdWorld, expected: u32) {
+    let Row::CrapDelta { threshold, .. } = parsed_crap_delta(world) else {
+        panic!("expected Row::CrapDelta variant");
+    };
+    assert_eq!(*threshold, expected);
+}
+
+#[then(expr = "the parsed CrapDelta row carries delta_count {int}")]
+async fn then_parsed_row_delta_count(world: &mut ThresholdWorld, expected: i32) {
+    let Row::CrapDelta { delta_count, .. } = parsed_crap_delta(world) else {
+        panic!("expected Row::CrapDelta variant");
+    };
+    assert_eq!(*delta_count, expected);
+}
+
+#[then(
+    expr = "the aggregator returns a soft-None so the caller falls through to the producer-pending stub"
+)]
+async fn then_aggregator_returns_ok_none(world: &mut ThresholdWorld) {
+    let result = world
+        .crap_row_result
+        .as_ref()
+        .expect("the When step must have invoked read_crap_row_json");
+    let row_opt = result
+        .as_ref()
+        .expect("empty file must yield Ok(_), not Err — the binstall-regression probe is soft");
+    assert!(
+        row_opt.is_none(),
+        "empty --crap-row-json artifact must yield Ok(None) so the caller falls through to the stub",
+    );
+}
+
+#[then(expr = "the aggregator returns an error naming the expected CrapDelta variant")]
+async fn then_aggregator_returns_err(world: &mut ThresholdWorld) {
+    let result = world
+        .crap_row_result
+        .as_ref()
+        .expect("the When step must have invoked read_crap_row_json");
+    let err = result
+        .as_ref()
+        .expect_err("wrong-variant artifact must surface Err at the ingestion boundary");
+    assert!(
+        err.contains("CrapDelta"),
+        "the error must name the expected CrapDelta variant so a CI failure points the operator at the wired-wrong-artifact bug — got: {err}",
+    );
+}

--- a/crates/scorecard/tests/bdd_world/mod.rs
+++ b/crates/scorecard/tests/bdd_world/mod.rs
@@ -5,8 +5,9 @@
 //! discovers the step-defs.
 
 use cucumber::World;
-use scorecard::{PrMeta, Scorecard, Status};
+use scorecard::{PrMeta, Row, Scorecard, Status};
 
+pub mod crap_row_steps;
 pub mod fork_pr_steps;
 pub mod threshold_steps;
 
@@ -32,6 +33,14 @@ pub struct ThresholdWorld {
     /// produced scorecard. Cached out of [`Self::scorecard`] for
     /// terser Then steps.
     pub coverage_row_status: Option<Status>,
+    /// Path to a `--crap-row-json` tempfile written by an earlier step
+    /// for the crap-row ingestion scenarios. Owned by [`Self::tmp`]
+    /// so the file is cleaned up at the end of the scenario.
+    pub crap_row_path: Option<std::path::PathBuf>,
+    /// Result of the most recent `read_crap_row_json` call. Stashed by
+    /// the When step so subsequent Then steps can assert on the
+    /// `Ok(Some)` / `Ok(None)` / `Err` shape without re-invoking.
+    pub crap_row_result: Option<Result<Option<Row>, String>>,
 }
 
 impl ThresholdWorld {
@@ -41,6 +50,8 @@ impl ThresholdWorld {
             coverage_delta_pp: None,
             scorecard: None,
             coverage_row_status: None,
+            crap_row_path: None,
+            crap_row_result: None,
         }
     }
 

--- a/crates/scorecard/tests/features/crap_row_ingestion.feature
+++ b/crates/scorecard/tests/features/crap_row_ingestion.feature
@@ -1,0 +1,48 @@
+Feature: CrapDelta row ingestion from crap4rs --format scorecard-row artifact
+
+  The scorecard aggregator reads a `--crap-row-json` artifact emitted by
+  `crap4rs --format scorecard-row` (Model P — producer mints status,
+  aggregator trusts). The wire format deliberately omits the `tool`
+  field; the aggregator stamps it via the `RowCommon::tool` serde default
+  so cross-repo schema bumps stay decoupled. This spec pins both halves
+  of that contract plus the empty-file graceful fallthrough that lets a
+  binstall regression on the consuming composite action degrade to the
+  producer-pending stub instead of failing CI hard.
+
+  # Canonical step-phrase vocabulary:
+  #   - "the --crap-row-json artifact at <path>" — a temp file the
+  #     scenario writes representing the action's captured stdout from
+  #     `crap4rs --format scorecard-row`
+  #   - "the aggregator reads the --crap-row-json artifact" — the
+  #     producer call site invokes `scorecard::aggregate::read_crap_row_json`
+  #   - "the parsed CrapDelta row" — the `Row::CrapDelta` returned by
+  #     `read_crap_row_json` when the wire JSON is well-formed
+  #
+  # Out of scope (covered by Rust integration tests in tests/layer2_e2e.rs):
+  #   - Red row without failure_detail_md fail-loud (Model P contract)
+  #   - Whitespace-only file fallthrough (sibling of empty-file branch)
+  #   - Schema-validator (Layer 2) cross-checks on the full envelope
+
+  Rule: A well-formed producer artifact deserializes via the RowCommon serde default
+
+    Scenario: Producer wire JSON without the tool field is stamped "crap4rs"
+      Given a --crap-row-json artifact whose wire JSON omits the tool field and reports a Green CrapDelta of "5 → 5 (no change)" with threshold 15
+      When the aggregator reads the --crap-row-json artifact
+      Then the parsed CrapDelta row carries tool "crap4rs"
+      And the parsed CrapDelta row carries status Green
+      And the parsed CrapDelta row carries threshold 15
+      And the parsed CrapDelta row carries delta_count 0
+
+  Rule: The empty-file graceful-probe path falls through to the producer-pending stub
+
+    Scenario: An empty --crap-row-json artifact yields a soft-None for stub fallback
+      Given an empty --crap-row-json artifact
+      When the aggregator reads the --crap-row-json artifact
+      Then the aggregator returns a soft-None so the caller falls through to the producer-pending stub
+
+  Rule: A wrong-variant artifact fails loud at the ingestion boundary
+
+    Scenario: A --crap-row-json artifact containing a non-CrapDelta variant is rejected
+      Given a --crap-row-json artifact whose wire JSON contains a MutationSurvivors row instead of a CrapDelta row
+      When the aggregator reads the --crap-row-json artifact
+      Then the aggregator returns an error naming the expected CrapDelta variant


### PR DESCRIPTION
## Summary

- Adds `crates/scorecard/tests/features/crap_row_ingestion.feature` (3 scenarios) + step-defs covering `scorecard::aggregate::read_crap_row_json` — the load-bearing Model P behaviors: serde-default tool stamping on a wire JSON without `tool`, empty-file soft-None fallthrough (binstall-regression graceful probe), wrong-variant fail-loud at the ingestion boundary.
- Adds one `.config/pub-api-spec-audit/allowlist.txt` entry tracked against mokumo#838 (the ADR §D5 promote umbrella). The entry phrasing is **`lcov-pending`** not `coverage-pending` — the BDD scenario is landed; only the lcov-capture step that lets the gate see it is deferred to §D5. When #838 promotes, this allowlist line drops with zero rework.

## Why two artifacts in one PR

The `pub-api-spec-audit` gate today (per ADR §D5 soft-mode) invokes the producer with no `--lcov` input — every item registers `bdd_covered_lines: 0` regardless of `.feature` coverage. So merely adding a BDD scenario CANNOT move the gate today; the allowlist line is what flips it green. The scenario closes the **actual coverage gap** the gate was designed to catch so when §D5 wires lcov capture, the allowlist line can drop with no follow-up work.

## Test plan

- [x] `cargo test -p scorecard --features bdd --test bdd` — 3 new scenarios, 10 new steps, all pass.
- [x] `cargo run -p docs-gen --release --bin pub-api-spec-audit -- --workspace-root . --output-json pub-api-spec-audit.json --output-md pub-api-spec-audit.md` then `bash scripts/check-pub-api-spec-audit.sh` — exits 0 (was exit 2 before the allowlist entry on main).
- [x] `bash scripts/check-pub-api-spec-audit-allowlist-drift.sh` — exits 0 (mokumo#838 is OPEN).
- [x] `cargo clippy --workspace --exclude mokumo-desktop --exclude kikan-tauri --exclude kikan-admin-ui --all-targets --features scorecard/cli -- -D warnings` — passes. CI's clippy invocation does not pull `--features bdd` so cucumber-rs's `async fn` step-defs don't trip `unused_async` (same pattern as the existing `threshold_steps.rs`).
- [x] `cargo fmt --check` — clean.
- [x] Lefthook pre-push hooks (gitleaks + rust-fmt + shop:lint + tracked-exclusion-lint + route-coverage + rust-clippy) — all green at push time.
- [ ] CI `pub-api-spec-audit` job — must show GREEN; `read_crap_row_json` should no longer appear in the "new pub items" list.

## Context

- Closes #839
- Refs #838 (ADR §D5 promote umbrella; the allowlist entry's `tracked:` ref)
- Refs mokumo#835 (dry-rs#60 adoption chain — pub-api-spec-audit soft-gate row goes green for this item when this lands)
- ADR: `docs/adr/adr-pub-api-spec-audit.md` §D4 (lcov capture command) + §D5 (promotion posture)

## Cross-repo unblock chain

`pub-api-spec-audit` is wrapped in `continue-on-error: true` per ADR §D5, so this was never a hard-block on mokumo#835 / dry-rs#60. This PR cleans the soft-gate's visible red row + closes the actual BDD coverage gap that the audit was designed to catch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)